### PR TITLE
feat: exclude patterns are taken into consideration for all "include" CLI args

### DIFF
--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -2,9 +2,9 @@ use std::cell::UnsafeCell;
 use std::mem;
 use std::rc::Rc;
 
-use crate::formatting::id::IdCounter;
 use super::printer::Printer;
 use super::utils::with_bump_allocator;
+use crate::formatting::id::IdCounter;
 
 /** Print Items */
 

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -945,17 +945,17 @@ mod test {
   #[cfg(target_os = "linux")]
   #[test]
   fn should_format_absolute_paths_on_linux() {
-    let file_path = "/asdf/file1.txt";
+    let file_path = "/test/other/file1.txt"; // needs to be in the base directory
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
       .with_local_config("/test/other/dprint.json", |c| {
-        c.add_includes("**/*.txt").add_remote_wasm_plugin();
+        c.add_includes("asdf/**/*.txt").add_remote_wasm_plugin();
       })
       .write_file(&file_path, "text1")
       .set_cwd("/test/other/")
       .initialize()
       .build();
 
-    run_test_cli(vec!["fmt", "--", "/asdf/file1.txt"], &environment).unwrap();
+    run_test_cli(vec!["fmt", "--", "/test/other/file1.txt"], &environment).unwrap();
 
     assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
     assert_eq!(environment.take_stderr_messages().len(), 0);

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -70,7 +70,7 @@ fn get_include_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &Cano
     )
   } else {
     // resolve CLI patterns based on the current working directory
-    GlobPattern::new_vec(process_cli_patterns(process_file_patterns_slashes(&args.file_patterns)), cwd.clone())
+    GlobPattern::new_vec(process_cli_arg_patterns(process_file_patterns_slashes(&args.file_patterns), cwd), cwd.clone())
   });
 
   file_patterns
@@ -87,7 +87,10 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &Cano
       )
     } else {
       // resolve CLI patterns based on the current working directory
-      GlobPattern::new_vec(process_cli_patterns(process_file_patterns_slashes(&args.exclude_file_patterns)), cwd.clone())
+      GlobPattern::new_vec(
+        process_cli_arg_patterns(process_file_patterns_slashes(&args.exclude_file_patterns), cwd),
+        cwd.clone(),
+      )
     }
     .into_iter()
     .map(|pattern| pattern.into_negated()),
@@ -110,32 +113,38 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &CliArgs, cwd: &Cano
 }
 
 fn process_file_patterns_slashes(file_patterns: &[String]) -> Vec<String> {
-  file_patterns
-    .iter()
-    .map(|p| {
-      let mut p = p.to_string();
-      process_file_pattern_slashes(&mut p);
-      p
-    })
-    .collect()
+  file_patterns.iter().map(|p| p.as_str()).map(process_file_pattern_slashes).collect()
 }
 
-fn process_file_pattern_slashes(file_pattern: &mut String) {
+fn process_file_pattern_slashes(file_pattern: &str) -> String {
   // Convert all backslashes to forward slashes.
   // It is true that this means someone cannot specify patterns that
   // match files with backslashes in their name on Linux, however,
   // it is more desirable for this CLI to work the same way no matter
   // what operation system the user is on and for the CLI to match
   // backslashes as a path separator.
-  *file_pattern = file_pattern.replace("\\", "/");
+  file_pattern.replace("\\", "/")
 }
 
-fn process_cli_patterns(file_patterns: Vec<String>) -> Vec<String> {
-  file_patterns.into_iter().map(process_cli_pattern).collect()
+fn process_cli_arg_patterns(file_patterns: Vec<String>, cwd: &CanonicalizedPathBuf) -> Vec<String> {
+  file_patterns.into_iter().map(|p| process_cli_pattern(p, cwd)).collect()
 }
 
-fn process_cli_pattern(file_pattern: String) -> String {
-  if is_absolute_pattern(&file_pattern) || file_pattern.starts_with("./") || file_pattern.starts_with("!./") {
+fn process_cli_pattern(file_pattern: String, cwd: &CanonicalizedPathBuf) -> String {
+  if is_absolute_pattern(&file_pattern) {
+    let is_negated = is_negated_glob(&file_pattern);
+    let cwd = process_file_pattern_slashes(&cwd.to_string_lossy());
+    let file_pattern = if is_negated { &file_pattern[1..] } else { &file_pattern };
+    format!(
+      "{}./{}",
+      if is_negated { "!" } else { "" },
+      if file_pattern.starts_with(&cwd) {
+        file_pattern[cwd.len()..].trim_start_matches('/')
+      } else {
+        file_pattern
+      },
+    )
+  } else if file_pattern.starts_with("./") || file_pattern.starts_with("!./") {
     file_pattern
   } else {
     // make all cli specified patterns relative
@@ -168,17 +177,24 @@ mod test {
 
   #[test]
   fn should_process_cli_pattern() {
-    assert_eq!(process_cli_pattern("/test".to_string()), "/test");
-    assert_eq!(process_cli_pattern("C:/test".to_string()), "C:/test");
-    assert_eq!(process_cli_pattern("./test".to_string()), "./test");
-    assert_eq!(process_cli_pattern("test".to_string()), "./test");
-    assert_eq!(process_cli_pattern("**/test".to_string()), "./**/test");
+    assert_eq!(do_process_cli_pattern("/test", "/"), "./test");
+    assert_eq!(do_process_cli_pattern("C:/test", "C:\\"), "./test");
+    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test\\"), "./other");
+    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test"), "./other");
+    assert_eq!(do_process_cli_pattern("./test", "/"), "./test");
+    assert_eq!(do_process_cli_pattern("test", "/"), "./test");
+    assert_eq!(do_process_cli_pattern("**/test", "/"), "./**/test");
 
-    assert_eq!(process_cli_pattern("!/test".to_string()), "!/test");
-    assert_eq!(process_cli_pattern("!C:/test".to_string()), "!C:/test");
-    assert_eq!(process_cli_pattern("!./test".to_string()), "!./test");
-    assert_eq!(process_cli_pattern("!test".to_string()), "!./test");
-    assert_eq!(process_cli_pattern("!**/test".to_string()), "!./**/test");
+    assert_eq!(do_process_cli_pattern("!/test", "/"), "!./test");
+    assert_eq!(do_process_cli_pattern("!C:/test", "C:\\"), "!./test");
+    assert_eq!(do_process_cli_pattern("!C:/test/other", "C:\\test\\"), "!./other");
+    assert_eq!(do_process_cli_pattern("!./test", "/"), "!./test");
+    assert_eq!(do_process_cli_pattern("!test", "/"), "!./test");
+    assert_eq!(do_process_cli_pattern("!**/test", "/"), "!./**/test");
+  }
+
+  fn do_process_cli_pattern(file_pattern: &str, cwd: &str) -> String {
+    process_cli_pattern(file_pattern.to_string(), &CanonicalizedPathBuf::new_for_testing(cwd))
   }
 
   #[test]

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -176,21 +176,27 @@ mod test {
   use super::*;
 
   #[test]
-  fn should_process_cli_pattern() {
+  fn should_process_cli_patterns() {
     assert_eq!(do_process_cli_pattern("/test", "/"), "./test");
-    assert_eq!(do_process_cli_pattern("C:/test", "C:\\"), "./test");
-    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test\\"), "./other");
-    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test"), "./other");
     assert_eq!(do_process_cli_pattern("./test", "/"), "./test");
     assert_eq!(do_process_cli_pattern("test", "/"), "./test");
     assert_eq!(do_process_cli_pattern("**/test", "/"), "./**/test");
 
     assert_eq!(do_process_cli_pattern("!/test", "/"), "!./test");
-    assert_eq!(do_process_cli_pattern("!C:/test", "C:\\"), "!./test");
-    assert_eq!(do_process_cli_pattern("!C:/test/other", "C:\\test\\"), "!./other");
     assert_eq!(do_process_cli_pattern("!./test", "/"), "!./test");
     assert_eq!(do_process_cli_pattern("!test", "/"), "!./test");
     assert_eq!(do_process_cli_pattern("!**/test", "/"), "!./**/test");
+  }
+
+  #[cfg(windows)]
+  #[test]
+  fn should_process_cli_patterns_windows() {
+    assert_eq!(do_process_cli_pattern("C:/test", "C:\\"), "./test");
+    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test\\"), "./other");
+    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test"), "./other");
+
+    assert_eq!(do_process_cli_pattern("!C:/test", "C:\\"), "!./test");
+    assert_eq!(do_process_cli_pattern("!C:/test/other", "C:\\test\\"), "!./other");
   }
 
   fn do_process_cli_pattern(file_pattern: &str, cwd: &str) -> String {

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -1,84 +1,9 @@
-use std::borrow::Cow;
-
-pub fn to_absolute_glob(pattern: &str, dir: &str) -> String {
-  // Adapted from https://github.com/dsherret/ts-morph/blob/0f8a77a9fa9d74e32f88f36992d527a2f059c6ac/packages/common/src/fileSystem/FileUtils.ts#L272
-
-  // convert backslashes to forward slashes (don't worry about matching file names with back slashes)
-  let mut pattern = pattern.replace("\\", "/");
-  let dir = dir.replace("\\", "/");
-
-  // check to see if glob is negated
-  let is_negated = is_negated_glob(&pattern);
-  if is_negated {
-    pattern.drain(..1); // remove the leading "!"
-  }
-
-  // .gitignore: "If there is a separator at the beginning or middle (or both) of
-  // the pattern, then the pattern is relative to the directory level of the particular
-  // .gitignore file itself. Otherwise the pattern may also match at any level below the
-  // .gitignore level."
-  let is_relative = match pattern.find('/') {
-    Some(index) => index != pattern.len() - 1, // not the end of the pattern
-    None => false,
-  };
-
-  // trim starting ./ from glob patterns
-  if pattern.starts_with("./") {
-    pattern.drain(..2);
-  }
-
-  // when the glob pattern is only a . use an empty string
-  if pattern == "." {
-    pattern = String::new();
-  }
-
-  // store last character before glob is modified
-  let suffix = pattern.chars().last();
-
-  // make glob absolute
-  if !is_absolute_pattern(&pattern) {
-    if is_relative || pattern.starts_with("**/") || pattern.trim().is_empty() {
-      pattern = glob_join(dir, pattern);
-    } else {
-      pattern = glob_join(dir, format!("**/{}", pattern));
-    }
-  }
-
-  // if glob had a trailing `/`, re-add it back
-  if suffix == Some('/') && !pattern.ends_with('/') {
-    pattern.push('/');
-  }
-
-  if is_negated {
-    format!("!{}", pattern)
-  } else {
-    pattern
-  }
-}
-
 pub fn is_negated_glob(pattern: &str) -> bool {
   let mut chars = pattern.chars();
   let first_char = chars.next();
   let second_char = chars.next();
 
   first_char == Some('!') && second_char != Some('(')
-}
-
-fn glob_join(dir: String, pattern: String) -> String {
-  // strip trailing slash
-  let dir = if dir.ends_with('/') {
-    Cow::Borrowed(&dir[..dir.len() - 1])
-  } else {
-    Cow::Owned(dir)
-  };
-  // strip leading slash
-  let pattern = if let Some(pattern) = pattern.strip_prefix('/') { pattern } else { &pattern };
-
-  if pattern.is_empty() {
-    dir.into_owned()
-  } else {
-    format!("{}/{}", dir, pattern)
-  }
 }
 
 pub fn is_absolute_pattern(pattern: &str) -> bool {
@@ -124,40 +49,5 @@ mod tests {
     assert_eq!(is_absolute_pattern("!/test.ts"), true);
     assert_eq!(is_absolute_pattern("D:/test.ts"), true);
     assert_eq!(is_absolute_pattern("!D:/test.ts"), true);
-  }
-
-  #[test]
-  fn should_get_absolute_globs() {
-    assert_eq!(to_absolute_glob("**/*.ts", "/"), "/**/*.ts");
-    assert_eq!(to_absolute_glob("/**/*.ts", "/"), "/**/*.ts");
-    assert_eq!(to_absolute_glob("**/*.ts", "/test"), "/test/**/*.ts");
-    assert_eq!(to_absolute_glob("**/*.ts", "/test/"), "/test/**/*.ts");
-    assert_eq!(to_absolute_glob("/**/*.ts", "/test"), "/**/*.ts");
-    assert_eq!(to_absolute_glob("/**/*.ts", "/test/"), "/**/*.ts");
-    assert_eq!(to_absolute_glob("D:/**/*.ts", "/test/"), "D:/**/*.ts");
-    assert_eq!(to_absolute_glob("**/*.ts", "D:/"), "D:/**/*.ts");
-    assert_eq!(to_absolute_glob(".", "D:\\test"), "D:/test");
-    assert_eq!(to_absolute_glob("\\test\\asdf.ts", "D:\\test"), "/test/asdf.ts");
-    assert_eq!(to_absolute_glob("!**/*.ts", "D:\\test"), "!D:/test/**/*.ts");
-    assert_eq!(to_absolute_glob("///test/**/*.ts", "D:\\test"), "///test/**/*.ts");
-    assert_eq!(to_absolute_glob("**/*.ts", "CD:\\"), "CD:/**/*.ts");
-
-    assert_eq!(to_absolute_glob("./test.ts", "/test/"), "/test/test.ts");
-    assert_eq!(to_absolute_glob("test.ts", "/test/"), "/test/**/test.ts");
-    assert_eq!(to_absolute_glob("*/test.ts", "/test/"), "/test/*/test.ts");
-    assert_eq!(to_absolute_glob("*test.ts", "/test/"), "/test/**/*test.ts");
-    assert_eq!(to_absolute_glob("**/test.ts", "/test/"), "/test/**/test.ts");
-    assert_eq!(to_absolute_glob("/test.ts", "/test/"), "/test.ts");
-    assert_eq!(to_absolute_glob("test/", "/test/"), "/test/**/test/");
-
-    assert_eq!(to_absolute_glob("!./test.ts", "/test/"), "!/test/test.ts");
-    assert_eq!(to_absolute_glob("!test.ts", "/test/"), "!/test/**/test.ts");
-    assert_eq!(to_absolute_glob("!*/test.ts", "/test/"), "!/test/*/test.ts");
-    assert_eq!(to_absolute_glob("!*test.ts", "/test/"), "!/test/**/*test.ts");
-    assert_eq!(to_absolute_glob("!**/test.ts", "/test/"), "!/test/**/test.ts");
-    assert_eq!(to_absolute_glob("!/test.ts", "/test/"), "!/test.ts");
-    assert_eq!(to_absolute_glob("!test/", "/test/"), "!/test/**/test/");
-    // has a slash in the middle, so it's relative
-    assert_eq!(to_absolute_glob("test/test.ts", "/test/"), "/test/test/test.ts");
   }
 }


### PR DESCRIPTION
Previously, dprint would always format the provided file paths. This led to problems with tools like lint-staged where the excludes patterns weren't taken into account. See #473.

With this change, dprint treats all provided include and exclude CLI args as patterns instead of sometimes treating them as file paths (which had a lot of complexity and wasn't exactly right). The args simply override what is present in the config file (as occurred before, but non-glob file paths weren't ever excluded if they matched an excludes pattern).

Closes #473

FYI @joscha @declanvong (not sure this affects the setup you have… probably doesn’t?)