### PR TITLE
refactor: move glob matching up to a higher level so it can be properly tested

### DIFF
--- a/crates/dprint/src/cli/paths.rs
+++ b/crates/dprint/src/cli/paths.rs
@@ -5,6 +5,7 @@ use dprint_cli_core::types::ErrBox;
 
 use crate::environment::Environment;
 use crate::plugins::Plugin;
+use crate::utils::glob;
 
 use super::configuration::ResolvedConfig;
 use super::patterns::get_all_file_patterns;
@@ -71,7 +72,7 @@ fn resolve_file_paths(
   let cwd = environment.cwd();
   let is_in_sub_dir = cwd != config.base_path && cwd.starts_with(&config.base_path);
   if is_in_sub_dir {
-    let mut file_paths = environment.glob(&cwd, file_patterns)?;
+    let mut file_paths = glob(environment, &cwd, file_patterns)?;
     if args.file_patterns.is_empty() {
       // filter file paths by cwd if no CLI paths are specified
       file_paths.extend(absolute_paths.iter().filter(|path| path.starts_with(&cwd)).map(ToOwned::to_owned));
@@ -80,7 +81,7 @@ fn resolve_file_paths(
     }
     return Ok(file_paths);
   } else {
-    let mut file_paths = environment.glob(&config.base_path, file_patterns)?;
+    let mut file_paths = glob(environment, &config.base_path, file_patterns)?;
     file_paths.extend(absolute_paths.clone());
     return Ok(file_paths);
   }

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -4,6 +4,18 @@ use std::path::{Path, PathBuf};
 
 use crate::plugins::CompilationResult;
 
+#[derive(Debug)]
+pub struct DirEntry {
+  pub kind: DirEntryKind,
+  pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DirEntryKind {
+  Directory,
+  File,
+}
+
 pub trait Environment: Clone + std::marker::Send + std::marker::Sync + 'static {
   fn is_real(&self) -> bool;
   fn read_file(&self, file_path: impl AsRef<Path>) -> Result<String, ErrBox>;
@@ -12,7 +24,7 @@ pub trait Environment: Clone + std::marker::Send + std::marker::Sync + 'static {
   fn write_file_bytes(&self, file_path: impl AsRef<Path>, bytes: &[u8]) -> Result<(), ErrBox>;
   fn remove_file(&self, file_path: impl AsRef<Path>) -> Result<(), ErrBox>;
   fn remove_dir_all(&self, dir_path: impl AsRef<Path>) -> Result<(), ErrBox>;
-  fn glob(&self, base: impl AsRef<Path>, file_patterns: &Vec<String>) -> Result<Vec<PathBuf>, ErrBox>;
+  fn dir_info(&self, dir_path: impl AsRef<Path>) -> Result<Vec<DirEntry>, ErrBox>;
   fn path_exists(&self, file_path: impl AsRef<Path>) -> bool;
   fn canonicalize(&self, path: impl AsRef<Path>) -> Result<PathBuf, ErrBox>;
   fn is_absolute_path(&self, path: impl AsRef<Path>) -> bool;


### PR DESCRIPTION
This moves glob specific functionality out of the `RealEnvironment` and `TestEnvironment` so the logic for globbing that was previously in `RealEnvironment` actually gets tested by the tests.

This is now possible due to dropping the `globwalk` dependency in https://github.com/dprint/dprint/commit/5a3b6c213259fb6e3db9a92c346d28a06f7ce644 (unfortunately that also caused some of these bugs, but overall we will be in a better place going forward)

cc @joscha 