### PR TITLE
Replace next_node_stack Vec with RcStack

### DIFF
--- a/crates/core/src/formatting/collections/mod.rs
+++ b/crates/core/src/formatting/collections/mod.rs
@@ -1,5 +1,7 @@
 mod fast_cell_map;
 mod graph_node;
+mod rc_stack;
 
 pub use fast_cell_map::*;
 pub use graph_node::*;
+pub use rc_stack::*;

--- a/crates/core/src/formatting/collections/rc_stack.rs
+++ b/crates/core/src/formatting/collections/rc_stack.rs
@@ -1,0 +1,29 @@
+use std::rc::Rc;
+
+use crate::formatting::PrintItemPath;
+
+#[derive(Clone)]
+struct RcNode {
+  path: PrintItemPath,
+  next: Option<Rc<RcNode>>,
+}
+
+#[derive(Default, Clone)]
+pub struct RcStack(Option<Rc<RcNode>>);
+
+impl RcStack {
+  pub fn push(&mut self, path: PrintItemPath) {
+    let next = self.0.as_ref().map(Rc::clone);
+    self.0 = Some(Rc::new(RcNode { path, next }));
+  }
+
+  pub fn pop(&mut self) -> Option<PrintItemPath> {
+    let head = Rc::clone(self.0.as_ref()?);
+    self.0 = head.next.as_ref().cloned();
+    Some(head.path)
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.0.is_none()
+  }
+}

--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -1,4 +1,6 @@
-use std::{cell::UnsafeCell, mem, rc::Rc};
+use std::cell::UnsafeCell;
+use std::mem;
+use std::rc::Rc;
 
 use super::printer::Printer;
 use super::utils::{with_bump_allocator, CounterCell};
@@ -690,32 +692,6 @@ impl StringContainer {
   pub fn new(text: String) -> StringContainer {
     let char_count = text.chars().count() as u32;
     StringContainer { text, char_count }
-  }
-}
-
-#[derive(Clone)]
-struct RcNode {
-  path: PrintItemPath,
-  next: Option<Rc<RcNode>>,
-}
-
-#[derive(Default, Clone)]
-pub struct RcStack(Option<Rc<RcNode>>);
-
-impl RcStack {
-  pub fn push(&mut self, path: PrintItemPath) {
-    let next = self.0.as_ref().map(Rc::clone);
-    self.0 = Some(Rc::new(RcNode { path, next }));
-  }
-
-  pub fn pop(&mut self) -> Option<PrintItemPath> {
-    let head = Rc::clone(self.0.as_ref()?);
-    self.0 = head.next.as_ref().cloned();
-    Some(head.path)
-  }
-
-  pub fn is_empty(&self) -> bool {
-    self.0.is_none()
   }
 }
 


### PR DESCRIPTION
This change replaces the `Printer::next_node_stack` and `SavePoint::next_node_stack` from being a `Vec<_>` to a `RcStack`.

`RcStack` is essentially a linked list based stack, but uses reference counting to behave more like a persistent data structure. That is, when the `RcStack` is cloned, we just need to clone the head node and all tail nodes are untouched. And when the `Printer` pops values off the stack, all `SavePoint`s will maintain pointers to the head of their view of the stack.

Local testing also indicates that change fixes dprint/dprint-plugin-typescript#269.

Noting that further improvements could be made here. For instance we may be able to get rid of reference counting in the `RcStack` in favor of regular referencing. But I'll leave these for a separate change.