### PR TITLE
feat: `dprint config add <user-or-org>/<repo>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-cli-core"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a411b468cc1d2a10aaad46d1cc0eaffd6c6d9b6401baa5915c4b5126c5ea2"
+checksum = "34bbb0cd324c4ed32861be1d00c58635b94d03a2d2c70f6aec5f1a419c532783"
 
 [[package]]
 name = "lazy_static"

--- a/crates/cli-core/Cargo.toml
+++ b/crates/cli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-cli-core"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -14,11 +14,11 @@ anyhow = "1.0.53"
 clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
-dprint-cli-core = { path = "../cli-core", version = "0.10.2" }
+dprint-cli-core = { path = "../cli-core", version = "0.11.0" }
 dprint-core = { path = "../core", version = "0.50.0", features = ["process", "wasm"] }
 dunce = "1.0.2"
 ignore = "0.4.18"
-jsonc-parser = { version = "0.18.0" }
+jsonc-parser = { version = "0.19.0" }
 num_cpus = "1.13.0"
 parking_lot = "0.11.2"
 rayon = "1.5.1"

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -92,7 +92,7 @@ pub fn add_plugin_config_file<TEnvironment: Environment>(
           if let Ok(config_plugin) = config_plugin {
             if let Some(update_url) = config_plugin.update_url() {
               if let Ok(Some(config_plugin_latest)) = read_update_url(&cached_downloader, update_url) {
-                // if two plugins have the same update URL then they're the same plugin
+                // if two plugins have the same URL to be updated to then they're the same plugin
                 if config_plugin_latest.url == plugin.url {
                   let file_text = environment.read_file(&config_path)?;
                   let new_reference = plugin.as_source_reference()?;

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -347,7 +347,7 @@ mod test {
     expected_messages.push(concat!(
       "There was a problem getting the latest plugin info. ",
       "The created config file may not be as helpful of a starting point. ",
-      "Error: Could not find file at url https://plugins.dprint.dev/info.json"
+      "Error: Error downloading https://plugins.dprint.dev/info.json - 404 Not Found"
     ));
     assert_eq!(environment.take_stderr_messages(), expected_messages);
   }

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -16,6 +16,7 @@ use super::CanonicalizedPathBuf;
 use super::DirEntry;
 use super::DirEntryKind;
 use super::Environment;
+use super::UrlDownloader;
 use crate::plugins::CompilationResult;
 
 #[derive(Clone)]
@@ -41,6 +42,14 @@ impl RealEnvironment {
     }
 
     Ok(environment)
+  }
+}
+
+impl UrlDownloader for RealEnvironment {
+  fn download_file(&self, url: &str) -> Result<Option<Vec<u8>>> {
+    log_verbose!(self, "Downloading url: {}", url);
+
+    download_url(url, &self.progress_bars, |env_var_name| std::env::var(env_var_name).ok())
   }
 }
 
@@ -89,12 +98,6 @@ impl Environment for RealEnvironment {
       Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
       Err(err) => bail!("Error removing directory {}: {}", dir_path.as_ref().display(), err.to_string()),
     }
-  }
-
-  fn download_file(&self, url: &str) -> Result<Vec<u8>> {
-    log_verbose!(self, "Downloading url: {}", url);
-
-    download_url(url, &self.progress_bars, |env_var_name| std::env::var(env_var_name).ok())
   }
 
   fn dir_info(&self, dir_path: impl AsRef<Path>) -> Result<Vec<DirEntry>> {

--- a/crates/dprint/src/environment/test_environment_builder.rs
+++ b/crates/dprint/src/environment/test_environment_builder.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::Environment;
 use super::TestEnvironment;
+use super::UrlDownloader;
 use crate::test_helpers;
 
 pub struct TestConfigFileBuilder {
@@ -79,7 +80,10 @@ impl TestConfigFileBuilder {
 
   pub fn add_remote_process_plugin(&mut self) -> &mut Self {
     // get the process plugin file and check its checksum
-    let remote_file_text = self.environment.download_file("https://plugins.dprint.dev/test-process.exe-plugin").unwrap();
+    let remote_file_text = self
+      .environment
+      .download_file_err_404("https://plugins.dprint.dev/test-process.exe-plugin")
+      .unwrap();
     let checksum = dprint_cli_core::checksums::get_sha256_checksum(&remote_file_text);
     self.add_remote_process_plugin_with_checksum(&checksum)
   }

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -131,7 +131,7 @@ where
 }
 
 fn download_url<TEnvironment: Environment>(path_source: PathSource, environment: TEnvironment) -> Result<Vec<u8>> {
-  environment.download_file(path_source.unwrap_remote().url.as_str())
+  environment.download_file_err_404(path_source.unwrap_remote().url.as_str())
 }
 
 fn get_file_bytes<TEnvironment: Environment>(path_source: PathSource, environment: TEnvironment) -> Result<Vec<u8>> {

--- a/crates/dprint/src/utils/cached_downloader.rs
+++ b/crates/dprint/src/utils/cached_downloader.rs
@@ -1,0 +1,69 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::environment::UrlDownloader;
+
+type CachedDownloadResult = Result<Option<Vec<u8>>, String>;
+
+pub struct CachedDownloader<TInner: UrlDownloader> {
+  inner: TInner,
+  results: RefCell<HashMap<String, CachedDownloadResult>>,
+}
+
+impl<TInner: UrlDownloader> CachedDownloader<TInner> {
+  pub fn new(inner: TInner) -> Self {
+    Self {
+      inner,
+      results: Default::default(),
+    }
+  }
+}
+
+impl<TInner: UrlDownloader> UrlDownloader for CachedDownloader<TInner> {
+  fn download_file(&self, url: &str) -> Result<Option<Vec<u8>>> {
+    let mut results = self.results.borrow_mut();
+    if let Some(result) = results.get(url) {
+      match result {
+        Ok(result) => Ok(result.clone()),
+        Err(err) => Err(anyhow!("{}", err)),
+      }
+    } else {
+      let result = self.inner.download_file(url);
+      results.insert(
+        url.to_string(),
+        match &result {
+          Ok(result) => Ok(result.clone()),
+          Err(err) => Err(format!("{}", err)),
+        },
+      );
+      result
+    }
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::environment::TestEnvironmentBuilder;
+
+  #[test]
+  fn should_download_and_cache() {
+    let mut builder = TestEnvironmentBuilder::new();
+    let exists_url = "http://localhost/test.txt";
+    let not_exists_url = "http://localhost/non-existent.txt";
+    let environment = builder.add_remote_file(exists_url, "1").build();
+    let downloader = CachedDownloader::new(environment.clone());
+
+    // should cache when not exists
+    assert!(downloader.download_file(not_exists_url).as_ref().unwrap().is_none());
+    environment.add_remote_file_bytes(not_exists_url, Vec::new());
+    assert!(downloader.download_file(not_exists_url).as_ref().unwrap().is_none());
+
+    // should get data and have it cached
+    assert_eq!(downloader.download_file(exists_url).as_ref().unwrap().as_ref().unwrap(), "1".as_bytes());
+    environment.add_remote_file_bytes(exists_url, Vec::new());
+    assert_eq!(downloader.download_file(exists_url).as_ref().unwrap().as_ref().unwrap(), "1".as_bytes());
+  }
+}

--- a/crates/dprint/src/utils/mod.rs
+++ b/crates/dprint/src/utils/mod.rs
@@ -1,3 +1,4 @@
+mod cached_downloader;
 mod error_count_logger;
 mod extract_zip;
 mod file_path_utils;
@@ -13,6 +14,7 @@ mod stdin_reader;
 mod table_text;
 mod thread_exit_signal;
 
+pub use cached_downloader::*;
 pub use error_count_logger::*;
 pub use extract_zip::*;
 pub use file_path_utils::*;

--- a/crates/dprint/src/utils/resolve_url_or_file_path.rs
+++ b/crates/dprint/src/utils/resolve_url_or_file_path.rs
@@ -65,7 +65,7 @@ fn resolve_url<TEnvironment: Environment>(url: &Url, cache: &Cache<TEnvironment>
     cache_item
   } else {
     // download and save
-    let file_bytes = environment.download_file(url.as_str())?;
+    let file_bytes = environment.download_file_err_404(url.as_str())?;
     is_first_download = true;
     cache.create_cache_item(CreateCacheItemOptions {
       key: cache_key,
@@ -84,7 +84,7 @@ fn resolve_url<TEnvironment: Environment>(url: &Url, cache: &Cache<TEnvironment>
 
 pub fn fetch_file_or_url_bytes(url_or_file_path: &PathSource, environment: &impl Environment) -> Result<Vec<u8>> {
   match url_or_file_path {
-    PathSource::Remote(path_source) => environment.download_file(path_source.url.as_str()),
+    PathSource::Remote(path_source) => environment.download_file_err_404(path_source.url.as_str()),
     PathSource::Local(path_source) => environment.read_file_bytes(&path_source.path),
   }
 }
@@ -143,6 +143,7 @@ fn is_absolute_windows_file_path(value: &str) -> bool {
 mod tests {
   use crate::cache::Cache;
   use crate::environment::TestEnvironment;
+  use pretty_assertions::assert_eq;
 
   use super::super::PathSource;
   use super::*;
@@ -249,7 +250,7 @@ mod tests {
     let err = resolve_url_or_file_path("https://dprint.dev/test.json", &base, &cache, &environment)
       .err()
       .unwrap();
-    assert_eq!(err.to_string(), "Could not find file at url https://dprint.dev/test.json");
+    assert_eq!(err.to_string(), "Error downloading https://dprint.dev/test.json - 404 Not Found");
   }
 
   #[test]

--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -55,7 +55,7 @@ impl PluginHandler<Configuration> for TestWasmPlugin {
       file_names: vec![],
       help_url: "https://dprint.dev/plugins/test".to_string(),
       config_schema_url: "https://plugins.dprint.dev/test/schema.json".to_string(),
-      update_url: Some("https://plugins.dprint.dev/test/latest.json".to_string()),
+      update_url: Some("https://plugins.dprint.dev/dprint/test-plugin/latest.json".to_string()),
     }
   }
 


### PR DESCRIPTION
Adds support for a more distributed `dprint config add <arg>` command (though it still relies on the plugins.dprint.dev service... will be addressed in the future. I think that should be configurable probably).

This isn't explicitly tied to GitHub... it's just that the plugins.dprint.dev service happens to implement it that way (ex. https://plugins.dprint.dev/malobre/vue/latest.json)

Example:

```bash
dprint config add malobre/vue
```

Closes #455