### PR TITLE
feat: add plugin pattern associations

### DIFF
--- a/crates/dprint/src/cli/commands/editor.rs
+++ b/crates/dprint/src/cli/commands/editor.rs
@@ -11,6 +11,7 @@ use crate::cache::Cache;
 use crate::cli::configuration::resolve_config_from_args;
 use crate::cli::configuration::ResolvedConfig;
 use crate::cli::format::format_with_plugin_pools;
+use crate::cli::patterns::get_plugin_association_glob_matchers;
 use crate::cli::patterns::FileMatcher;
 use crate::cli::plugins::get_plugins_from_args;
 use crate::cli::plugins::resolve_plugins;
@@ -211,7 +212,8 @@ impl<'a, TEnvironment: Environment> EditorService<'a, TEnvironment> {
     if has_config_changed {
       self.plugin_pools.drop_plugins(); // clear the existing plugins
       let plugins = resolve_plugins(self.args, &config, self.environment, self.plugin_resolver)?;
-      self.plugin_pools.set_plugins(plugins);
+      let association_matchers = get_plugin_association_glob_matchers(&plugins, &config.base_path)?;
+      self.plugin_pools.set_plugins(plugins, association_matchers);
     }
 
     self.config = Some(config);

--- a/crates/dprint/src/cli/commands/formatting.rs
+++ b/crates/dprint/src/cli/commands/formatting.rs
@@ -75,8 +75,8 @@ pub fn output_format_times<TEnvironment: Environment>(
 ) -> Result<(), ErrBox> {
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
-  let resolved_file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, resolved_file_paths)?;
+  let file_paths = get_and_resolve_file_paths(&config, args, environment)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
   plugin_pools.set_plugins(plugins);
   let durations: Arc<Mutex<Vec<(PathBuf, u128)>>> = Arc::new(Mutex::new(Vec::new()));
 
@@ -109,7 +109,7 @@ pub fn check<TEnvironment: Environment>(
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
   let file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
   plugin_pools.set_plugins(plugins);
 
   let incremental_file = get_incremental_file(args, &config, &cache, &plugin_pools, &environment);
@@ -156,7 +156,7 @@ pub fn format<TEnvironment: Environment>(
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
   let file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
   plugin_pools.set_plugins(plugins);
 
   let incremental_file = get_incremental_file(args, &config, &cache, &plugin_pools, &environment);

--- a/crates/dprint/src/cli/commands/formatting.rs
+++ b/crates/dprint/src/cli/commands/formatting.rs
@@ -75,8 +75,8 @@ pub fn output_format_times<TEnvironment: Environment>(
 ) -> Result<(), ErrBox> {
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
-  let file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, file_paths)?;
+  let resolved_file_paths = get_and_resolve_file_paths(&config, args, environment)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin_and_err_if_empty(&plugins, resolved_file_paths)?;
   plugin_pools.set_plugins(plugins);
   let durations: Arc<Mutex<Vec<(PathBuf, u128)>>> = Arc::new(Mutex::new(Vec::new()));
 

--- a/crates/dprint/src/cli/commands/general.rs
+++ b/crates/dprint/src/cli/commands/general.rs
@@ -85,7 +85,7 @@ pub fn output_file_paths<TEnvironment: Environment>(
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
   let resolved_file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin(&plugins, resolved_file_paths)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin(&plugins, resolved_file_paths, &config.base_path)?;
 
   let file_paths = file_paths_by_plugin.values().flat_map(|x| x.iter());
   for file_path in file_paths {

--- a/crates/dprint/src/cli/commands/general.rs
+++ b/crates/dprint/src/cli/commands/general.rs
@@ -84,8 +84,8 @@ pub fn output_file_paths<TEnvironment: Environment>(
 ) -> Result<(), ErrBox> {
   let config = resolve_config_from_args(args, cache, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver)?;
-  let file_paths = get_and_resolve_file_paths(&config, args, environment)?;
-  let file_paths_by_plugin = get_file_paths_by_plugin(&plugins, file_paths);
+  let resolved_file_paths = get_and_resolve_file_paths(&config, args, environment)?;
+  let file_paths_by_plugin = get_file_paths_by_plugin(&plugins, resolved_file_paths)?;
 
   let file_paths = file_paths_by_plugin.values().flat_map(|x| x.iter());
   for file_path in file_paths {

--- a/crates/dprint/src/cli/patterns.rs
+++ b/crates/dprint/src/cli/patterns.rs
@@ -4,6 +4,7 @@ use dprint_cli_core::types::ErrBox;
 
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
+use crate::plugins::Plugin;
 use crate::utils::is_absolute_pattern;
 use crate::utils::is_negated_glob;
 use crate::utils::GlobMatcher;
@@ -44,11 +45,33 @@ pub fn get_all_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &Cano
   }
 }
 
-pub fn get_plugin_association_file_patterns(associations: &Vec<String>, config_base_path: &CanonicalizedPathBuf) -> GlobPatterns {
-  GlobPatterns {
-    includes: GlobPattern::new_vec(process_config_patterns(process_file_patterns_slashes(associations)), config_base_path.clone()),
-    excludes: Vec::new(),
+pub fn get_plugin_association_glob_matchers(
+  plugins: &[Box<dyn Plugin>],
+  config_base_path: &CanonicalizedPathBuf,
+) -> Result<Vec<(String, GlobMatcher)>, ErrBox> {
+  let mut matchers = Vec::new();
+  for plugin in plugins.iter() {
+    if let Some(matcher) = get_plugin_association_glob_matcher(plugin, config_base_path)? {
+      matchers.push((plugin.name().to_string(), matcher));
+    }
   }
+  Ok(matchers)
+}
+
+pub fn get_plugin_association_glob_matcher(plugin: &Box<dyn Plugin>, config_base_path: &CanonicalizedPathBuf) -> Result<Option<GlobMatcher>, ErrBox> {
+  Ok(if let Some(associations) = plugin.get_config().0.associations.as_ref() {
+    Some(GlobMatcher::new(
+      GlobPatterns {
+        includes: GlobPattern::new_vec(process_config_patterns(process_file_patterns_slashes(associations)), config_base_path.clone()),
+        excludes: Vec::new(),
+      },
+      &GlobMatcherOptions {
+        case_sensitive: !cfg!(windows),
+      },
+    )?)
+  } else {
+    None
+  })
 }
 
 fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &CanonicalizedPathBuf) -> Vec<GlobPattern> {

--- a/crates/dprint/src/cli/patterns.rs
+++ b/crates/dprint/src/cli/patterns.rs
@@ -44,6 +44,13 @@ pub fn get_all_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &Cano
   }
 }
 
+pub fn get_plugin_association_file_patterns(associations: &Vec<String>, config_base_path: &CanonicalizedPathBuf) -> GlobPatterns {
+  GlobPatterns {
+    includes: GlobPattern::new_vec(process_config_patterns(process_file_patterns_slashes(associations)), config_base_path.clone()),
+    excludes: Vec::new(),
+  }
+}
+
 fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &CanonicalizedPathBuf) -> Vec<GlobPattern> {
   let mut file_patterns = Vec::new();
 

--- a/crates/dprint/src/configuration/get_global_config.rs
+++ b/crates/dprint/src/configuration/get_global_config.rs
@@ -89,7 +89,7 @@ mod tests {
   #[test]
   fn it_should_error_on_unexpected_object_properties_when_check_unknown_property_diagnostics_true() {
     let mut config_map = HashMap::new();
-    config_map.insert(String::from("test"), ConfigMapValue::HashMap(HashMap::new()));
+    config_map.insert(String::from("test"), ConfigMapValue::PluginConfig(Default::default()));
     assert_errors_with_options(
       config_map,
       vec![],
@@ -103,7 +103,7 @@ mod tests {
   #[test]
   fn it_should_not_error_on_unexpected_object_properties_when_check_unknown_property_diagnostics_false() {
     let mut config_map = HashMap::new();
-    config_map.insert(String::from("test"), ConfigMapValue::HashMap(HashMap::new()));
+    config_map.insert(String::from("test"), ConfigMapValue::PluginConfig(Default::default()));
     assert_gets_with_options(
       config_map,
       GlobalConfiguration {

--- a/crates/dprint/src/configuration/types.rs
+++ b/crates/dprint/src/configuration/types.rs
@@ -2,10 +2,18 @@ use dprint_core::configuration::ConfigKeyMap;
 use dprint_core::configuration::ConfigKeyValue;
 use std::collections::HashMap;
 
+/// Unresolved plugin configuration.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct RawPluginConfig {
+  pub associations: Option<Vec<String>>,
+  pub locked: bool,
+  pub properties: ConfigKeyMap,
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum ConfigMapValue {
   KeyValue(ConfigKeyValue),
-  HashMap(ConfigKeyMap),
+  PluginConfig(RawPluginConfig),
   Vec(Vec<String>),
 }
 

--- a/crates/dprint/src/plugins/implementations/process/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/plugin.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::configuration::RawPluginConfig;
 use crate::environment::Environment;
 use crate::plugins::InitializedPlugin;
 use crate::plugins::Plugin;
@@ -43,7 +44,7 @@ pub struct ProcessPlugin<TEnvironment: Environment> {
   environment: TEnvironment,
   executable_file_path: PathBuf,
   plugin_info: PluginInfo,
-  config: Option<(ConfigKeyMap, GlobalConfiguration)>,
+  config: Option<(RawPluginConfig, GlobalConfiguration)>,
   plugin_pools: Arc<PluginPools<TEnvironment>>,
 }
 
@@ -88,11 +89,11 @@ impl<TEnvironment: Environment> Plugin for ProcessPlugin<TEnvironment> {
     &self.plugin_info.config_schema_url
   }
 
-  fn set_config(&mut self, plugin_config: ConfigKeyMap, global_config: GlobalConfiguration) {
+  fn set_config(&mut self, plugin_config: RawPluginConfig, global_config: GlobalConfiguration) {
     self.config = Some((plugin_config, global_config));
   }
 
-  fn get_config(&self) -> &(ConfigKeyMap, GlobalConfiguration) {
+  fn get_config(&self) -> &(RawPluginConfig, GlobalConfiguration) {
     self.config.as_ref().expect("Call set_config first.")
   }
 
@@ -102,7 +103,7 @@ impl<TEnvironment: Environment> Plugin for ProcessPlugin<TEnvironment> {
       self.environment.clone(),
       self.plugin_info.name.clone(),
       self.executable_file_path.clone(),
-      config.clone(),
+      (config.0.properties.clone(), config.1.clone()),
     )?;
     let process_plugin = InitializedProcessPlugin::new(self.name().to_string(), self.environment.clone(), communicator, self.plugin_pools.clone())?;
 

--- a/crates/dprint/src/plugins/implementations/wasm/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/plugin.rs
@@ -14,6 +14,7 @@ use super::load_instance;
 use super::FormatResult;
 use super::ImportObjectEnvironment;
 use super::WasmFunctions;
+use crate::configuration::RawPluginConfig;
 use crate::environment::Environment;
 use crate::plugins::InitializedPlugin;
 use crate::plugins::Plugin;
@@ -22,7 +23,7 @@ use crate::plugins::PluginPools;
 pub struct WasmPlugin<TEnvironment: Environment> {
   module: wasmer::Module,
   plugin_info: PluginInfo,
-  config: Option<(ConfigKeyMap, GlobalConfiguration)>,
+  config: Option<(RawPluginConfig, GlobalConfiguration)>,
   plugin_pools: Arc<PluginPools<TEnvironment>>,
 }
 
@@ -67,11 +68,11 @@ impl<TEnvironment: Environment> Plugin for WasmPlugin<TEnvironment> {
     &self.plugin_info.config_schema_url
   }
 
-  fn set_config(&mut self, plugin_config: ConfigKeyMap, global_config: GlobalConfiguration) {
+  fn set_config(&mut self, plugin_config: RawPluginConfig, global_config: GlobalConfiguration) {
     self.config = Some((plugin_config, global_config));
   }
 
-  fn get_config(&self) -> &(ConfigKeyMap, GlobalConfiguration) {
+  fn get_config(&self) -> &(RawPluginConfig, GlobalConfiguration) {
     self.config.as_ref().expect("Call set_config first.")
   }
 
@@ -91,7 +92,7 @@ impl<TEnvironment: Environment> Plugin for WasmPlugin<TEnvironment> {
     let (plugin_config, global_config) = self.config.as_ref().expect("Call set_config first.");
 
     wasm_plugin.set_global_config(&global_config)?;
-    wasm_plugin.set_plugin_config(&plugin_config)?;
+    wasm_plugin.set_plugin_config(&plugin_config.properties)?;
 
     Ok(Box::new(wasm_plugin))
   }

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -75,7 +75,12 @@ impl GlobMatcher {
         include_matcher,
         exclude_matcher,
       } => {
-        let path = path.as_ref().strip_prefix(&base_dir).unwrap();
+        let path = path.as_ref();
+        let path = if path.is_absolute() {
+          Cow::Borrowed(path.strip_prefix(&base_dir).unwrap())
+        } else {
+          Cow::Owned(base_dir.join(path))
+        };
         matches!(include_matcher.matched(&path, false), Match::Whitelist(_)) && !matches!(exclude_matcher.matched(&path, false), Match::Whitelist(_))
       }
     }


### PR DESCRIPTION
This implements https://github.com/dprint/dprint/issues/365#issuecomment-913279108 where people can provide an `"associations"` key to a plugin config to get it to grab certain files that are matched by the includes/excludes patterns and have that plugin format them.

Todo:

- [x] Tests
- [x] Plugin pool should inspect this (almost forgot)

Closes #365