### PR TITLE
fix: include CPU architecture in plugin cache path

### DIFF
--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -65,6 +65,7 @@ pub trait Environment: Clone + std::marker::Send + std::marker::Sync + UrlDownlo
     total_size: usize,
   ) -> TResult;
   fn get_cache_dir(&self) -> PathBuf;
+  fn cpu_arch(&self) -> String;
   fn get_time_secs(&self) -> u64;
   fn get_selection(&self, prompt_message: &str, item_indent_width: u16, items: &[String]) -> Result<usize>;
   fn get_multi_selection(&self, prompt_message: &str, item_indent_width: u16, items: &[(bool, String)]) -> Result<Vec<usize>>;

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -193,6 +193,10 @@ impl Environment for RealEnvironment {
     get_cache_dir().unwrap()
   }
 
+  fn cpu_arch(&self) -> String {
+    std::env::consts::ARCH.to_string()
+  }
+
   fn get_time_secs(&self) -> u64 {
     SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap().as_secs()
   }

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -97,6 +97,7 @@ pub struct TestEnvironment {
   std_out: MockStdInOut,
   #[cfg(windows)]
   path_dirs: Arc<Mutex<Vec<PathBuf>>>,
+  cpu_arch: Arc<Mutex<String>>,
 }
 
 impl TestEnvironment {
@@ -119,6 +120,7 @@ impl TestEnvironment {
       std_out: MockStdInOut::new(),
       #[cfg(windows)]
       path_dirs: Arc::new(Mutex::new(Vec::new())),
+      cpu_arch: Arc::new(Mutex::new("x86_64".to_string())),
     }
   }
 
@@ -205,6 +207,10 @@ impl TestEnvironment {
   pub fn set_dir_info_error(&self, err: Error) {
     let mut dir_info_error = self.dir_info_error.lock();
     *dir_info_error = Some(err);
+  }
+
+  pub fn set_cpu_arch(&self, value: &str) {
+    *self.cpu_arch.lock() = value.to_string();
   }
 
   fn clean_path(&self, path: impl AsRef<Path>) -> PathBuf {
@@ -401,6 +407,10 @@ impl Environment for TestEnvironment {
 
   fn get_cache_dir(&self) -> PathBuf {
     PathBuf::from("/cache")
+  }
+
+  fn cpu_arch(&self) -> String {
+    self.cpu_arch.lock().clone()
   }
 
   fn get_time_secs(&self) -> u64 {

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -154,11 +154,12 @@ mod test {
     let environment = TestEnvironment::new();
     environment.add_remote_file("https://plugins.dprint.dev/test.wasm", "t".as_bytes());
     environment.set_wasm_compile_result(create_compilation_result("t".as_bytes()));
+    environment.set_cpu_arch("aarch64");
 
     let plugin_cache = PluginCache::new(environment.clone());
     let plugin_source = PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test.wasm");
     let file_path = plugin_cache.get_plugin_cache_item(&plugin_source)?.file_path;
-    let expected_file_path = PathBuf::from("/cache").join("plugins").join("test-plugin").join("test-plugin-0.1.0.cached");
+    let expected_file_path = PathBuf::from("/cache").join("plugins").join("test-plugin").join("0.1.0-aarch64.cached");
 
     assert_eq!(file_path, expected_file_path);
     assert_eq!(environment.take_stderr_messages(), vec!["Compiling https://plugins.dprint.dev/test.wasm"]);
@@ -197,7 +198,7 @@ mod test {
     let plugin_cache = PluginCache::new(environment.clone());
     let plugin_source = PluginSourceReference::new_local(original_file_path.clone());
     let file_path = plugin_cache.get_plugin_cache_item(&plugin_source)?.file_path;
-    let expected_file_path = PathBuf::from("/cache").join("plugins").join("test-plugin").join("test-plugin-0.1.0.cached");
+    let expected_file_path = PathBuf::from("/cache").join("plugins").join("test-plugin").join("0.1.0-x86_64.cached");
 
     assert_eq!(file_path, expected_file_path);
 

--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -24,7 +24,7 @@ pub fn get_file_path_from_plugin_info(plugin_info: &PluginInfo, environment: &im
 
 fn get_plugin_dir_path(name: &str, version: &str, environment: &impl Environment) -> PathBuf {
   let cache_dir_path = environment.get_cache_dir();
-  cache_dir_path.join("plugins").join(&name).join(&version)
+  cache_dir_path.join("plugins").join(&name).join(&version).join(&environment.cpu_arch())
 }
 
 fn get_plugin_executable_file_path(dir_path: &Path, plugin_name: &str) -> PathBuf {

--- a/crates/dprint/src/plugins/implementations/wasm/setup_wasm_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/setup_wasm_plugin.rs
@@ -11,7 +11,7 @@ use super::super::SetupPluginResult;
 pub fn get_file_path_from_plugin_info(plugin_info: &PluginInfo, environment: &impl Environment) -> PathBuf {
   let cache_dir_path = environment.get_cache_dir();
   let plugin_cache_dir_path = cache_dir_path.join("plugins").join(&plugin_info.name);
-  plugin_cache_dir_path.join(format!("{}-{}.cached", plugin_info.name, plugin_info.version))
+  plugin_cache_dir_path.join(format!("{}-{}.cached", plugin_info.version, environment.cpu_arch()))
 }
 
 pub fn setup_wasm_plugin<TEnvironment: Environment>(url_or_file_path: &PathSource, file_bytes: &[u8], environment: &TEnvironment) -> Result<SetupPluginResult> {


### PR DESCRIPTION
Does this for both Wasm and process plugins.

```
./cache/plugins/<plugin-name>/<version>-<arch>.cached
./cache/plugins/<plugin-name>/<version>/<arch>/<process-plugin-output>
```

Closes #466