### PR TITLE
fix: do not output logging context name for machine readable output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-cli-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/crates/cli-core/Cargo.toml
+++ b/crates/cli-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-cli-core"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/crates/cli-core/src/logging/logger.rs
+++ b/crates/cli-core/src/logging/logger.rs
@@ -28,12 +28,19 @@ struct LoggerRefreshItem {
 }
 
 #[derive(Clone)]
+pub struct LoggerOptions {
+  pub initial_context_name: String,
+  /// Whether stdout will be read by a program.
+  pub is_stdout_machine_readable: bool,
+}
+
+#[derive(Clone)]
 pub struct Logger {
   output_lock: Arc<Mutex<LoggerState>>,
+  is_stdout_machine_readable: bool,
 }
 
 struct LoggerState {
-  is_silent: bool,
   last_context_name: String,
   std_out: Stdout,
   std_err: Stderr,
@@ -42,30 +49,31 @@ struct LoggerState {
 }
 
 impl Logger {
-  pub fn new(initial_context_name: &str, is_silent: bool) -> Self {
+  pub fn new(options: &LoggerOptions) -> Self {
     Logger {
       output_lock: Arc::new(Mutex::new(LoggerState {
-        is_silent,
-        last_context_name: initial_context_name.to_string(),
+        last_context_name: options.initial_context_name.clone(),
         std_out: stdout(),
         std_err: stderr(),
         refresh_items: Vec::new(),
         last_terminal_size: None,
       })),
+      is_stdout_machine_readable: options.is_stdout_machine_readable,
     }
   }
 
   pub fn log(&self, text: &str, context_name: &str) {
-    let mut state = self.output_lock.lock();
-    if state.is_silent {
+    if self.is_stdout_machine_readable {
       return;
     }
+    let mut state = self.output_lock.lock();
     self.inner_log(&mut state, true, text, context_name);
   }
 
-  pub fn log_bypass_silent(&self, text: &str, context_name: &str) {
+  pub fn log_machine_readable(&self, text: &str) {
     let mut state = self.output_lock.lock();
-    self.inner_log(&mut state, true, text, context_name);
+    let last_context_name = state.last_context_name.clone(); // not really used here
+    self.inner_log(&mut state, true, text, &last_context_name);
   }
 
   pub fn log_err(&self, text: &str, context_name: &str) {
@@ -85,7 +93,10 @@ impl Logger {
 
     let mut output_text = String::new();
     if state.last_context_name != context_name {
-      output_text.push_str(&format!("[{}]\n", context_name));
+      // don't output this if stdout is machine readable
+      if !is_std_out || !self.is_stdout_machine_readable {
+        output_text.push_str(&format!("[{}]\n", context_name));
+      }
       state.last_context_name = context_name.to_string();
     }
 

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.53"
 clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
-dprint-cli-core = { path = "../cli-core", version = "0.11.0" }
+dprint-cli-core = { path = "../cli-core", version = "0.12.0" }
 dprint-core = { path = "../core", version = "0.50.0", features = ["process", "wasm"] }
 dunce = "1.0.2"
 ignore = "0.4.18"

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -17,8 +17,12 @@ pub struct CliArgs {
 }
 
 impl CliArgs {
-  pub fn is_silent_output(&self) -> bool {
-    matches!(self.sub_command, SubCommand::StdInFmt(..))
+  pub fn is_stdout_machine_readable(&self) -> bool {
+    // these output json or other text that's read by stdout
+    matches!(
+      self.sub_command,
+      SubCommand::StdInFmt(..) | SubCommand::EditorInfo | SubCommand::OutputResolvedConfig
+    )
   }
 
   fn new_with_sub_command(sub_command: SubCommand) -> CliArgs {

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -307,12 +307,12 @@ pub fn output_resolved_config<TEnvironment: Environment>(
     plugin_jsons.push(format!("\"{}\": {}", config_key, pretty_text));
   }
 
-  if plugin_jsons.is_empty() {
-    environment.log("{}");
+  environment.log_machine_readable(&if plugin_jsons.is_empty() {
+    "{}".to_string()
   } else {
     let text = plugin_jsons.join(",\n").lines().map(|l| format!("  {}", l)).collect::<Vec<_>>().join("\n");
-    environment.log(&format!("{{\n{}\n}}", text));
-  }
+    format!("{{\n{}\n}}", text)
+  });
 
   Ok(())
 }

--- a/crates/dprint/src/commands/editor.rs
+++ b/crates/dprint/src/commands/editor.rs
@@ -67,7 +67,7 @@ pub fn output_editor_info<TEnvironment: Environment>(
     });
   }
 
-  environment.log_silent(&serde_json::to_string(&EditorInfo {
+  environment.log_machine_readable(&serde_json::to_string(&EditorInfo {
     schema_version: 4,
     cli_version: env!("CARGO_PKG_VERSION").to_string(),
     config_schema_url: "https://dprint.dev/schemas/v0.json".to_string(),

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -44,7 +44,7 @@ pub fn stdin_fmt<TEnvironment: Environment>(
     let resolved_file_path = environment.canonicalize(&cmd.file_name_or_path)?;
     // log the file text as-is since it's not in the list of files to format
     if !file_matcher.matches(&resolved_file_path) {
-      environment.log_silent(&cmd.file_text);
+      environment.log_machine_readable(&cmd.file_text);
       return Ok(());
     }
   }
@@ -58,7 +58,7 @@ fn output_stdin_format<TEnvironment: Environment>(
   plugin_pools: Arc<PluginPools<TEnvironment>>,
 ) -> Result<()> {
   let formatted_text = format_with_plugin_pools(file_name, file_text, environment, &plugin_pools)?;
-  environment.log_silent(&formatted_text);
+  environment.log_machine_readable(&formatted_text);
   Ok(())
 }
 
@@ -1488,7 +1488,10 @@ mod test {
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "file.txt"], &environment, test_std_in).unwrap();
     // should format even though it wasn't matched because an absolute path wasn't provided
     assert_eq!(environment.take_stdout_messages(), vec!["text_formatted"]);
-    assert_eq!(environment.take_stderr_messages().len(), 0);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Compiling https://plugins.dprint.dev/test-plugin.wasm"]
+    );
   }
 
   #[test]
@@ -1503,7 +1506,10 @@ mod test {
     run_test_cli_with_stdin(vec!["fmt", "--stdin", "txt"], &environment, test_std_in).unwrap();
     // should format even though it wasn't matched because an absolute path wasn't provided
     assert_eq!(environment.take_stdout_messages(), vec!["text_formatted"]);
-    assert_eq!(environment.take_stderr_messages().len(), 0);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Compiling https://plugins.dprint.dev/test-plugin.wasm"]
+    );
   }
 
   #[test]
@@ -1572,7 +1578,10 @@ mod test {
     // the absolute path must be provided instead of a relative one in order to properly pick up
     // inclusion/exclusion rules and the proper configuration file.
     assert_eq!(environment.take_stdout_messages(), vec!["text_formatted"]);
-    assert_eq!(environment.take_stderr_messages().len(), 0);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Compiling https://plugins.dprint.dev/test-plugin.wasm"]
+    );
   }
 
   #[test]

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -53,8 +53,8 @@ pub trait Environment: Clone + std::marker::Send + std::marker::Sync + UrlDownlo
   /// This will cause the logger to output the context name when appropriate.
   /// Ex. Will log the dprint process plugin name.
   fn log_stderr_with_context(&self, text: &str, context_name: &str);
-  /// Information to output when logging is silent.
-  fn log_silent(&self, text: &str);
+  /// Information to force output when the environment is in "machine readable mode".
+  fn log_machine_readable(&self, text: &str);
   fn log_action_with_progress<
     TResult: std::marker::Send + std::marker::Sync,
     TCreate: FnOnce(Box<dyn Fn(usize)>) -> TResult + std::marker::Send + std::marker::Sync,

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -6,6 +6,7 @@ use dprint_cli_core::logging::show_confirm;
 use dprint_cli_core::logging::show_multi_select;
 use dprint_cli_core::logging::show_select;
 use dprint_cli_core::logging::Logger;
+use dprint_cli_core::logging::LoggerOptions;
 use dprint_cli_core::logging::ProgressBars;
 use std::fs;
 use std::path::Path;
@@ -19,6 +20,11 @@ use super::Environment;
 use super::UrlDownloader;
 use crate::plugins::CompilationResult;
 
+pub struct RealEnvironmentOptions {
+  pub is_verbose: bool,
+  pub is_stdout_machine_readable: bool,
+}
+
 #[derive(Clone)]
 pub struct RealEnvironment {
   logger: Logger,
@@ -27,13 +33,16 @@ pub struct RealEnvironment {
 }
 
 impl RealEnvironment {
-  pub fn new(is_verbose: bool, is_silent: bool) -> Result<RealEnvironment> {
-    let logger = Logger::new("dprint", is_silent);
-    let progress_bars = if is_silent { None } else { ProgressBars::new(&logger) };
+  pub fn new(options: &RealEnvironmentOptions) -> Result<RealEnvironment> {
+    let logger = Logger::new(&LoggerOptions {
+      initial_context_name: "dprint".to_string(),
+      is_stdout_machine_readable: options.is_stdout_machine_readable,
+    });
+    let progress_bars = ProgressBars::new(&logger);
     let environment = RealEnvironment {
       logger,
       progress_bars,
-      is_verbose,
+      is_verbose: options.is_verbose,
     };
 
     // ensure the cache directory is created
@@ -168,8 +177,8 @@ impl Environment for RealEnvironment {
     self.logger.log(text, "dprint");
   }
 
-  fn log_silent(&self, text: &str) {
-    self.logger.log_bypass_silent(text, "dprint");
+  fn log_machine_readable(&self, text: &str) {
+    self.logger.log_machine_readable(text);
   }
 
   fn log_stderr_with_context(&self, text: &str, context_name: &str) {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -90,7 +90,7 @@ pub struct TestEnvironment {
   selection_result: Arc<Mutex<usize>>,
   multi_selection_result: Arc<Mutex<Option<Vec<usize>>>>,
   confirm_results: Arc<Mutex<Vec<Result<Option<bool>>>>>,
-  is_silent: Arc<Mutex<bool>>,
+  is_stdout_machine_readable: Arc<Mutex<bool>>,
   wasm_compile_result: Arc<Mutex<Option<CompilationResult>>>,
   dir_info_error: Arc<Mutex<Option<Error>>>,
   std_in: MockStdInOut,
@@ -113,7 +113,7 @@ impl TestEnvironment {
       selection_result: Arc::new(Mutex::new(0)),
       multi_selection_result: Arc::new(Mutex::new(None)),
       confirm_results: Arc::new(Mutex::new(Vec::new())),
-      is_silent: Arc::new(Mutex::new(false)),
+      is_stdout_machine_readable: Arc::new(Mutex::new(false)),
       wasm_compile_result: Arc::new(Mutex::new(None)),
       dir_info_error: Arc::new(Mutex::new(None)),
       std_in: MockStdInOut::new(),
@@ -176,9 +176,8 @@ impl TestEnvironment {
     *cwd = String::from(new_path);
   }
 
-  pub fn set_silent(&self, value: bool) {
-    let mut is_silent = self.is_silent.lock();
-    *is_silent = value;
+  pub fn set_stdout_machine_readable(&self, value: bool) {
+    *self.is_stdout_machine_readable.lock() = value;
   }
 
   pub fn set_verbose(&self, value: bool) {
@@ -375,20 +374,18 @@ impl Environment for TestEnvironment {
   }
 
   fn log(&self, text: &str) {
-    if *self.is_silent.lock() {
+    if *self.is_stdout_machine_readable.lock() {
       return;
     }
     self.stdout_messages.lock().push(String::from(text));
   }
 
   fn log_stderr_with_context(&self, text: &str, _: &str) {
-    if *self.is_silent.lock() {
-      return;
-    }
     self.stderr_messages.lock().push(String::from(text));
   }
 
-  fn log_silent(&self, text: &str) {
+  fn log_machine_readable(&self, text: &str) {
+    assert!(*self.is_stdout_machine_readable.lock());
     self.stdout_messages.lock().push(String::from(text));
   }
 

--- a/crates/dprint/src/main.rs
+++ b/crates/dprint/src/main.rs
@@ -6,6 +6,7 @@ mod environment;
 
 use anyhow::Result;
 use environment::RealEnvironment;
+use environment::RealEnvironmentOptions;
 use std::sync::Arc;
 use utils::RealStdInReader;
 
@@ -38,7 +39,10 @@ fn main() -> Result<()> {
 
 fn run() -> Result<()> {
   let args = arg_parser::parse_args(wild::args().collect(), RealStdInReader)?;
-  let environment = RealEnvironment::new(args.verbose, args.is_silent_output())?;
+  let environment = RealEnvironment::new(&RealEnvironmentOptions {
+    is_verbose: args.verbose,
+    is_stdout_machine_readable: args.is_stdout_machine_readable(),
+  })?;
   let cache = Arc::new(cache::Cache::new(environment.clone()));
   let plugin_cache = Arc::new(plugins::PluginCache::new(environment.clone()));
   let plugin_pools = Arc::new(plugins::PluginPools::new(environment.clone()));

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -62,7 +62,7 @@ pub fn run_test_cli_with_stdin(args: Vec<&str>, environment: &TestEnvironment, s
   let _plugins_dropper = PluginsDropper::new(plugin_pools.clone());
   let plugin_resolver = PluginResolver::new(environment.clone(), plugin_cache, plugin_pools.clone());
   let args = parse_args(args, stdin_reader)?;
-  environment.set_silent(args.is_silent_output());
+  environment.set_stdout_machine_readable(args.is_stdout_machine_readable());
   environment.set_verbose(args.verbose);
   run_cli(&args, environment, &cache, &plugin_resolver, plugin_pools)
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.58.1"
+components = ["clippy"]


### PR DESCRIPTION
Spotted this in the vscode output:

```
[ERROR] Error initializing in v:\dprint-plugin-yapf: Error: Error parsing editor info. Output was: [dprint]
{"schemaVersion":4,"cliVersion":"0.22.2","configSchemaUrl":"https://dprint.dev/schemas/v0.json","plugins":[{"name":"dprint-plugin-typescript","version":"0.62.1","configKey":"typescript","fileExtensions":["ts","tsx","js","jsx","mjs","cjs","mts","cts"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/schemas/typescript-0.62.1.json","helpUrl":"https://dprint.dev/plugins/typescript"},{"name":"dprint-plugin-jsonc","version":"0.7.2","configKey":"json","fileExtensions":["json"],"fileNames":[],"helpUrl":"https://dprint.dev/plugins/json"},{"name":"dprint-plugin-markdown","version":"0.12.1","configKey":"markdown","fileExtensions":["md","mkd","mdwn","mkdn","mdown","markdown"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/schemas/markdown-0.12.1.json","helpUrl":"https://dprint.dev/plugins/markdown"},{"name":"dprint-plugin-yapf","version":"0.2.1","configKey":"yapf","fileExtensions":["py"],"fileNames":[],"helpUrl":"https://dprint.dev/plugins/yapf"}]}

Error: SyntaxError: Unexpected token d in JSON at position 1
```

The reason was because it initialized the yapf plugin, which outputted and switched the logging context to "dprint-plugin-yapf", but then when outputting the json for the editor, it outputted "dprint" because the context switched back and that broke the json output.

This PR changes the concept about "silent" output to instead by whether stdout will be "machine readable".