### PR TITLE
chore: do not run external resource-dependent publishes in forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,13 @@ jobs:
 
     - name: Cargo login
       run: cargo login ${{ secrets.CRATES_TOKEN }}
+      if: github.repository == 'dprint/dprint'
 
     - name: Cargo publish
       run: |
         cd crates/dprint
         cargo publish
+      if: github.repository == 'dprint/dprint'
 
     - name: npm publish
       env:
@@ -50,3 +52,4 @@ jobs:
         curl --fail --location --progress-bar --output "SHASUMS256.txt" "https://github.com/dprint/dprint/releases/download/${{steps.get_tag_version.outputs.TAG_VERSION}}/SHASUMS256.txt"
         node setup.js ${{steps.get_tag_version.outputs.TAG_VERSION}}
         npm publish
+      if: github.repository == 'dprint/dprint'


### PR DESCRIPTION
similar to https://github.com/dprint/dprint-plugin-typescript/pull/259