### PR TITLE
feat: support for plugins to specify how to update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 David Sherret. All rights reserved. MIT license.
+# Copyright 2020-2022 David Sherret. All rights reserved. MIT license.
 # Made with the help of:
 # https://github.com/denoland/deno/blob/main/.github/workflows/ci.yml
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 David Sherret. All rights reserved. MIT license.
+# Copyright 2020-2022 David Sherret. All rights reserved. MIT license.
 name: Package Publish
 
 on:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 David Sherret. All rights reserved. MIT license.
+# Copyright 2020-2022 David Sherret. All rights reserved. MIT license.
 name: Website
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "anyhow",
  "bumpalo",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/cli-core/LICENSE
+++ b/crates/cli-core/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.49.1"
+version = "0.50.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"

--- a/crates/core/LICENSE
+++ b/crates/core/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/core/src/plugins/plugin_info.rs
+++ b/crates/core/src/plugins/plugin_info.rs
@@ -19,5 +19,13 @@ pub struct PluginInfo {
   /// A url the user can go to in order to get help information about the plugin.
   pub help_url: String,
   /// Schema url for the plugin configuration.
+  ///
+  /// Generally in the format: https://plugins.dprint.dev/<org-or-user>/<repo>-<tag-name>/schema.json
+  /// For example: https://plugins.dprint.dev/dprint/dprint-plugin-typescript-0.60.0/schema.json
   pub config_schema_url: String,
+  /// Plugin update url.
+  ///
+  /// Generally in the format: https://plugins.dprint.dev/<org-or-user>/<repo>/latest.json
+  /// For example: https://plugins.dprint.dev/dprint/dprint-plugin-typescript/latest.json
+  pub update_url: Option<String>,
 }

--- a/crates/core/src/plugins/wasm/mod.rs
+++ b/crates/core/src/plugins/wasm/mod.rs
@@ -230,7 +230,7 @@ pub mod macros {
               for (key, value) in override_config {
                 plugin_config.insert(key, value);
               }
-              return unsafe { WASM_PLUGIN.get().resolve_config(plugin_config, global_config) };
+              return WASM_PLUGIN.get().resolve_config(plugin_config, global_config);
             }
           }
         }
@@ -293,7 +293,7 @@ pub mod macros {
       pub fn set_buffer_with_shared_bytes(offset: usize, length: usize) {
         unsafe {
           let bytes = &SHARED_BYTES.get()[offset..(offset + length)];
-          &WASM_MEMORY_BUFFER[..length].copy_from_slice(bytes);
+          WASM_MEMORY_BUFFER[..length].copy_from_slice(bytes);
         }
       }
 

--- a/crates/development/LICENSE
+++ b/crates/development/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -15,7 +15,7 @@ clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
 dprint-cli-core = { path = "../cli-core", version = "0.10.2" }
-dprint-core = { path = "../core", version = "0.49.1", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "0.50.0", features = ["process", "wasm"] }
 dunce = "1.0.2"
 ignore = "0.4.18"
 jsonc-parser = { version = "0.18.0" }

--- a/crates/dprint/LICENSE
+++ b/crates/dprint/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -228,7 +228,7 @@ fn create_cli_parser<'a, 'b>(is_outputting_main_help: bool) -> clap::App<'a, 'b>
     .bin_name("dprint")
     .version_short("v")
     .version(env!("CARGO_PKG_VERSION"))
-    .author("Copyright 2020-2021 by David Sherret")
+    .author("Copyright 2020-2022 by David Sherret")
     .about("Auto-formats source code based on the specified plugins.")
     .usage("dprint <SUBCOMMAND> [OPTIONS] [--] [file patterns]...")
     // .help_about("Prints help information.") // todo: Enable once clap supports this as I want periods

--- a/crates/dprint/src/commands/editor.rs
+++ b/crates/dprint/src/commands/editor.rs
@@ -252,7 +252,7 @@ mod test {
     final_output.push_str(&env!("CARGO_PKG_VERSION").to_string());
     final_output.push_str(r#"","configSchemaUrl":"https://dprint.dev/schemas/v0.json","plugins":["#);
     final_output
-      .push_str(r#"{"name":"test-plugin","version":"0.1.0","configKey":"test-plugin","fileExtensions":["txt"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/schemas/test.json","helpUrl":"https://dprint.dev/plugins/test"},"#);
+      .push_str(r#"{"name":"test-plugin","version":"0.1.0","configKey":"test-plugin","fileExtensions":["txt"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/test/schema.json","helpUrl":"https://dprint.dev/plugins/test"},"#);
     final_output.push_str(r#"{"name":"test-process-plugin","version":"0.1.0","configKey":"testProcessPlugin","fileExtensions":["txt_ps"],"fileNames":["test-process-plugin-exact-file"],"helpUrl":"https://dprint.dev/plugins/test-process"}]}"#);
     assert_eq!(environment.take_stdout_messages(), vec![final_output]);
     assert_eq!(

--- a/crates/dprint/src/configuration/manipulation.rs
+++ b/crates/dprint/src/configuration/manipulation.rs
@@ -6,28 +6,29 @@ use jsonc_parser::ast::Array;
 use jsonc_parser::ast::Object;
 use jsonc_parser::common::Ranged;
 
-use crate::plugins::InfoFilePluginInfo;
 use crate::plugins::PluginSourceReference;
 
 pub struct PluginUpdateInfo {
   pub name: String,
   pub old_version: String,
   pub old_reference: PluginSourceReference,
-  pub new_plugin: InfoFilePluginInfo,
+  pub new_version: String,
+  pub new_reference: PluginSourceReference,
 }
 
 impl PluginUpdateInfo {
   pub fn is_wasm(&self) -> bool {
-    self.new_plugin.is_wasm()
+    self.new_reference.is_wasm_plugin()
   }
 
   pub fn get_full_new_config_url(&self) -> String {
     // only add the checksum if not wasm or previously had a checksum
     let should_add_checksum = !self.is_wasm() || self.old_reference.checksum.is_some();
     if should_add_checksum {
-      return self.new_plugin.full_url();
+      self.new_reference.to_full_string()
+    } else {
+      self.new_reference.without_checksum().to_string()
     }
-    self.new_plugin.url.clone()
   }
 }
 

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -170,7 +170,7 @@ mod test {
     // should have saved the manifest
     assert_eq!(
       environment.read_file(&environment.get_cache_dir().join("plugin-cache-manifest.json")).unwrap(),
-      r#"{"schemaVersion":4,"plugins":{"remote:https://plugins.dprint.dev/test.wasm":{"createdTime":123456,"info":{"name":"test-plugin","version":"0.1.0","configKey":"test-plugin","fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url"}}}}"#,
+      r#"{"schemaVersion":4,"plugins":{"remote:https://plugins.dprint.dev/test.wasm":{"createdTime":123456,"info":{"name":"test-plugin","version":"0.1.0","configKey":"test-plugin","fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url","updateUrl":"update-url"}}}}"#,
     );
 
     // should forget it afterwards
@@ -213,7 +213,7 @@ mod test {
       concat!(
         r#"{"schemaVersion":4,"plugins":{"local:/test.wasm":{"createdTime":123456,"fileHash":10632242795325663332,"info":{"#,
         r#""name":"test-plugin","version":"0.1.0","configKey":"test-plugin","#,
-        r#""fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url"}}}}"#,
+        r#""fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url","updateUrl":"update-url"}}}}"#,
       )
     );
 
@@ -234,7 +234,7 @@ mod test {
       concat!(
         r#"{"schemaVersion":4,"plugins":{"local:/test.wasm":{"createdTime":123456,"fileHash":6989588595861227504,"info":{"#,
         r#""name":"test-plugin","version":"0.1.0","configKey":"test-plugin","#,
-        r#""fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url"}}}}"#,
+        r#""fileExtensions":["txt","dat"],"fileNames":[],"helpUrl":"test-url","configSchemaUrl":"schema-url","updateUrl":"update-url"}}}}"#,
       )
     );
 
@@ -269,6 +269,7 @@ mod test {
       file_names: vec![],
       help_url: String::from("test-url"),
       config_schema_url: String::from("schema-url"),
+      update_url: Some(String::from("update-url")),
     }
   }
 }

--- a/crates/dprint/src/plugins/cache_manifest.rs
+++ b/crates/dprint/src/plugins/cache_manifest.rs
@@ -88,6 +88,7 @@ fn get_manifest_file_path(environment: &impl Environment) -> PathBuf {
 mod test {
   use super::*;
   use crate::environment::TestEnvironment;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn should_read_ok_manifest() {
@@ -131,7 +132,8 @@ mod test {
                 "fileExtensions": [],
                 "fileNames": ["Cargo.toml"],
                 "helpUrl": "cargo help url",
-                "configSchemaUrl": "cargo schema url"
+                "configSchemaUrl": "cargo schema url",
+                "updateUrl": "cargo update url"
             }
         }
     }
@@ -153,6 +155,7 @@ mod test {
           file_names: vec![],
           help_url: "help url".to_string(),
           config_schema_url: "schema url".to_string(),
+          update_url: None,
         },
       },
     );
@@ -169,6 +172,7 @@ mod test {
           file_names: vec![],
           help_url: "help url 2".to_string(),
           config_schema_url: "schema url 2".to_string(),
+          update_url: None,
         },
       },
     );
@@ -185,6 +189,7 @@ mod test {
           file_names: vec!["Cargo.toml".to_string()],
           help_url: "cargo help url".to_string(),
           config_schema_url: "cargo schema url".to_string(),
+          update_url: Some("cargo update url".to_string()),
         },
       },
     );
@@ -259,6 +264,7 @@ mod test {
           file_names: vec![],
           help_url: "help url".to_string(),
           config_schema_url: "schema url".to_string(),
+          update_url: Some("update url".to_string()),
         },
       },
     );
@@ -275,6 +281,7 @@ mod test {
           file_names: vec!["file.test".to_string()],
           help_url: "help url 2".to_string(),
           config_schema_url: "schema url 2".to_string(),
+          update_url: None,
         },
       },
     );

--- a/crates/dprint/src/plugins/implementations/process/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/plugin.rs
@@ -89,6 +89,10 @@ impl<TEnvironment: Environment> Plugin for ProcessPlugin<TEnvironment> {
     &self.plugin_info.config_schema_url
   }
 
+  fn update_url(&self) -> Option<&str> {
+    self.plugin_info.update_url.as_deref()
+  }
+
   fn set_config(&mut self, plugin_config: RawPluginConfig, global_config: GlobalConfiguration) {
     self.config = Some((plugin_config, global_config));
   }

--- a/crates/dprint/src/plugins/implementations/wasm/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/plugin.rs
@@ -70,6 +70,10 @@ impl<TEnvironment: Environment> Plugin for WasmPlugin<TEnvironment> {
     &self.plugin_info.config_schema_url
   }
 
+  fn update_url(&self) -> Option<&str> {
+    self.plugin_info.update_url.as_deref()
+  }
+
   fn set_config(&mut self, plugin_config: RawPluginConfig, global_config: GlobalConfiguration) {
     self.config = Some((plugin_config, global_config));
   }

--- a/crates/dprint/src/plugins/plugin.rs
+++ b/crates/dprint/src/plugins/plugin.rs
@@ -23,6 +23,8 @@ pub trait Plugin: std::marker::Send + std::marker::Sync {
   fn help_url(&self) -> &str;
   /// Gets the configuration schema url.
   fn config_schema_url(&self) -> &str;
+  /// Gets the update url if it exists.
+  fn update_url(&self) -> Option<&str>;
   /// Sets the configuration for the plugin.
   fn set_config(&mut self, plugin_config: RawPluginConfig, global_config: GlobalConfiguration);
   /// Initializes the plugin.
@@ -107,6 +109,9 @@ impl Plugin for TestPlugin {
   }
   fn config_schema_url(&self) -> &str {
     "https://plugins.dprint.dev/schemas/test.json"
+  }
+  fn update_url(&self) -> Option<&str> {
+    None
   }
   fn config_key(&self) -> &str {
     &self.config_key

--- a/crates/dprint/src/plugins/repo/mod.rs
+++ b/crates/dprint/src/plugins/repo/mod.rs
@@ -1,3 +1,5 @@
 mod read_info_file;
+mod read_update_url;
 
 pub use read_info_file::*;
+pub use read_update_url::*;

--- a/crates/dprint/src/plugins/repo/read_info_file.rs
+++ b/crates/dprint/src/plugins/repo/read_info_file.rs
@@ -4,8 +4,11 @@ use jsonc_parser::parse_to_value;
 use jsonc_parser::JsonArray;
 use jsonc_parser::JsonObject;
 use jsonc_parser::JsonValue;
+use url::Url;
 
 use crate::environment::Environment;
+use crate::plugins::PluginSourceReference;
+use crate::utils::PathSource;
 
 #[derive(PartialEq, Debug)]
 pub struct InfoFile {
@@ -48,6 +51,13 @@ impl InfoFilePluginInfo {
     } else {
       self.full_url()
     }
+  }
+
+  pub fn as_source_reference(&self) -> Result<PluginSourceReference> {
+    Ok(PluginSourceReference {
+      path_source: PathSource::new_remote(Url::parse(&self.url)?),
+      checksum: self.checksum.clone(),
+    })
   }
 }
 

--- a/crates/dprint/src/plugins/repo/read_update_url.rs
+++ b/crates/dprint/src/plugins/repo/read_update_url.rs
@@ -1,0 +1,119 @@
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Result;
+use jsonc_parser::parse_to_value;
+use jsonc_parser::JsonValue;
+
+use crate::environment::Environment;
+
+const SCHEMA_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PluginUpdateUrlInfo {
+  pub url: String,
+  pub version: String,
+  pub checksum: Option<String>,
+}
+
+pub fn read_update_url(environment: &impl Environment, url: &str) -> Result<PluginUpdateUrlInfo> {
+  let info_bytes = environment.download_file(url)?;
+  let info_text = String::from_utf8(info_bytes.to_vec())?;
+  let json_value = parse_to_value(&info_text)?;
+  let mut obj = match json_value {
+    Some(JsonValue::Object(obj)) => obj,
+    _ => bail!("Expected object in root element."),
+  };
+
+  // check schema version
+  let schema_version = match obj.take_number("schemaVersion") {
+    Some(value) => value.parse::<u32>()?,
+    _ => bail!("Could not find schema version."),
+  };
+  if schema_version != SCHEMA_VERSION as u32 {
+    bail!(
+      concat!(
+        "Cannot handle schema version {}. Expected {}. This might mean your dprint CLI ",
+        "version is old and isn't able to get the latest information or the registry ",
+        "needs to update its schema version.",
+      ),
+      schema_version,
+      SCHEMA_VERSION
+    );
+  }
+
+  let version = obj
+    .take_string("version")
+    .ok_or_else(|| anyhow!("Expected to find a version property in the data."))?;
+  let url = obj.take_string("url").ok_or_else(|| anyhow!("Expected to find a url property in the data."))?;
+  let checksum = obj.take_string("checksum");
+
+  Ok(PluginUpdateUrlInfo {
+    version: version.to_string(),
+    url: url.to_string(),
+    checksum: checksum.map(|c| c.to_string()),
+  })
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::environment::TestEnvironmentBuilder;
+
+  #[test]
+  fn should_get_valid() {
+    let mut builder = TestEnvironmentBuilder::new();
+    builder
+      .add_remote_file(
+        "https://plugins.dprint.dev/plugin/latest.json",
+        r#"{ "schemaVersion": 1, "url": "url", "version": "version" }"#,
+      )
+      .add_remote_file(
+        "https://plugins.dprint.dev/plugin/latest-checksum.json",
+        r#"{ "schemaVersion": 1, "url": "url2", "version": "version2", "checksum": "checksum" }"#,
+      );
+    let environment = builder.build();
+    assert_eq!(
+      read_update_url(&environment, "https://plugins.dprint.dev/plugin/latest.json").unwrap(),
+      PluginUpdateUrlInfo {
+        version: "version".to_string(),
+        url: "url".to_string(),
+        checksum: None,
+      }
+    );
+    assert_eq!(
+      read_update_url(&environment, "https://plugins.dprint.dev/plugin/latest-checksum.json").unwrap(),
+      PluginUpdateUrlInfo {
+        version: "version2".to_string(),
+        url: "url2".to_string(),
+        checksum: Some("checksum".to_string()),
+      }
+    );
+  }
+
+  #[test]
+  fn should_err_invalid() {
+    let mut builder = TestEnvironmentBuilder::new();
+    builder.add_remote_file(
+      "https://plugins.dprint.dev/plugin/latest.json",
+      r#"{ "schemaVersion": 205, "url": "url", "version": "version" }"#,
+    );
+    let environment = builder.build();
+    assert_eq!(
+      read_update_url(&environment, "https://plugins.dprint.dev/plugin/latest.json")
+        .err()
+        .unwrap()
+        .to_string(),
+      concat!(
+        "Cannot handle schema version 205. Expected 1. This might mean your dprint CLI version ",
+        "is old and isn't able to get the latest information or the registry needs to update its schema version.",
+      )
+    );
+    assert_eq!(
+      read_update_url(&environment, "https://plugins.dprint.dev/plugin/not-exists.json")
+        .err()
+        .unwrap()
+        .to_string(),
+      "Could not find file at url https://plugins.dprint.dev/plugin/not-exists.json",
+    );
+  }
+}

--- a/crates/dprint/src/plugins/types.rs
+++ b/crates/dprint/src/plugins/types.rs
@@ -35,6 +35,21 @@ impl PluginSourceReference {
     self.path_source.is_process_plugin()
   }
 
+  pub fn without_checksum(&self) -> PluginSourceReference {
+    PluginSourceReference {
+      path_source: self.path_source.clone(),
+      checksum: None,
+    }
+  }
+
+  pub fn to_full_string(&self) -> String {
+    if let Some(checksum) = &self.checksum {
+      format!("{}@{}", self.path_source, checksum)
+    } else {
+      self.path_source.display()
+    }
+  }
+
   #[cfg(test)]
   pub fn new_local(path: impl AsRef<std::path::Path>) -> PluginSourceReference {
     use crate::environment::CanonicalizedPathBuf;
@@ -56,11 +71,7 @@ impl PluginSourceReference {
 
 impl fmt::Display for PluginSourceReference {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    if let Some(checksum) = &self.checksum {
-      write!(f, "{}@{}", self.path_source, checksum)
-    } else {
-      write!(f, "{}", self.path_source)
-    }
+    write!(f, "{}", self.to_full_string())
   }
 }
 

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -125,7 +125,7 @@ pub fn get_expected_help_text() -> &'static str {
     "dprint ",
     env!("CARGO_PKG_VERSION"),
     r#"
-Copyright 2020-2021 by David Sherret
+Copyright 2020-2022 by David Sherret
 
 Auto-formats source code based on the specified plugins.
 

--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -54,7 +54,8 @@ impl PluginHandler<Configuration> for TestWasmPlugin {
       file_extensions: vec!["txt".to_string()],
       file_names: vec![],
       help_url: "https://dprint.dev/plugins/test".to_string(),
-      config_schema_url: "https://plugins.dprint.dev/schemas/test.json".to_string(),
+      config_schema_url: "https://plugins.dprint.dev/test/schema.json".to_string(),
+      update_url: Some("https://plugins.dprint.dev/test/latest.json".to_string()),
     }
   }
 

--- a/crates/test-process-plugin/src/main.rs
+++ b/crates/test-process-plugin/src/main.rs
@@ -50,6 +50,7 @@ impl PluginHandler<Configuration> for TestProcessPluginHandler {
       file_names: vec!["test-process-plugin-exact-file".to_string()],
       help_url: "https://dprint.dev/plugins/test-process".to_string(),
       config_schema_url: "".to_string(),
+      update_url: None,
     }
   }
 

--- a/deployment/installer/dprint-installer.nsi
+++ b/deployment/installer/dprint-installer.nsi
@@ -1,5 +1,5 @@
 # dprint installer script
-# Copyright 2020-2021 David Sherret. All rights reserved. MIT license.
+# Copyright 2020-2022 David Sherret. All rights reserved. MIT license.
 
 Name "dprint"
 

--- a/deployment/npm/LICENSE
+++ b/deployment/npm/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 David Sherret
+Copyright (c) 2019-2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This changes allows plugins to specify an optional `updateUrl` in their `PluginInfo`, which can be used by the CLI to figure out how to upgrade a plugin. This url must point to an endpoint that returns a JSON object that looks like the following:

```
{
  "schemaVersion": 1,
  "url": "https://plugins.dprint.dev/json-0.14.0.wasm",
  "version": "0.14.0"
}
```

This object also has an optional `"checksum"` property, which is useful for process plugins.

Example values:

* https://plugins.dprint.dev/dprint/dprint-plugin-prettier/latest.json
* https://plugins.dprint.dev/malobre/dprint-plugin-vue/latest.json

Currently, the plugins.dprint.dev service provides these endpoints for free and is based off of GitHub repositories.

The dprint CLI will then use this information instead of https://plugins.dprint.dev/info.json in order to upgrade.

This change is a slow progression towards a more decentralized CLI where anyone can create and share plugins.

Closes #454