### PR TITLE
Fix linter errors for tests in core

### DIFF
--- a/crates/core/src/configuration.rs
+++ b/crates/core/src/configuration.rs
@@ -325,7 +325,7 @@ mod test {
     assert_eq!(config_result.diagnostics.len(), 0);
     assert_eq!(config.line_width, None);
     assert_eq!(config.indent_width, None);
-    assert_eq!(config.new_line_kind.is_none(), true);
+    assert!(config.new_line_kind.is_none());
     assert_eq!(config.use_tabs, None);
   }
 
@@ -342,7 +342,7 @@ mod test {
     assert_eq!(config_result.diagnostics.len(), 0);
     assert_eq!(config.line_width, Some(80));
     assert_eq!(config.indent_width, Some(8));
-    assert_eq!(config.new_line_kind == Some(NewLineKind::CarriageReturnLineFeed), true);
+    assert_eq!(config.new_line_kind, Some(NewLineKind::CarriageReturnLineFeed));
     assert_eq!(config.use_tabs, Some(true));
   }
 

--- a/crates/core/src/formatting/writer.rs
+++ b/crates/core/src/formatting/writer.rs
@@ -311,8 +311,8 @@ mod test {
   #[test]
   fn write_singleword_writes() {
     with_bump_allocator_mut(|bump| {
-      let mut writer = create_writer(&bump);
-      write_text(&mut writer, "test", &bump);
+      let mut writer = create_writer(bump);
+      write_text(&mut writer, "test", bump);
       assert_writer_equal(writer, "test");
       bump.reset();
     });
@@ -321,10 +321,10 @@ mod test {
   #[test]
   fn write_multiple_lines_writes() {
     with_bump_allocator_mut(|bump| {
-      let mut writer = create_writer(&bump);
-      write_text(&mut writer, "1", &bump);
+      let mut writer = create_writer(bump);
+      write_text(&mut writer, "1", bump);
       writer.new_line();
-      write_text(&mut writer, "2", &bump);
+      write_text(&mut writer, "2", bump);
       assert_writer_equal(writer, "1\n2");
       bump.reset();
     });
@@ -333,14 +333,14 @@ mod test {
   #[test]
   fn write_indented_writes() {
     with_bump_allocator_mut(|bump| {
-      let mut writer = create_writer(&bump);
-      write_text(&mut writer, "1", &bump);
+      let mut writer = create_writer(bump);
+      write_text(&mut writer, "1", bump);
       writer.new_line();
       writer.start_indent();
-      write_text(&mut writer, "2", &bump);
+      write_text(&mut writer, "2", bump);
       writer.finish_indent();
       writer.new_line();
-      write_text(&mut writer, "3", &bump);
+      write_text(&mut writer, "3", bump);
       assert_writer_equal(writer, "1\n  2\n3");
       bump.reset();
     });
@@ -349,9 +349,9 @@ mod test {
   #[test]
   fn write_singleindent_writes() {
     with_bump_allocator_mut(|bump| {
-      let mut writer = create_writer(&bump);
+      let mut writer = create_writer(bump);
       writer.single_indent();
-      write_text(&mut writer, "t", &bump);
+      write_text(&mut writer, "t", bump);
       assert_writer_equal(writer, "  t");
       bump.reset();
     });
@@ -360,10 +360,10 @@ mod test {
   #[test]
   fn markexpectnewline_writesnewline() {
     with_bump_allocator_mut(|bump| {
-      let mut writer = create_writer(&bump);
-      write_text(&mut writer, "1", &bump);
+      let mut writer = create_writer(bump);
+      write_text(&mut writer, "1", bump);
       writer.mark_expect_new_line();
-      write_text(&mut writer, "2", &bump);
+      write_text(&mut writer, "2", bump);
       assert_writer_equal(writer, "1\n2");
       bump.reset();
     });
@@ -385,7 +385,7 @@ mod test {
     writer.write(string_container);
   }
 
-  fn create_writer<'a>(bump: &'a Bump) -> Writer<'a> {
+  fn create_writer(bump: &Bump) -> Writer {
     Writer::new(
       bump,
       WriterOptions {

--- a/crates/core/tests/sample_example_test.rs
+++ b/crates/core/tests/sample_example_test.rs
@@ -142,8 +142,8 @@ fn gen_node(node: Node) -> PrintItems {
   // in a real implementation this function would deal with surrounding comments
 
   match node {
-    Node::ArrayLiteralExpression(expr) => gen_array_literal_expression(&expr),
-    Node::ArrayElement(array_element) => gen_array_element(&array_element),
+    Node::ArrayLiteralExpression(expr) => gen_array_literal_expression(expr),
+    Node::ArrayElement(array_element) => gen_array_element(array_element),
   }
 }
 
@@ -167,7 +167,7 @@ fn gen_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
   items.push_condition(conditions::if_true_or(
     "indentIfMultipleLines",
     is_multiple_lines.clone(),
-    ir_helpers::with_indent(generated_elements.clone().into()),
+    ir_helpers::with_indent(generated_elements.into()),
     generated_elements.into(),
   ));
 
@@ -178,7 +178,7 @@ fn gen_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
 
   return items;
 
-  fn gen_elements(elements: &Vec<ArrayElement>, is_multiple_lines: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)) -> PrintItems {
+  fn gen_elements(elements: &[ArrayElement], is_multiple_lines: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)) -> PrintItems {
     let mut items = PrintItems::new();
     let elements_len = elements.len();
 
@@ -214,9 +214,9 @@ fn create_is_multiple_lines_resolver(
 ) -> impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static {
   // todo: this could be more efficient only only use references and avoid the clones
   // I'm too lazy to update this sample, but it should help you get the idea.
-  return move |condition_context: &mut ConditionResolverContext| {
+  move |condition_context: &mut ConditionResolverContext| {
     // no items, so format on the same line
-    if child_positions.len() == 0 {
+    if child_positions.is_empty() {
       return Some(false);
     }
     // first child is on a different line than the start of the parent
@@ -227,5 +227,5 @@ fn create_is_multiple_lines_resolver(
 
     // check if it spans multiple lines, and if it does then make it multi-line
     condition_resolvers::is_multiple_lines(condition_context, &start_info, &end_info)
-  };
+  }
 }


### PR DESCRIPTION
This makes minor improvements by fixing clippy errors that occur when
linting the tests in crates/core.