### PR TITLE
Remove 'static bound on StdInReader trait

### DIFF
--- a/crates/dprint/src/cli/arg_parser.rs
+++ b/crates/dprint/src/cli/arg_parser.rs
@@ -81,7 +81,7 @@ pub enum HiddenSubCommand {
   WindowsUninstall(String),
 }
 
-pub fn parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader: &TStdInReader) -> Result<CliArgs, ErrBox> {
+pub fn parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader: TStdInReader) -> Result<CliArgs, ErrBox> {
   // this is all done because clap doesn't output exactly how I like
   if args.len() == 1 || (args.len() == 2 && (args[1] == "help" || args[1] == "--help")) {
     let mut help_text = Vec::new();

--- a/crates/dprint/src/cli/commands/formatting.rs
+++ b/crates/dprint/src/cli/commands/formatting.rs
@@ -1291,7 +1291,7 @@ mod test {
       })
       .build();
 
-    let test_std_in = TestStdInReader::new_with_text("text");
+    let test_std_in = TestStdInReader::from("text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "file.txt"], &environment, test_std_in).unwrap();
     // should format even though it wasn't matched because an absolute path wasn't provided
     assert_eq!(environment.take_stdout_messages(), vec!["text_formatted"]);
@@ -1306,7 +1306,7 @@ mod test {
       })
       .build();
 
-    let test_std_in = TestStdInReader::new_with_text("text");
+    let test_std_in = TestStdInReader::from("text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "txt"], &environment, test_std_in).unwrap();
     // should format even though it wasn't matched because an absolute path wasn't provided
     assert_eq!(environment.take_stdout_messages(), vec!["text_formatted"]);
@@ -1316,7 +1316,7 @@ mod test {
   #[test]
   fn it_should_stdin_fmt_calling_other_plugin() {
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin().build();
-    let test_std_in = TestStdInReader::new_with_text("plugin: format this text");
+    let test_std_in = TestStdInReader::from("plugin: format this text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "file.txt"], &environment, test_std_in).unwrap();
     assert_eq!(environment.take_stdout_messages(), vec!["format this text_formatted_process"]);
   }
@@ -1330,7 +1330,7 @@ mod test {
         c.add_remote_wasm_plugin();
       })
       .build(); // don't initialize
-    let test_std_in = TestStdInReader::new_with_text("should_error");
+    let test_std_in = TestStdInReader::from("should_error");
     let error_message = run_test_cli_with_stdin(vec!["fmt", "--stdin", "file.txt"], &environment, test_std_in)
       .err()
       .unwrap();
@@ -1348,7 +1348,7 @@ mod test {
       .write_file("/src/file.txt", "")
       .build();
     // not matching file
-    let test_std_in = TestStdInReader::new_with_text("text");
+    let test_std_in = TestStdInReader::from("text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "/file.txt"], &environment, test_std_in.clone()).unwrap();
     assert_eq!(environment.take_stdout_messages(), vec!["text"]);
 
@@ -1373,7 +1373,7 @@ mod test {
           .add_config_section("test-plugin", r#"{ "ending": "new_ending" }"#);
       })
       .build();
-    let test_std_in = TestStdInReader::new_with_text("text");
+    let test_std_in = TestStdInReader::from("text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "sub-dir/file.txt"], &environment, test_std_in).unwrap();
     // Should use cwd since the absolute path wasn't provided. In order to use the proper config file,
     // the absolute path must be provided instead of a relative one in order to properly pick up
@@ -1396,7 +1396,7 @@ mod test {
       .write_file("/sub-dir/file.txt", "test")
       .initialize()
       .build();
-    let test_std_in = TestStdInReader::new_with_text("text");
+    let test_std_in = TestStdInReader::from("text");
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "/sub-dir/file.txt"], &environment, test_std_in).unwrap();
     assert_eq!(environment.take_stdout_messages(), vec!["text_new_ending"]);
     assert_eq!(environment.take_stderr_messages().len(), 0);

--- a/crates/dprint/src/cli/configuration/resolve_config.rs
+++ b/crates/dprint/src/cli/configuration/resolve_config.rs
@@ -331,10 +331,9 @@ mod tests {
   use super::*;
 
   fn get_result(url: &str, environment: &impl Environment) -> Result<ResolvedConfig, ErrBox> {
-    let stdin_reader = TestStdInReader::new();
     let args = parse_args(
       vec![String::from(""), String::from("check"), String::from("-c"), String::from(url)],
-      &stdin_reader,
+      TestStdInReader::default(),
     )
     .unwrap();
     let cache = Cache::new(environment.to_owned());

--- a/crates/dprint/src/main.rs
+++ b/crates/dprint/src/main.rs
@@ -10,6 +10,7 @@ mod environment;
 use dprint_core::types::ErrBox;
 use environment::RealEnvironment;
 use std::sync::Arc;
+use utils::RealStdInReader;
 
 mod cache;
 mod cli;
@@ -33,8 +34,7 @@ fn main() -> Result<(), ErrBox> {
 }
 
 fn run() -> Result<(), ErrBox> {
-  let stdin_reader = crate::utils::RealStdInReader::new();
-  let args = cli::parse_args(wild::args().collect(), &stdin_reader)?;
+  let args = cli::parse_args(wild::args().collect(), RealStdInReader)?;
   let environment = RealEnvironment::new(args.verbose, args.is_silent_output())?;
   let cache = Arc::new(cache::Cache::new(environment.clone()));
   let plugin_cache = Arc::new(plugins::PluginCache::new(environment.clone()));

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -44,14 +44,10 @@ lazy_static! {
 }
 
 pub fn run_test_cli(args: Vec<&str>, environment: &TestEnvironment) -> Result<(), ErrBox> {
-  run_test_cli_with_stdin(args, environment, TestStdInReader::new())
+  run_test_cli_with_stdin(args, environment, TestStdInReader::default())
 }
 
-pub fn run_test_cli_with_stdin(
-  args: Vec<&str>,
-  environment: &TestEnvironment,
-  stdin_reader: TestStdInReader, // todo: no clue why this can't be passed in by reference
-) -> Result<(), ErrBox> {
+pub fn run_test_cli_with_stdin(args: Vec<&str>, environment: &TestEnvironment, stdin_reader: TestStdInReader) -> Result<(), ErrBox> {
   let mut args: Vec<String> = args.into_iter().map(String::from).collect();
   args.insert(0, String::from(""));
   environment.set_wasm_compile_result(COMPILATION_RESULT.clone());
@@ -60,7 +56,7 @@ pub fn run_test_cli_with_stdin(
   let plugin_pools = Arc::new(PluginPools::new(environment.clone()));
   let _plugins_dropper = PluginsDropper::new(plugin_pools.clone());
   let plugin_resolver = PluginResolver::new(environment.clone(), plugin_cache, plugin_pools.clone());
-  let args = parse_args(args, &stdin_reader)?;
+  let args = parse_args(args, stdin_reader)?;
   environment.set_silent(args.is_silent_output());
   environment.set_verbose(args.verbose);
   run_cli(&args, environment, &cache, &plugin_resolver, plugin_pools)

--- a/crates/dprint/src/utils/stdin_reader.rs
+++ b/crates/dprint/src/utils/stdin_reader.rs
@@ -1,53 +1,47 @@
 use dprint_core::types::ErrBox;
+use std::io::{self, Read};
 
-pub trait StdInReader: Clone + std::marker::Send + std::marker::Sync + 'static {
+#[cfg(test)]
+pub use tests::TestStdInReader;
+
+pub trait StdInReader: Clone + Send + Sync {
   fn read(&self) -> Result<String, ErrBox>;
 }
 
-#[derive(Clone)]
-pub struct RealStdInReader {}
-
-impl RealStdInReader {
-  pub fn new() -> RealStdInReader {
-    RealStdInReader {}
-  }
-}
+#[derive(Default, Clone, Copy)]
+pub struct RealStdInReader;
 
 impl StdInReader for RealStdInReader {
   fn read(&self) -> Result<String, ErrBox> {
-    use std::io::{self, Read};
     let mut text = String::new();
     io::stdin().read_to_string(&mut text)?;
     Ok(text)
   }
 }
 
-#[derive(Clone)]
 #[cfg(test)]
-pub struct TestStdInReader {
-  text: std::sync::Arc<parking_lot::Mutex<Option<String>>>,
-}
+mod tests {
+  use super::*;
+  use parking_lot::Mutex;
+  use std::sync::Arc;
 
-#[cfg(test)]
-impl TestStdInReader {
-  pub fn new() -> TestStdInReader {
-    TestStdInReader::new_with_option(None)
+  #[derive(Default, Clone)]
+  pub struct TestStdInReader {
+    text: Arc<Mutex<Option<String>>>,
   }
 
-  pub fn new_with_text(text: &str) -> TestStdInReader {
-    TestStdInReader::new_with_option(Some(text.to_string()))
-  }
-
-  fn new_with_option(text: Option<String>) -> TestStdInReader {
-    TestStdInReader {
-      text: std::sync::Arc::new(parking_lot::Mutex::new(text)),
+  impl<S: ToString> From<S> for TestStdInReader {
+    fn from(value: S) -> Self {
+      Self {
+        text: Arc::new(Mutex::new(Some(value.to_string()))),
+      }
     }
   }
-}
 
-#[cfg(test)]
-impl StdInReader for TestStdInReader {
-  fn read(&self) -> Result<String, ErrBox> {
-    Ok(self.text.lock().as_ref().expect("Expected to have stdin text set.").clone())
+  impl StdInReader for TestStdInReader {
+    fn read(&self) -> Result<String, ErrBox> {
+      let text = self.text.lock();
+      Ok(text.as_ref().expect("Expected to have stdin text set.").clone())
+    }
   }
 }


### PR DESCRIPTION
This change removes the `'static` bound on the `StdInReader` trait, and makes the API a little nicer to use in tests. The motivation for this change was the todo

```rs
// todo: no clue why this can't be passed in by reference
```

IIUC, one of the reasons is due to the `'static` bound on the `StdInReader` trait. As a result, we cannot implement `StdInReader` for any `&'a T` where `'a` has a shorter lifetime than `'static`. And so the `'static` bound is kind of like telling compiler that we don't want to allow `&'a T` to implement this trait.

- `RealStdInReader` is a unit struct and so is trivially `Clone + Copy + Send + Sync`; and
- `TestStdInReader` is a wrapper around an `Arc` which suggests we should be passing by value most of the time, as the `Arc` will take care of managing references the reference counting for us.