### PR TITLE
feat(core): maintain order of configuration keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "dprint-core",
  "dunce",
  "ignore",
+ "indexmap",
  "jsonc-parser",
  "lazy_static",
  "num_cpus",
@@ -506,10 +507,11 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.50.1"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "bumpalo",
+ "indexmap",
  "libc",
  "rustc-hash",
  "serde",
@@ -658,12 +660,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -717,12 +713,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
  "serde",
 ]
 
@@ -1245,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86c74fc6ea0317f1ba207eef55f5401b3180237625211866703183977b57dd45"
 dependencies = [
  "bytecheck",
- "hashbrown 0.11.2",
+ "hashbrown",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -1365,6 +1361,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.50.1"
+version = "0.51.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"
@@ -20,9 +20,10 @@ tracing = ["formatting"]
 [dependencies]
 anyhow = "1.0.53"
 bumpalo = { version = "3.9.1", optional = true }
+indexmap = { version = "1.8.0", features = ["serde-1"] }
 rustc-hash = { version = "1.1.0", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true, features = ["preserve_order"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "synchapi", "winbase", "winerror"], optional = true }

--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -2,9 +2,9 @@ use std::cell::UnsafeCell;
 use std::mem;
 use std::rc::Rc;
 
-use crate::formatting::id::IdCounter;
 use super::printer::Printer;
 use super::utils::with_bump_allocator;
+use crate::formatting::id::IdCounter;
 
 /** Print Items */
 

--- a/crates/core/src/plugins/process/message_processor.rs
+++ b/crates/core/src/plugins/process/message_processor.rs
@@ -3,7 +3,6 @@ use anyhow::bail;
 use anyhow::Result;
 use serde::Serialize;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::io::Read;
 use std::io::Write;
 use std::path::Path;
@@ -130,7 +129,7 @@ fn ensure_resolved_config<TConfiguration: Clone + Serialize, THandler: PluginHan
   state: &mut MessageProcessorState<TConfiguration>,
 ) -> Result<()> {
   if state.resolved_config_result.is_none() {
-    state.resolved_config_result = Some(create_resolved_config_result(handler, state, HashMap::new())?);
+    state.resolved_config_result = Some(create_resolved_config_result(handler, state, Default::default())?);
   }
 
   Ok(())

--- a/crates/core/src/plugins/wasm/mod.rs
+++ b/crates/core/src/plugins/wasm/mod.rs
@@ -214,7 +214,7 @@ pub mod macros {
       fn ensure_initialized() {
         unsafe {
           if RESOLVE_CONFIGURATION_RESULT.get().is_none() {
-            let config_result = create_resolved_config_result(std::collections::HashMap::new());
+            let config_result = create_resolved_config_result(dprint_core::configuration::ConfigKeyMap::new());
             RESOLVE_CONFIGURATION_RESULT.get().replace(config_result);
           }
         }

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -15,15 +15,16 @@ clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
 dprint-cli-core = { path = "../cli-core", version = "0.12.0" }
-dprint-core = { path = "../core", version = "0.50.1", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "0.51.0", features = ["process", "wasm"] }
 dunce = "1.0.2"
 ignore = "0.4.18"
+indexmap = { version = "1.8.0", features = ["serde-1"] }
 jsonc-parser = { version = "0.19.0" }
 num_cpus = "1.13.0"
 parking_lot = "0.11.2"
 rayon = "1.5.1"
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 similar = { version = "2.1.0", features = ["inline"] }
 twox-hash = "1.6.2"
 url = "2.2.2"

--- a/crates/dprint/src/configuration/get_global_config.rs
+++ b/crates/dprint/src/configuration/get_global_config.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 use dprint_core::configuration::ConfigKeyMap;
 use dprint_core::configuration::GlobalConfiguration;
 use dprint_core::configuration::ResolveGlobalConfigOptions;
-use std::collections::HashMap;
 
 use super::ConfigMap;
 use super::ConfigMapValue;
@@ -47,7 +46,7 @@ fn get_global_config_inner(config_map: ConfigMap, environment: &impl Environment
 
   fn get_global_config_from_config_map(config_map: ConfigMap, options: &GetGlobalConfigOptions) -> Result<ConfigKeyMap> {
     // at this point, there should only be key values inside the hash map
-    let mut global_config = HashMap::new();
+    let mut global_config = ConfigKeyMap::new();
 
     for (key, value) in config_map.into_iter() {
       if key == "$schema" {
@@ -70,11 +69,10 @@ mod tests {
   use super::*;
   use crate::configuration::ConfigMap;
   use crate::environment::TestEnvironment;
-  use std::collections::HashMap;
 
   #[test]
   fn should_get_global_config() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("lineWidth"), ConfigMapValue::from_i32(80));
     assert_gets(
       config_map,
@@ -89,7 +87,7 @@ mod tests {
 
   #[test]
   fn should_error_on_unexpected_object_properties_when_check_unknown_property_diagnostics_true() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("test"), ConfigMapValue::PluginConfig(Default::default()));
     assert_errors_with_options(
       config_map,
@@ -103,7 +101,7 @@ mod tests {
 
   #[test]
   fn should_not_error_on_unexpected_object_properties_when_check_unknown_property_diagnostics_false() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("test"), ConfigMapValue::PluginConfig(Default::default()));
     assert_gets_with_options(
       config_map,
@@ -121,7 +119,7 @@ mod tests {
 
   #[test]
   fn should_log_config_file_diagnostics() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("lineWidth"), ConfigMapValue::from_str("test"));
     config_map.insert(String::from("unknownProperty"), ConfigMapValue::from_i32(80));
     assert_errors(
@@ -136,7 +134,7 @@ mod tests {
 
   #[test]
   fn should_ignore_schema_property() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("$schema"), ConfigMapValue::from_str("test"));
     assert_gets(
       config_map,

--- a/crates/dprint/src/configuration/get_plugin_config_map.rs
+++ b/crates/dprint/src/configuration/get_plugin_config_map.rs
@@ -30,8 +30,8 @@ fn get_plugin_config_map_inner(plugin: &dyn Plugin, config_map: &mut ConfigMap) 
 #[cfg(test)]
 mod tests {
   use crate::plugins::TestPlugin;
+  use dprint_core::configuration::ConfigKeyMap;
   use dprint_core::configuration::ConfigKeyValue;
-  use std::collections::HashMap;
 
   use super::super::ConfigMap;
   use super::super::ConfigMapValue;
@@ -39,11 +39,11 @@ mod tests {
 
   #[test]
   fn should_get_config_for_plugin() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     let ts_plugin = RawPluginConfig {
       associations: None,
       locked: false,
-      properties: HashMap::from([("lineWidth".to_string(), ConfigKeyValue::from_i32(40))]),
+      properties: ConfigKeyMap::from([("lineWidth".to_string(), ConfigKeyValue::from_i32(40))]),
     };
     config_map.insert(String::from("lineWidth"), ConfigMapValue::from_i32(80));
     config_map.insert(String::from("typescript"), ConfigMapValue::PluginConfig(ts_plugin.clone()));
@@ -55,7 +55,7 @@ mod tests {
 
   #[test]
   fn should_error_plugin_key_is_not_object() {
-    let mut config_map = HashMap::new();
+    let mut config_map = ConfigMap::new();
     config_map.insert(String::from("lineWidth"), ConfigMapValue::from_i32(80));
     config_map.insert(String::from("typescript"), ConfigMapValue::from_str(""));
     assert_errors(&mut config_map, "Expected the configuration property 'typescript' to be an object.");

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -2,7 +2,6 @@ use anyhow::bail;
 use anyhow::Result;
 use crossterm::style::Stylize;
 use dprint_core::configuration::ConfigKeyValue;
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::arg_parser::CliArgs;
@@ -43,7 +42,7 @@ pub fn resolve_config_from_args<TEnvironment: Environment>(args: &CliArgs, cache
     Err(err) => {
       // allow no config file when plugins are specified
       if !args.plugins.is_empty() && !environment.path_exists(config_file_path) {
-        HashMap::new()
+        ConfigMap::new()
       } else {
         bail!(
           "No config file found at {}. Did you mean to create (dprint init) or specify one (--config <path>)?\n  Error: {}",
@@ -311,6 +310,7 @@ mod tests {
   use crate::environment::TestEnvironment;
   use crate::utils::TestStdInReader;
   use anyhow::Result;
+  use dprint_core::configuration::ConfigKeyMap;
   use pretty_assertions::assert_eq;
 
   use super::*;
@@ -502,7 +502,7 @@ mod tests {
       ]
     );
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("lineWidth"), ConfigMapValue::from_i32(1)),
       (String::from("otherProp"), ConfigMapValue::from_i32(6)),
       (String::from("otherProp2"), ConfigMapValue::from_str("a")),
@@ -511,7 +511,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([
+          properties: ConfigKeyMap::from([
             (String::from("prop"), ConfigKeyValue::from_i32(5)),
             (String::from("other"), ConfigKeyValue::from_str("test")),
           ]),
@@ -522,7 +522,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
+          properties: ConfigKeyMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
         }),
       ),
     ]);
@@ -591,7 +591,7 @@ mod tests {
       ]
     );
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("lineWidth"), ConfigMapValue::from_i32(1)),
       (String::from("otherProp"), ConfigMapValue::from_i32(6)),
       (String::from("asdf"), ConfigMapValue::from_i32(4)),
@@ -600,7 +600,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([
+          properties: ConfigKeyMap::from([
             (String::from("prop"), ConfigKeyValue::from_i32(5)),
             (String::from("other"), ConfigKeyValue::from_str("test")),
           ]),
@@ -611,7 +611,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
+          properties: ConfigKeyMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
         }),
       ),
     ]);
@@ -689,7 +689,7 @@ mod tests {
       ]
     );
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("lineWidth"), ConfigMapValue::from_i32(1)),
       (String::from("otherProp"), ConfigMapValue::from_i32(6)),
       (String::from("asdf"), ConfigMapValue::from_i32(4)),
@@ -699,7 +699,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([
+          properties: ConfigKeyMap::from([
             (String::from("prop"), ConfigKeyValue::from_i32(5)),
             (String::from("other"), ConfigKeyValue::from_str("test")),
           ]),
@@ -710,7 +710,7 @@ mod tests {
         ConfigMapValue::PluginConfig(RawPluginConfig {
           locked: false,
           associations: None,
-          properties: HashMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
+          properties: ConfigKeyMap::from([(String::from("prop"), ConfigKeyValue::from_i32(2))]),
         }),
       ),
     ]);
@@ -774,7 +774,7 @@ mod tests {
     let result = get_result("https://dprint.dev/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("prop1"), ConfigMapValue::from_i32(1)),
       (String::from("prop2"), ConfigMapValue::from_i32(2)),
       (String::from("prop3"), ConfigMapValue::from_i32(3)),
@@ -816,7 +816,7 @@ mod tests {
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("prop1"), ConfigMapValue::from_i32(1)),
       (String::from("prop2"), ConfigMapValue::from_i32(2)),
       (String::from("prop3"), ConfigMapValue::from_i32(3)),
@@ -857,7 +857,7 @@ mod tests {
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
 
-    let expected_config_map = HashMap::from([
+    let expected_config_map = ConfigMap::from([
       (String::from("prop1"), ConfigMapValue::from_i32(1)),
       (String::from("prop2"), ConfigMapValue::from_i32(2)),
       (String::from("prop3"), ConfigMapValue::from_i32(3)),
@@ -956,12 +956,12 @@ mod tests {
 
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
-    let expected_config_map = HashMap::from([(
+    let expected_config_map = ConfigMap::from([(
       String::from("test"),
       ConfigMapValue::PluginConfig(RawPluginConfig {
         locked: true,
         associations: None,
-        properties: HashMap::from([
+        properties: ConfigKeyMap::from([
           (String::from("prop"), ConfigKeyValue::from_i32(6)),
           (String::from("other"), ConfigKeyValue::from_str("test")),
         ]),
@@ -999,12 +999,12 @@ mod tests {
 
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
-    let expected_config_map = HashMap::from([(
+    let expected_config_map = ConfigMap::from([(
       String::from("test"),
       ConfigMapValue::PluginConfig(RawPluginConfig {
         locked: true,
         associations: None,
-        properties: HashMap::from([
+        properties: ConfigKeyMap::from([
           (String::from("prop"), ConfigKeyValue::from_i32(7)),
           (String::from("other"), ConfigKeyValue::from_str("test")),
         ]),
@@ -1040,12 +1040,12 @@ mod tests {
 
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
-    let expected_config_map = HashMap::from([(
+    let expected_config_map = ConfigMap::from([(
       String::from("test"),
       ConfigMapValue::PluginConfig(RawPluginConfig {
         locked: false,
         associations: None,
-        properties: HashMap::from([
+        properties: ConfigKeyMap::from([
           (String::from("prop"), ConfigKeyValue::from_i32(6)),
           (String::from("other"), ConfigKeyValue::from_str("test")),
         ]),
@@ -1079,12 +1079,12 @@ mod tests {
 
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
-    let expected_config_map = HashMap::from([(
+    let expected_config_map = ConfigMap::from([(
       String::from("test"),
       ConfigMapValue::PluginConfig(RawPluginConfig {
         locked: false,
         associations: Some(vec!["test".to_string()]),
-        properties: HashMap::new(),
+        properties: ConfigKeyMap::new(),
       }),
     )]);
 
@@ -1117,12 +1117,12 @@ mod tests {
 
     let result = get_result("/test.json", &environment).unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
-    let expected_config_map = HashMap::from([(
+    let expected_config_map = ConfigMap::from([(
       String::from("test"),
       ConfigMapValue::PluginConfig(RawPluginConfig {
         locked: false,
         associations: Some(vec!["test1".to_string(), "test2".to_string()]),
-        properties: HashMap::new(),
+        properties: ConfigKeyMap::new(),
       }),
     )]);
 

--- a/crates/dprint/src/configuration/types.rs
+++ b/crates/dprint/src/configuration/types.rs
@@ -1,6 +1,6 @@
 use dprint_core::configuration::ConfigKeyMap;
 use dprint_core::configuration::ConfigKeyValue;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 /// Unresolved plugin configuration.
 #[derive(Clone, PartialEq, Debug, Default)]
@@ -32,4 +32,4 @@ impl ConfigMapValue {
   }
 }
 
-pub type ConfigMap = HashMap<String, ConfigMapValue>;
+pub type ConfigMap = IndexMap<String, ConfigMapValue>;

--- a/crates/dprint/src/format.rs
+++ b/crates/dprint/src/format.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use anyhow::Result;
+use dprint_core::configuration::ConfigKeyMap;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
@@ -30,7 +31,7 @@ pub fn format_with_plugin_pools<'a, TEnvironment: Environment>(
     let error_logger = ErrorCountLogger::from_environment(environment);
     match plugin_pool.take_or_create_checking_config_diagnostics(&error_logger)? {
       TakePluginResult::Success(mut initialized_plugin) => {
-        let result = initialized_plugin.format_text(file_name, &file_text, &HashMap::new());
+        let result = initialized_plugin.format_text(file_name, &file_text, &ConfigKeyMap::new());
         plugin_pool.release(initialized_plugin);
         file_text = Cow::Owned(result?); // release plugin above, then propagate this error
       }
@@ -100,7 +101,7 @@ where
         let start_instant = Instant::now();
         let format_text_result = plugin
           .pool
-          .format_measuring_time(|| plugin.plugin.format_text(file_path, &file_text, &HashMap::new()));
+          .format_measuring_time(|| plugin.plugin.format_text(file_path, &file_text, &ConfigKeyMap::new()));
         log_verbose!(
           environment,
           "Formatted file: {} in {}ms{}",

--- a/crates/dprint/src/plugins/implementations/wasm/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/plugin.rs
@@ -1,7 +1,6 @@
 use anyhow::bail;
 use anyhow::Error;
 use anyhow::Result;
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -132,7 +131,7 @@ impl InitializedWasmPlugin {
         indent_width: None,
         new_line_kind: None,
       },
-      plugin_config: HashMap::new(),
+      plugin_config: ConfigKeyMap::new(),
     })
   }
 

--- a/crates/test-plugin/Cargo.toml
+++ b/crates/test-plugin/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["lib", "cdylib"]
 anyhow = "1.0.51"
 dprint-core = { path = "../core", features = ["wasm"] }
 serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -10,7 +10,6 @@ use dprint_core::plugins::PluginHandler;
 use dprint_core::plugins::PluginInfo;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -73,9 +72,9 @@ impl PluginHandler<Configuration> for TestWasmPlugin {
     if self.has_panicked {
       panic!("Previously panicked. Plugin should not have been used by the CLI again.")
     } else if file_text.starts_with("plugin: ") {
-      format_with_host(&PathBuf::from("./test.txt_ps"), file_text.replace("plugin: ", ""), &HashMap::new())
+      format_with_host(&PathBuf::from("./test.txt_ps"), file_text.replace("plugin: ", ""), &ConfigKeyMap::new())
     } else if file_text.starts_with("plugin-config: ") {
-      let mut config_map = HashMap::new();
+      let mut config_map = ConfigKeyMap::new();
       config_map.insert("ending".to_string(), "custom_config".into());
       format_with_host(&PathBuf::from("./test.txt_ps"), file_text.replace("plugin-config: ", ""), &config_map)
     } else if file_text == "should_error" {

--- a/crates/test-process-plugin/Cargo.toml
+++ b/crates/test-process-plugin/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 anyhow = "1.0.51"
 dprint-core = { path = "../core", features = ["process"] }
 serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/crates/test-process-plugin/src/main.rs
+++ b/crates/test-process-plugin/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::bail;
 use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -80,9 +79,9 @@ impl PluginHandler<Configuration> for TestProcessPluginHandler {
     mut format_with_host: impl FnMut(&Path, String, &ConfigKeyMap) -> Result<String>,
   ) -> Result<String> {
     if file_text.starts_with("plugin: ") {
-      format_with_host(&PathBuf::from("./test.txt"), file_text.replace("plugin: ", ""), &HashMap::new())
+      format_with_host(&PathBuf::from("./test.txt"), file_text.replace("plugin: ", ""), &Default::default())
     } else if file_text.starts_with("plugin-config: ") {
-      let mut config_map = HashMap::new();
+      let mut config_map = ConfigKeyMap::new();
       config_map.insert("ending".to_string(), "custom_config".into());
       format_with_host(&PathBuf::from("./test.txt"), file_text.replace("plugin-config: ", ""), &config_map)
     } else if file_text == "should_error" {

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -11,7 +11,7 @@ Implementing a Process plugin is easy if you're using Rust as there are several 
    ```toml
    dprint-core = { version = "...", features = ["process"] }
    serde = { version = "1.0.117", features = ["derive"] }
-   serde_json = "1.0"
+   serde_json = { version = "1.0", features = ["preserve_order"] }
    ```
 
 2. Create a `Configuration` struct somewhere in your project:

--- a/docs/wasm-plugin-development.md
+++ b/docs/wasm-plugin-development.md
@@ -11,7 +11,7 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
    ```toml
    dprint-core = { version = "...", features = ["wasm"] }
    serde = { version = "1.0.117", features = ["derive"] }
-   serde_json = "1.0"
+   serde_json = { version = "1.0", features = ["preserve_order"] }
    ```
 
 2. Add the following to _Cargo.toml_:


### PR DESCRIPTION
For dprint-plugin-exec it is important to maintain the order of configuration keys because the order determines which binary it will use to format first.