### PR TITLE
fix: Support unzipping on Windows 8.1

### DIFF
--- a/website/assets/install.ps1
+++ b/website/assets/install.ps1
@@ -60,7 +60,16 @@ if (!(Test-Path $BinDir)) {
 
 Invoke-WebRequest $DprintUri -OutFile $DprintZip -UseBasicParsing
 
-Expand-Archive $DprintZip -Destination $BinDir -Force
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+  Expand-Archive $DprintZip -Destination $BinDir -Force
+} else {
+  if (Test-Path $DprintExe) {
+    Remove-Item $DprintExe
+  }
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [IO.Compression.ZipFile]::ExtractToDirectory($DprintZip, $BinDir)
+}
+
 Remove-Item $DprintZip
 
 $User = [EnvironmentVariableTarget]::User


### PR DESCRIPTION
`Expand-Archive` should be available since PowerShell 5.1: https://docs.microsoft.com/de-de/powershell/module/microsoft.powershell.archive/Expand-Archive?view=powershell-5.1