### PR TITLE
Switch to using ignore crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
  "dprint-cli-core",
  "dprint-core",
  "dunce",
- "globset",
+ "ignore",
  "jsonc-parser",
  "lazy_static",
  "num_cpus",
@@ -662,6 +662,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1295,6 +1313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1716,17 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2017,6 +2064,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -17,7 +17,7 @@ dissimilar = "1.0"
 dprint-cli-core = { path = "../cli-core", version = "0.8.0" }
 dprint-core = { path = "../core", version = "0.46.2", features = ["process", "wasm"] }
 dunce = "1.0.2"
-globset = "0.4.8"
+ignore = "0.4.18"
 jsonc-parser = { version = "0.17.0" }
 num_cpus = "1.13.0"
 parking_lot = "0.11.1"

--- a/crates/dprint/src/cli/paths.rs
+++ b/crates/dprint/src/cli/paths.rs
@@ -100,9 +100,11 @@ pub fn take_absolute_paths(file_patterns: &mut Vec<GlobPattern>, environment: &i
   let len = file_patterns.len();
   let mut file_paths = Vec::new();
   for i in (0..len).rev() {
-    if is_absolute_path(&file_patterns[i].absolute_pattern, environment) {
+    let absolute_pattern = file_patterns[i].absolute_pattern();
+    if is_absolute_path(&absolute_pattern, environment) {
       // can't use swap_remove because order is important
-      file_paths.push(PathBuf::from(file_patterns.remove(i).absolute_pattern));
+      file_patterns.remove(i);
+      file_paths.push(PathBuf::from(absolute_pattern));
     }
   }
   file_paths

--- a/crates/dprint/src/cli/paths.rs
+++ b/crates/dprint/src/cli/paths.rs
@@ -6,6 +6,7 @@ use dprint_cli_core::types::ErrBox;
 use crate::environment::Environment;
 use crate::plugins::Plugin;
 use crate::utils::glob;
+use crate::utils::GlobPattern;
 use crate::utils::GlobPatterns;
 
 use super::configuration::ResolvedConfig;
@@ -52,12 +53,12 @@ pub fn get_file_paths_by_plugin(plugins: &Vec<Box<dyn Plugin>>, file_paths: Vec<
 
 pub fn get_and_resolve_file_paths(config: &ResolvedConfig, args: &CliArgs, environment: &impl Environment) -> Result<Vec<PathBuf>, ErrBox> {
   let (file_patterns, absolute_paths) = get_config_file_paths(config, args, environment)?;
-  return resolve_file_paths(&file_patterns, &absolute_paths, args, config, environment);
+  return resolve_file_paths(file_patterns, &absolute_paths, args, config, environment);
 }
 
 fn get_config_file_paths(config: &ResolvedConfig, args: &CliArgs, environment: &impl Environment) -> Result<(GlobPatterns, Vec<PathBuf>), ErrBox> {
   let cwd = environment.cwd();
-  let mut file_patterns = get_all_file_patterns(config, args, &cwd.to_string_lossy());
+  let mut file_patterns = get_all_file_patterns(config, args, &cwd);
   let absolute_paths = take_absolute_paths(&mut file_patterns.includes, environment);
   let absolute_paths = if args.file_patterns.is_empty() {
     // Filter out any config absolute file paths that don't exist.
@@ -71,7 +72,7 @@ fn get_config_file_paths(config: &ResolvedConfig, args: &CliArgs, environment: &
 }
 
 fn resolve_file_paths(
-  file_patterns: &GlobPatterns,
+  file_patterns: GlobPatterns,
   absolute_paths: &Vec<PathBuf>,
   args: &CliArgs,
   config: &ResolvedConfig,
@@ -95,12 +96,13 @@ fn resolve_file_paths(
   }
 }
 
-pub fn take_absolute_paths(file_patterns: &mut Vec<String>, environment: &impl Environment) -> Vec<PathBuf> {
+pub fn take_absolute_paths(file_patterns: &mut Vec<GlobPattern>, environment: &impl Environment) -> Vec<PathBuf> {
   let len = file_patterns.len();
   let mut file_paths = Vec::new();
   for i in (0..len).rev() {
-    if is_absolute_path(&file_patterns[i], environment) {
-      file_paths.push(PathBuf::from(file_patterns.swap_remove(i))); // faster
+    if is_absolute_path(&file_patterns[i].absolute_pattern, environment) {
+      // can't use swap_remove because order is important
+      file_paths.push(PathBuf::from(file_patterns.remove(i).absolute_pattern));
     }
   }
   file_paths

--- a/crates/dprint/src/cli/patterns.rs
+++ b/crates/dprint/src/cli/patterns.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use dprint_cli_core::types::ErrBox;
 
 use crate::environment::Environment;
-use crate::utils::{is_absolute_pattern, is_negated_glob, to_absolute_glob, to_absolute_globs, GlobMatcher, GlobMatcherOptions, GlobPatterns};
+use crate::utils::{is_absolute_pattern, is_negated_glob, GlobMatcher, GlobMatcherOptions, GlobPattern, GlobPatterns};
 
 use super::configuration::ResolvedConfig;
 use super::CliArgs;
@@ -15,14 +15,12 @@ pub struct FileMatcher {
 impl FileMatcher {
   pub fn new(config: &ResolvedConfig, args: &CliArgs, environment: &impl Environment) -> Result<Self, ErrBox> {
     let cwd = environment.cwd();
-    let cwd_str = cwd.to_string_lossy();
-    let patterns = get_all_file_patterns(config, args, &cwd_str);
+    let patterns = get_all_file_patterns(config, args, &cwd);
     let glob_matcher = GlobMatcher::new(
-      &patterns,
+      patterns,
       &GlobMatcherOptions {
         // issue on windows where V:/ was not matching for pattern with v:/
         case_insensitive: true,
-        base_dir: cwd,
       },
     )?;
 
@@ -36,52 +34,52 @@ impl FileMatcher {
   }
 }
 
-pub fn get_all_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str) -> GlobPatterns {
+pub fn get_all_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &PathBuf) -> GlobPatterns {
   GlobPatterns {
     includes: get_include_file_patterns(config, args, cwd),
     excludes: get_exclude_file_patterns(config, args, cwd),
   }
 }
 
-fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str) -> Vec<String> {
+fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &PathBuf) -> Vec<GlobPattern> {
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(if args.file_patterns.is_empty() {
-    to_absolute_globs(
+    GlobPattern::new_vec(
       process_config_patterns(process_file_patterns_slashes(&config.includes)),
-      &config.base_path.to_string_lossy(),
+      config.base_path.clone(),
     )
   } else {
     // resolve CLI patterns based on the current working directory
-    to_absolute_globs(process_cli_patterns(process_file_patterns_slashes(&args.file_patterns)), cwd)
+    GlobPattern::new_vec(process_cli_patterns(process_file_patterns_slashes(&args.file_patterns)), cwd.clone())
   });
 
   return file_patterns;
 }
 
-fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str) -> Vec<String> {
+fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &PathBuf) -> Vec<GlobPattern> {
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(
     if args.exclude_file_patterns.is_empty() {
-      to_absolute_globs(
+      GlobPattern::new_vec(
         process_config_patterns(process_file_patterns_slashes(&config.excludes)),
-        &config.base_path.to_string_lossy(),
+        config.base_path.clone(),
       )
     } else {
       // resolve CLI patterns based on the current working directory
-      to_absolute_globs(process_cli_patterns(process_file_patterns_slashes(&args.exclude_file_patterns)), cwd)
+      GlobPattern::new_vec(process_cli_patterns(process_file_patterns_slashes(&args.exclude_file_patterns)), cwd.clone())
     }
     .into_iter()
-    .map(|exclude| if exclude.starts_with("!") { exclude } else { format!("!{}", exclude) }),
+    .map(|pattern| pattern.into_negated()),
   );
 
   if !args.allow_node_modules {
     // glob walker will not search the children of a directory once it's ignored like this
     let node_modules_exclude = String::from("!**/node_modules");
     let exclude_node_module_patterns = vec![
-      to_absolute_glob(&node_modules_exclude, cwd),
-      to_absolute_glob(&node_modules_exclude, &config.base_path.to_string_lossy()),
+      GlobPattern::new(node_modules_exclude.clone(), cwd.clone()),
+      GlobPattern::new(node_modules_exclude, config.base_path.clone()),
     ];
     for node_modules_exclude in exclude_node_module_patterns {
       if !file_patterns.contains(&node_modules_exclude) {
@@ -89,7 +87,7 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &str)
       }
     }
   }
-  return file_patterns;
+  file_patterns
 }
 
 fn process_file_patterns_slashes(file_patterns: &Vec<String>) -> Vec<String> {

--- a/crates/dprint/src/cli/patterns.rs
+++ b/crates/dprint/src/cli/patterns.rs
@@ -22,6 +22,7 @@ impl FileMatcher {
       &GlobMatcherOptions {
         // issue on windows where V:/ was not matching for pattern with v:/
         case_insensitive: true,
+        base_dir: cwd,
       },
     )?;
 

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -369,4 +369,25 @@ mod test {
     result.sort();
     assert_eq!(result, vec!["/a/b/b.json", "/test.json"]);
   }
+
+  #[test]
+  fn excluding_dir_but_including_sub_dir_case_2() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/dir/a/a.txt", "")
+      .write_file("/dir/b/b.txt", "")
+      .build();
+    let result = glob(
+      &environment,
+      "/",
+      &GlobPatterns {
+        includes: vec!["**/*.*".to_string(), "!dir/a/**/*".to_string(), "dir/b/b/**/*".to_string()],
+        excludes: Vec::new(),
+      },
+    )
+    .unwrap();
+
+    let mut result = result.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    assert_eq!(result, vec!["/dir/b/b.txt"]);
+  }
 }

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -6,54 +6,100 @@ use ignore::overrides::Override;
 use ignore::overrides::OverrideBuilder;
 use ignore::Match;
 
-use super::is_negated_glob;
+use crate::utils::is_negated_glob;
 
-#[derive(Debug)]
-pub struct GlobPatterns {
-  pub includes: Vec<String>,
-  pub excludes: Vec<String>,
-}
+use super::strip_slash_start_pattern;
+use super::GlobPattern;
+use super::GlobPatterns;
 
 pub struct GlobMatcherOptions {
-  pub base_dir: PathBuf,
   pub case_insensitive: bool,
 }
 
 pub struct GlobMatcher {
+  base_dir: PathBuf,
   include_matcher: Override,
   exclude_matcher: Override,
 }
 
 impl GlobMatcher {
-  pub fn new(patterns: &GlobPatterns, opts: &GlobMatcherOptions) -> Result<GlobMatcher, ErrBox> {
+  pub fn new(patterns: GlobPatterns, opts: &GlobMatcherOptions) -> Result<GlobMatcher, ErrBox> {
+    let base_dir = get_base_dir(
+      patterns
+        .includes
+        .iter()
+        .map(|p| &p.base_dir)
+        .chain(patterns.excludes.iter().map(|p| &p.base_dir)),
+    )
+    .unwrap_or_else(|| {
+      // just use a dummy path, no directories means this won't ever be matched against
+      PathBuf::from("./")
+    });
+
+    // map the includes and excludes to have a new base
     let excludes = patterns
       .excludes
-      .iter()
-      .map(|pattern| if is_negated_glob(pattern) { &pattern[1..] } else { pattern })
+      .into_iter()
+      .map(|pattern| pattern.into_non_negated().into_new_base(base_dir.clone()))
       .collect::<Vec<_>>();
+    let includes = patterns
+      .includes
+      .into_iter()
+      .map(|pattern| pattern.into_new_base(base_dir.clone()))
+      .collect::<Vec<_>>();
+
     Ok(GlobMatcher {
-      include_matcher: build_override(&patterns.includes, opts)?,
-      exclude_matcher: build_override(&excludes, opts)?,
+      include_matcher: build_override(&includes, opts, &base_dir)?,
+      exclude_matcher: build_override(&excludes, opts, &base_dir)?,
+      base_dir,
     })
   }
 
   pub fn is_match(&self, path: impl AsRef<Path>) -> bool {
-    matches!(self.include_matcher.matched(path.as_ref(), false), Match::Whitelist(_))
-      && !matches!(self.exclude_matcher.matched(path.as_ref(), false), Match::Whitelist(_))
+    let path = path.as_ref().strip_prefix(&self.base_dir).unwrap();
+    matches!(self.include_matcher.matched(&path, false), Match::Whitelist(_)) && !matches!(self.exclude_matcher.matched(&path, false), Match::Whitelist(_))
   }
 
   pub fn is_dir_ignored(&self, path: impl AsRef<Path>) -> bool {
-    matches!(self.exclude_matcher.matched(path.as_ref(), true), Match::Whitelist(_))
+    let path = path.as_ref().strip_prefix(&self.base_dir).unwrap();
+    matches!(self.exclude_matcher.matched(&path, true), Match::Whitelist(_))
   }
 }
 
-fn build_override(patterns: &[impl AsRef<str>], opts: &GlobMatcherOptions) -> Result<Override, ErrBox> {
-  let mut builder = OverrideBuilder::new(&opts.base_dir);
+fn build_override(patterns: &[GlobPattern], opts: &GlobMatcherOptions, base_dir: &Path) -> Result<Override, ErrBox> {
+  let mut builder = OverrideBuilder::new(&base_dir);
   let builder = builder.case_insensitive(opts.case_insensitive)?;
 
   for pattern in patterns {
-    builder.add(pattern.as_ref())?;
+    // todo: bug here
+    // println!("-------");
+    // println!("{}", pattern.relative_pattern);
+
+    let pattern = if pattern.relative_pattern.contains("/") {
+      strip_slash_start_pattern(&pattern.relative_pattern)
+    } else {
+      if is_negated_glob(&pattern.relative_pattern) {
+        format!("!**/{}", &pattern.relative_pattern[1..])
+      } else {
+        format!("**/{}", pattern.relative_pattern)
+      }
+    };
+    builder.add(&pattern)?;
   }
 
-  return Ok(builder.build()?);
+  Ok(builder.build()?)
+}
+
+fn get_base_dir<'a>(dirs: impl Iterator<Item = &'a PathBuf>) -> Option<PathBuf> {
+  let mut base_dir: Option<&'a PathBuf> = None;
+  for dir in dirs {
+    if let Some(base_dir) = base_dir.as_mut() {
+      if base_dir.starts_with(dir) {
+        *base_dir = dir;
+      }
+    } else {
+      base_dir = Some(dir);
+    }
+  }
+  base_dir.map(|d| d.to_owned())
 }

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -1,0 +1,160 @@
+use std::path::PathBuf;
+
+use super::is_negated_glob;
+use super::to_absolute_glob;
+
+#[derive(Debug, PartialEq)]
+pub struct GlobPattern {
+  pub absolute_pattern: String,
+  pub relative_pattern: String,
+  pub base_dir: PathBuf,
+}
+
+impl GlobPattern {
+  pub fn new(relative_pattern: String, base_dir: PathBuf) -> Self {
+    GlobPattern {
+      absolute_pattern: to_absolute_glob(&relative_pattern, &base_dir.to_string_lossy()),
+      relative_pattern,
+      base_dir,
+    }
+  }
+
+  pub fn new_vec(relative_patterns: Vec<String>, base_dir: PathBuf) -> Vec<Self> {
+    relative_patterns
+      .into_iter()
+      .map(|relative_pattern| GlobPattern::new(relative_pattern, base_dir.clone()))
+      .collect()
+  }
+
+  pub fn is_negated(&self) -> bool {
+    is_negated_glob(&self.absolute_pattern)
+  }
+
+  pub fn into_non_negated(self) -> GlobPattern {
+    if self.is_negated() {
+      GlobPattern {
+        base_dir: self.base_dir,
+        absolute_pattern: self.absolute_pattern[1..].to_string(),
+        relative_pattern: self.relative_pattern[1..].to_string(),
+      }
+    } else {
+      self
+    }
+  }
+
+  pub fn into_negated(self) -> GlobPattern {
+    if self.is_negated() {
+      self
+    } else {
+      GlobPattern {
+        base_dir: self.base_dir,
+        absolute_pattern: format!("!{}", self.absolute_pattern),
+        relative_pattern: format!("!{}", self.relative_pattern),
+      }
+    }
+  }
+
+  pub fn into_new_base(self, new_base_dir: PathBuf) -> Self {
+    assert!(self.base_dir.starts_with(&new_base_dir));
+    if self.base_dir == new_base_dir {
+      self
+    } else {
+      let mut start_pattern = self
+        .base_dir
+        .strip_prefix(&new_base_dir)
+        .unwrap()
+        .to_string_lossy()
+        .to_string()
+        .replace("\\", "/");
+      if start_pattern.starts_with("./") {
+        start_pattern.drain(..2);
+      }
+      if start_pattern.starts_with("/") {
+        start_pattern.drain(..1);
+      }
+      let is_negated = self.is_negated();
+      let mut old_pattern = self.relative_pattern;
+      if is_negated {
+        old_pattern.drain(..1); // remove !
+      }
+      if old_pattern.starts_with("./") {
+        old_pattern.drain(..2);
+      }
+      if old_pattern.starts_with("/") {
+        old_pattern.drain(..1);
+      }
+
+      let mut new_pattern = String::new();
+      if is_negated {
+        new_pattern.push_str("!");
+      }
+      new_pattern.push_str("./");
+      if !start_pattern.is_empty() {
+        new_pattern.push_str(&start_pattern);
+        new_pattern.push_str("/");
+      }
+      new_pattern.push_str(&old_pattern);
+
+      GlobPattern::new(new_pattern, new_base_dir)
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct GlobPatterns {
+  pub includes: Vec<GlobPattern>,
+  pub excludes: Vec<GlobPattern>,
+}
+
+#[cfg(test)]
+mod test {
+  use std::path::PathBuf;
+
+  use super::*;
+
+  #[test]
+  fn should_make_negated() {
+    let pattern = GlobPattern::new("**/*".to_string(), PathBuf::from("/test")).into_negated();
+    assert_eq!(pattern.relative_pattern, "!**/*");
+    assert_eq!(pattern.absolute_pattern, "!/test/**/*");
+
+    // should keep as-is
+    let pattern = GlobPattern::new("!**/*".to_string(), PathBuf::from("/test")).into_negated();
+    assert_eq!(pattern.relative_pattern, "!**/*");
+    assert_eq!(pattern.absolute_pattern, "!/test/**/*");
+  }
+
+  #[test]
+  fn should_make_non_negated() {
+    let pattern = GlobPattern::new("!**/*".to_string(), PathBuf::from("/test")).into_non_negated();
+    assert_eq!(pattern.relative_pattern, "**/*");
+    assert_eq!(pattern.absolute_pattern, "/test/**/*");
+
+    // should keep as-is
+    let pattern = GlobPattern::new("**/*".to_string(), PathBuf::from("/test")).into_non_negated();
+    assert_eq!(pattern.relative_pattern, "**/*");
+    assert_eq!(pattern.absolute_pattern, "/test/**/*");
+  }
+
+  #[test]
+  fn should_make_with_new_base() {
+    let pattern = GlobPattern::new("**/*".to_string(), PathBuf::from("/test/dir"));
+    assert_eq!(pattern.relative_pattern, "**/*");
+    assert_eq!(pattern.absolute_pattern, "/test/dir/**/*");
+    assert_eq!(pattern.base_dir, PathBuf::from("/test/dir"));
+
+    let pattern = pattern.into_new_base(PathBuf::from("/test"));
+    assert_eq!(pattern.relative_pattern, "./dir/**/*");
+    assert_eq!(pattern.absolute_pattern, "/test/dir/**/*");
+    assert_eq!(pattern.base_dir, PathBuf::from("/test"));
+  }
+
+  #[test]
+  fn should_make_with_new_base_when_relative() {
+    let pattern = GlobPattern::new("./**/*".to_string(), PathBuf::from("/test/dir"));
+    let pattern = pattern.into_new_base(PathBuf::from("/"));
+    assert_eq!(pattern.relative_pattern, "./test/dir/**/*");
+    assert_eq!(pattern.absolute_pattern, "/test/dir/**/*");
+    assert_eq!(pattern.base_dir, PathBuf::from("/"));
+  }
+}

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -116,22 +116,6 @@ fn is_windows_absolute_pattern(pattern: &str) -> bool {
   matches!(next_char, Some('/'))
 }
 
-pub fn strip_slash_start_pattern(pattern: &str) -> String {
-  let is_negated = is_negated_glob(&pattern);
-  let mut start_index = 0;
-  if is_negated {
-    start_index += 1; // remove !
-  }
-  if pattern[start_index..].starts_with("./") {
-    start_index += 2;
-  }
-  if is_negated {
-    format!("!{}", &pattern[start_index..])
-  } else {
-    pattern[start_index..].to_string()
-  }
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -1,9 +1,5 @@
 use std::borrow::Cow;
 
-pub fn to_absolute_globs(file_patterns: Vec<String>, base_dir: &str) -> Vec<String> {
-  file_patterns.into_iter().map(|p| to_absolute_glob(&p, base_dir)).collect()
-}
-
 pub fn to_absolute_glob(pattern: &str, dir: &str) -> String {
   // Adapted from https://github.com/dsherret/ts-morph/blob/0f8a77a9fa9d74e32f88f36992d527a2f059c6ac/packages/common/src/fileSystem/FileUtils.ts#L272
 
@@ -118,6 +114,22 @@ fn is_windows_absolute_pattern(pattern: &str) -> bool {
   // now check for the last slash
   let next_char = chars.next();
   matches!(next_char, Some('/'))
+}
+
+pub fn strip_slash_start_pattern(pattern: &str) -> String {
+  let is_negated = is_negated_glob(&pattern);
+  let mut start_index = 0;
+  if is_negated {
+    start_index += 1; // remove !
+  }
+  if pattern[start_index..].starts_with("./") {
+    start_index += 2;
+  }
+  if is_negated {
+    format!("!{}", &pattern[start_index..])
+  } else {
+    pattern[start_index..].to_string()
+  }
 }
 
 #[cfg(test)]

--- a/crates/dprint/src/utils/glob/mod.rs
+++ b/crates/dprint/src/utils/glob/mod.rs
@@ -1,7 +1,9 @@
 mod glob;
 mod glob_matcher;
+mod glob_pattern;
 mod glob_utils;
 
 pub use glob::glob;
 pub use glob_matcher::*;
+pub use glob_pattern::*;
 pub use glob_utils::*;


### PR DESCRIPTION
Closes #417.

cc @joscha - You may wish to try out this PR. I'll do a release tomorrow.

On building, you may have to run:

```bash
cargo build --manifest-path=crates/test-plugin/Cargo.toml --release --target=wasm32-unknown-unknown
cargo build --manifest-path=crates/test-process-plugin/Cargo.toml --release

# this should produce the binary at ./target/release/dprint
cargo build --locked --all-features ---release
```