### PR TITLE
fix: restore searching all directories when glob pattern does not contain a slash at the beginning or middle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.52.0
+        toolchain: 1.54.0
         override: true
     - name: Install wasm32 target
       run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,10 @@
 # Copyright 2020-2021 David Sherret. All rights reserved. MIT license.
 name: Website
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/crates/dprint/src/cli/patterns.rs
+++ b/crates/dprint/src/cli/patterns.rs
@@ -38,7 +38,6 @@ impl FileMatcher {
 pub fn get_all_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str) -> Vec<String> {
   let mut file_patterns = get_include_file_patterns(config, args, cwd);
   file_patterns.append(&mut get_exclude_file_patterns(config, args, cwd));
-  process_file_patterns_slashes(&mut file_patterns);
   return file_patterns;
 }
 
@@ -46,10 +45,13 @@ fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str)
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(if args.file_patterns.is_empty() {
-    to_absolute_globs(&process_config_patterns(&config.includes), &config.base_path.to_string_lossy())
+    to_absolute_globs(
+      process_config_patterns(process_file_patterns_slashes(&config.includes)),
+      &config.base_path.to_string_lossy(),
+    )
   } else {
     // resolve CLI patterns based on the current working directory
-    to_absolute_globs(&process_cli_patterns(&args.file_patterns), cwd)
+    to_absolute_globs(process_cli_patterns(process_file_patterns_slashes(&args.file_patterns)), cwd)
   });
 
   return file_patterns;
@@ -60,10 +62,13 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str)
 
   file_patterns.extend(
     if args.exclude_file_patterns.is_empty() {
-      to_absolute_globs(&process_config_patterns(&config.excludes), &config.base_path.to_string_lossy())
+      to_absolute_globs(
+        process_config_patterns(process_file_patterns_slashes(&config.excludes)),
+        &config.base_path.to_string_lossy(),
+      )
     } else {
       // resolve CLI patterns based on the current working directory
-      to_absolute_globs(&process_cli_patterns(&args.exclude_file_patterns), cwd)
+      to_absolute_globs(process_cli_patterns(process_file_patterns_slashes(&args.exclude_file_patterns)), cwd)
     }
     .into_iter()
     .map(|exclude| if exclude.starts_with("!") { exclude } else { format!("!{}", exclude) }),
@@ -85,10 +90,15 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str)
   return file_patterns;
 }
 
-fn process_file_patterns_slashes(file_patterns: &mut Vec<String>) {
-  for file_pattern in file_patterns.iter_mut() {
-    process_file_pattern_slashes(file_pattern);
-  }
+fn process_file_patterns_slashes(file_patterns: &Vec<String>) -> Vec<String> {
+  file_patterns
+    .iter()
+    .map(|p| {
+      let mut p = p.to_string();
+      process_file_pattern_slashes(&mut p);
+      p
+    })
+    .collect()
 }
 
 fn process_file_pattern_slashes(file_pattern: &mut String) {
@@ -99,28 +109,20 @@ fn process_file_pattern_slashes(file_pattern: &mut String) {
   // what operation system the user is on and for the CLI to match
   // backslashes as a path separator.
   *file_pattern = file_pattern.replace("\\", "/");
-
-  // glob walker doesn't support having `./` at the front of paths, so just remove them when they appear
-  if file_pattern.starts_with("./") {
-    *file_pattern = String::from(&file_pattern[2..]);
-  }
-  if file_pattern.starts_with("!./") {
-    *file_pattern = format!("!{}", &file_pattern[3..]);
-  }
 }
 
-fn process_cli_patterns(file_patterns: &Vec<String>) -> Vec<String> {
-  file_patterns.iter().map(|pattern| process_cli_pattern(pattern)).collect()
+fn process_cli_patterns(file_patterns: Vec<String>) -> Vec<String> {
+  file_patterns.into_iter().map(|pattern| process_cli_pattern(pattern)).collect()
 }
 
-fn process_cli_pattern(file_pattern: &str) -> String {
-  if is_absolute_pattern(file_pattern) {
-    file_pattern.to_string()
+fn process_cli_pattern(file_pattern: String) -> String {
+  if is_absolute_pattern(&file_pattern) {
+    file_pattern
   } else if file_pattern.starts_with("./") || file_pattern.starts_with("!./") {
-    file_pattern.to_string()
+    file_pattern
   } else {
     // make all cli specified patterns relative
-    if is_negated_glob(file_pattern) {
+    if is_negated_glob(&file_pattern) {
       format!("!./{}", &file_pattern[1..])
     } else {
       format!("./{}", file_pattern)
@@ -128,18 +130,18 @@ fn process_cli_pattern(file_pattern: &str) -> String {
   }
 }
 
-fn process_config_patterns(file_patterns: &Vec<String>) -> Vec<String> {
-  file_patterns.iter().map(|pattern| process_config_pattern(pattern)).collect()
+fn process_config_patterns(file_patterns: Vec<String>) -> Vec<String> {
+  file_patterns.into_iter().map(|pattern| process_config_pattern(pattern)).collect()
 }
 
-fn process_config_pattern(file_pattern: &str) -> String {
+fn process_config_pattern(file_pattern: String) -> String {
   // make config patterns that start with `/` be relative
   if file_pattern.starts_with("/") {
     format!(".{}", file_pattern)
   } else if file_pattern.starts_with("!/") {
     format!("!.{}", &file_pattern[1..])
   } else {
-    file_pattern.to_string()
+    file_pattern
   }
 }
 
@@ -149,29 +151,29 @@ mod test {
 
   #[test]
   fn it_should_process_cli_pattern() {
-    assert_eq!(process_cli_pattern("/test"), "/test");
-    assert_eq!(process_cli_pattern("C:\\test"), "C:\\test");
-    assert_eq!(process_cli_pattern("./test"), "./test");
-    assert_eq!(process_cli_pattern("test"), "./test");
-    assert_eq!(process_cli_pattern("**/test"), "./**/test");
+    assert_eq!(process_cli_pattern("/test".to_string()), "/test");
+    assert_eq!(process_cli_pattern("C:/test".to_string()), "C:/test");
+    assert_eq!(process_cli_pattern("./test".to_string()), "./test");
+    assert_eq!(process_cli_pattern("test".to_string()), "./test");
+    assert_eq!(process_cli_pattern("**/test".to_string()), "./**/test");
 
-    assert_eq!(process_cli_pattern("!/test"), "!/test");
-    assert_eq!(process_cli_pattern("!C:\\test"), "!C:\\test");
-    assert_eq!(process_cli_pattern("!./test"), "!./test");
-    assert_eq!(process_cli_pattern("!test"), "!./test");
-    assert_eq!(process_cli_pattern("!**/test"), "!./**/test");
+    assert_eq!(process_cli_pattern("!/test".to_string()), "!/test");
+    assert_eq!(process_cli_pattern("!C:/test".to_string()), "!C:/test");
+    assert_eq!(process_cli_pattern("!./test".to_string()), "!./test");
+    assert_eq!(process_cli_pattern("!test".to_string()), "!./test");
+    assert_eq!(process_cli_pattern("!**/test".to_string()), "!./**/test");
   }
 
   #[test]
   fn it_should_process_config_pattern() {
-    assert_eq!(process_config_pattern("/test"), "./test");
-    assert_eq!(process_config_pattern("./test"), "./test");
-    assert_eq!(process_config_pattern("test"), "test");
-    assert_eq!(process_config_pattern("**/test"), "**/test");
+    assert_eq!(process_config_pattern("/test".to_string()), "./test");
+    assert_eq!(process_config_pattern("./test".to_string()), "./test");
+    assert_eq!(process_config_pattern("test".to_string()), "test");
+    assert_eq!(process_config_pattern("**/test".to_string()), "**/test");
 
-    assert_eq!(process_config_pattern("!/test"), "!./test");
-    assert_eq!(process_config_pattern("!./test"), "!./test");
-    assert_eq!(process_config_pattern("!test"), "!test");
-    assert_eq!(process_config_pattern("!**/test"), "!**/test");
+    assert_eq!(process_config_pattern("!/test".to_string()), "!./test");
+    assert_eq!(process_config_pattern("!./test".to_string()), "!./test");
+    assert_eq!(process_config_pattern("!test".to_string()), "!test");
+    assert_eq!(process_config_pattern("!**/test".to_string()), "!**/test");
   }
 }

--- a/crates/dprint/src/cli/run_cli.rs
+++ b/crates/dprint/src/cli/run_cli.rs
@@ -1262,21 +1262,33 @@ mod tests {
   fn it_should_format_files_with_config_excludes() {
     let file_path1 = "/file1.txt";
     let file_path2 = "/file2.txt";
+    let file_path3 = "/file3.txt";
+    let sub_dir_file_path2 = "/sub-dir/file2.txt";
+    let sub_dir_file_path3 = "/sub-dir/file3.txt";
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
-      .write_file(file_path1, "text1")
-      .write_file(file_path2, "text2")
+      .write_file(file_path1, "text")
+      .write_file(file_path2, "text")
+      .write_file(file_path3, "text")
+      .write_file(sub_dir_file_path2, "text")
+      .write_file(sub_dir_file_path3, "text")
       .with_default_config(|c| {
-        c.add_includes("**/*.txt").add_excludes("/file2.txt").add_remote_wasm_plugin();
+        c.add_includes("**/*.txt")
+          .add_excludes("/file2.txt")
+          .add_excludes("file3.txt")
+          .add_remote_wasm_plugin();
       })
       .initialize()
       .build();
 
     run_test_cli(vec!["fmt"], &environment).unwrap();
 
-    assert_eq!(environment.take_logged_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.take_logged_messages(), vec![get_plural_formatted_text(2)]);
     assert_eq!(environment.take_logged_errors().len(), 0);
-    assert_eq!(environment.read_file(&file_path1).unwrap(), "text1_formatted");
-    assert_eq!(environment.read_file(&file_path2).unwrap(), "text2");
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_formatted");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text");
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text");
+    assert_eq!(environment.read_file(&sub_dir_file_path2).unwrap(), "text_formatted");
+    assert_eq!(environment.read_file(&sub_dir_file_path3).unwrap(), "text");
   }
 
   #[test]

--- a/crates/dprint/src/utils/glob_utils.rs
+++ b/crates/dprint/src/utils/glob_utils.rs
@@ -50,8 +50,8 @@ pub fn glob(environment: &impl Environment, base: impl AsRef<Path>, file_pattern
   Ok(results)
 }
 
-pub fn to_absolute_globs(file_patterns: &Vec<String>, base_dir: &str) -> Vec<String> {
-  file_patterns.iter().map(|p| to_absolute_glob(p, base_dir)).collect()
+pub fn to_absolute_globs(file_patterns: Vec<String>, base_dir: &str) -> Vec<String> {
+  file_patterns.into_iter().map(|p| to_absolute_glob(&p, base_dir)).collect()
 }
 
 pub fn to_absolute_glob(pattern: &str, dir: &str) -> String {
@@ -167,7 +167,7 @@ fn is_windows_absolute_pattern(pattern: &str) -> bool {
 
   // now check for the last slash
   let next_char = chars.next();
-  matches!(next_char, Some('/' | '\\'))
+  matches!(next_char, Some('/'))
 }
 
 pub struct GlobMatcherOptions {
@@ -225,8 +225,6 @@ mod tests {
     assert_eq!(is_absolute_pattern("!/test.ts"), true);
     assert_eq!(is_absolute_pattern("D:/test.ts"), true);
     assert_eq!(is_absolute_pattern("!D:/test.ts"), true);
-    assert_eq!(is_absolute_pattern("D:\\test.ts"), true);
-    assert_eq!(is_absolute_pattern("!D:\\test.ts"), true);
   }
 
   #[test]

--- a/crates/dprint/src/utils/glob_utils.rs
+++ b/crates/dprint/src/utils/glob_utils.rs
@@ -61,6 +61,15 @@ pub fn to_absolute_glob(pattern: &str, dir: &str) -> String {
   let mut pattern = pattern.replace("\\", "/");
   let dir = dir.replace("\\", "/");
 
+  // .gitignore: "If there is a separator at the beginning or middle (or both) of
+  // the pattern, then the pattern is relative to the directory level of the particular
+  // .gitignore file itself. Otherwise the pattern may also match at any level below the
+  // .gitignore level."
+  let is_relative = match pattern.find("/") {
+    Some(index) => index != pattern.len() - 1, // not the end of the pattern
+    None => false,
+  };
+
   // trim starting ./ from glob patterns
   if pattern.starts_with("./") {
     pattern = pattern.chars().skip(2).collect();
@@ -81,8 +90,12 @@ pub fn to_absolute_glob(pattern: &str, dir: &str) -> String {
   }
 
   // make glob absolute
-  if !is_absolute_path(&pattern) {
-    pattern = glob_join(dir, pattern);
+  if !is_absolute_pattern(&pattern) {
+    if is_relative || pattern.starts_with("**/") || pattern.trim().is_empty() {
+      pattern = glob_join(dir, pattern);
+    } else {
+      pattern = glob_join(dir, format!("**/{}", pattern));
+    }
   }
 
   // if glob had a trailing `/`, re-add it back
@@ -126,13 +139,13 @@ fn glob_join(dir: String, pattern: String) -> String {
   }
 }
 
-fn is_absolute_path(file_path: &str) -> bool {
-  file_path.starts_with("/") || is_windows_absolute_path(file_path)
+pub fn is_absolute_pattern(pattern: &str) -> bool {
+  pattern.starts_with("/") || is_windows_absolute_pattern(pattern)
 }
 
-fn is_windows_absolute_path(file_path: &str) -> bool {
+fn is_windows_absolute_pattern(pattern: &str) -> bool {
   // ex. D:/
-  let mut chars = file_path.chars();
+  let mut chars = pattern.chars();
 
   // ensure the first character is alphabetic
   let next_char = chars.next();
@@ -153,7 +166,7 @@ fn is_windows_absolute_path(file_path: &str) -> bool {
 
   // now check for the last slash
   let next_char = chars.next();
-  next_char == Some('/')
+  matches!(next_char, Some('/' | '\\'))
 }
 
 pub struct GlobMatcherOptions {
@@ -205,18 +218,28 @@ mod tests {
 
   #[test]
   fn it_should_get_absolute_globs() {
-    assert_eq!("/**/*.ts", to_absolute_glob("**/*.ts", "/"));
-    assert_eq!("/**/*.ts", to_absolute_glob("/**/*.ts", "/"));
-    assert_eq!("/test/**/*.ts", to_absolute_glob("**/*.ts", "/test"));
-    assert_eq!("/test/**/*.ts", to_absolute_glob("**/*.ts", "/test/"));
-    assert_eq!("/**/*.ts", to_absolute_glob("/**/*.ts", "/test"));
-    assert_eq!("/**/*.ts", to_absolute_glob("/**/*.ts", "/test/"));
-    assert_eq!("D:/**/*.ts", to_absolute_glob("D:/**/*.ts", "/test/"));
-    assert_eq!("D:/**/*.ts", to_absolute_glob("**/*.ts", "D:/"));
-    assert_eq!("D:/test", to_absolute_glob(".", "D:\\test"));
-    assert_eq!("/test/asdf.ts", to_absolute_glob("\\test\\asdf.ts", "D:\\test"));
-    assert_eq!("!D:/test/**/*.ts", to_absolute_glob("!**/*.ts", "D:\\test"));
-    assert_eq!("///test/**/*.ts", to_absolute_glob("///test/**/*.ts", "D:\\test"));
-    assert_eq!("CD:/**/*.ts", to_absolute_glob("**/*.ts", "CD:\\"));
+    assert_eq!(to_absolute_glob("**/*.ts", "/"), "/**/*.ts");
+    assert_eq!(to_absolute_glob("/**/*.ts", "/"), "/**/*.ts");
+    assert_eq!(to_absolute_glob("**/*.ts", "/test"), "/test/**/*.ts");
+    assert_eq!(to_absolute_glob("**/*.ts", "/test/"), "/test/**/*.ts");
+    assert_eq!(to_absolute_glob("/**/*.ts", "/test"), "/**/*.ts");
+    assert_eq!(to_absolute_glob("/**/*.ts", "/test/"), "/**/*.ts");
+    assert_eq!(to_absolute_glob("D:/**/*.ts", "/test/"), "D:/**/*.ts");
+    assert_eq!(to_absolute_glob("**/*.ts", "D:/"), "D:/**/*.ts");
+    assert_eq!(to_absolute_glob(".", "D:\\test"), "D:/test");
+    assert_eq!(to_absolute_glob("\\test\\asdf.ts", "D:\\test"), "/test/asdf.ts");
+    assert_eq!(to_absolute_glob("!**/*.ts", "D:\\test"), "!D:/test/**/*.ts");
+    assert_eq!(to_absolute_glob("///test/**/*.ts", "D:\\test"), "///test/**/*.ts");
+    assert_eq!(to_absolute_glob("**/*.ts", "CD:\\"), "CD:/**/*.ts");
+
+    assert_eq!(to_absolute_glob("./test.ts", "/test/"), "/test/test.ts");
+    assert_eq!(to_absolute_glob("test.ts", "/test/"), "/test/**/test.ts");
+    assert_eq!(to_absolute_glob("*/test.ts", "/test/"), "/test/*/test.ts");
+    assert_eq!(to_absolute_glob("*test.ts", "/test/"), "/test/**/*test.ts");
+    assert_eq!(to_absolute_glob("**/test.ts", "/test/"), "/test/**/test.ts");
+    assert_eq!(to_absolute_glob("/test.ts", "/test/"), "/test.ts");
+    assert_eq!(to_absolute_glob("test/", "/test/"), "/test/**/test/");
+    // has a slash in the middle, so it's relative
+    assert_eq!(to_absolute_glob("test/test.ts", "/test/"), "/test/test/test.ts");
   }
 }


### PR DESCRIPTION
This restores the behaviour back to the intended .gitignore behaviour.

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.

Closes #401.

cc @joscha 