### PR TITLE
docs: documentation for process plugin schema version 4

### DIFF
--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -170,58 +170,73 @@ Responses are sent from the plugin to the client and could include format reques
 
 Causes the process to shut down gracefully.
 
-#### `2` - Get Plugin Info
+#### `2` - Active
+
+Used to tell if the process plugin is healthy and can respond to messages.
+
+Response: No body
+
+#### `3` - Get Plugin Info
 
 Response body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized plugin information
 
-#### `3` - Get License Text
+#### `4` - Get License Text
 
 Response body:
 
 - u32 (4 bytes) - Content length
 - License text
 
-#### `4` - Register Configuration
+#### `5` - Register Configuration
 
 Stores configuration in memory in the process plugin. The identifier of the configuration is the request identifier.
 
 Message body:
 
+- u32 (4 bytes) - Config id
 - u32 (4 bytes) - Content length
 - JSON serialized global configuration
 - u32 (4 bytes) - Content length
 - JSON serialized plugin configuration
 
-#### `5` - Release Configuration
+Response: No body
+
+#### `6` - Release Configuration
 
 Releases configuration from memory in the process plugin.
 
-Message body: None, uses id
+Message body:
 
-Response body: None
+- u32 (4 bytes) - Config id
 
-#### `6` - Get Configuration Diagnostics
+Response: No body
 
-Message body: None, uses id
+#### `7` - Get Configuration Diagnostics
+
+Message body:
+
+- u32 (4 bytes) - Config id
 
 Response body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized array of diagnostics
 
-#### `7` - Get Resolved Configuration
+#### `8` - Get Resolved Configuration
 
-Message body: None, uses id
+Message body:
+
+- u32 (4 bytes) - Config id
 
 Response body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized resolved configuration
 
-#### `8` - Format Text
+#### `9` - Format Text
 
 Message body:
 
@@ -243,15 +258,15 @@ Response body:
     - u32 (4 bytes) - Content length of the changed text
     - Formatted file text
 
-#### `9` - Cancel Format
+#### `10` - Cancel Format
 
-The request should use the same identifier as the format request.
+Message body:
 
-No response.
+- u32 (4 bytes) - Message id of the format to cancel
 
-The plugin may still respond with a completed formatting request, but the CLI will ignore it.
+Response: No response to the message should be given by the process plugin.
 
-#### `10` - Host Format Response
+#### `11` - Host Format Response
 
 The response should use the same identifier as the host formatting request.
 

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -273,16 +273,6 @@ Request body:
     - u32 (4 bytes) - Content length
     - Formatted file text
 
-#### `11` - Set max threads
-
-The CLI may tell the process plugin it can increase the number of threads it's using for formatting. To start, process plugins should be capped at 1 thread.
-
-Request body:
-
-- u32 (4 bytes) - Max number of threads.
-
-No response.
-
 ### Creating a `.exe-plugin` file
 
 TODO...

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -134,9 +134,9 @@ Requests are sent from the client to the plugin in the following format:
 <ID><KIND>[<BODY>]<SUCCESS_BYTES>
 ```
 
-- `ID` - u32 (4 bytes) - Number for the request or the ID of the host format request.
-- `KIND` - u32 (4 bytes) - Kind of request.
-- `BODY` - Depends on the kind and may be optional.
+- `ID` - u32 (4 bytes) - Number for the request or the ID of the host format request
+- `KIND` - u32 (4 bytes) - Kind of request
+- `BODY` - Depends on the kind and may be optional
 - `SUCCESS_BYTES` - 4 bytes (255, 255, 255, 255)
 
 ### Responses
@@ -151,17 +151,19 @@ Responses are sent from the plugin to the client and could include format reques
 - `KIND` - u32 (4 bytes) - `0` for success, `1` for failure, `2` for host format request.
 - `BODY`
   - When `KIND` is `0`:
-    - Depends on the request kind.
+    - Depends on the request kind
   - When `KIND` is `1`:
     - u32 (4 bytes) - Error message size
     - X bytes - Error message
   - When `KIND` is `2`:
-    - u32 (4 bytes) - Size of the file path.
-    - File path.
-    - u32 (4 bytes) - Size of the file text.
+    - u32 (4 bytes) - Size of the file path
+    - File path
+    - u32 (4 bytes) - Start byte index to format
+    - u32 (4 bytes) - End byte index to format
+    - u32 (4 bytes) - Size of the override configuration
+    - JSON serialized override configuration
+    - u32 (4 bytes) - Size of the file text
     - File text.
-    - u32 (4 bytes) - Size of the override configuration.
-    - JSON serialized override configuration.
 - `SUCCESS_BYTES` - 4 bytes (255, 255, 255, 255)
 
 ### Request Kinds
@@ -205,7 +207,7 @@ Releases configuration from memory in the process plugin.
 
 Request body:
 
-- u32 (4 bytes) - Identifier for the configuration.
+- u32 (4 bytes) - Identifier for the configuration
 
 Response body: None
 
@@ -213,7 +215,7 @@ Response body: None
 
 Request body:
 
-- u32 (4 bytes) - Identifier for the configuration to get diagnostics for.
+- u32 (4 bytes) - Identifier for the configuration to get diagnostics for
 
 Response body:
 
@@ -224,7 +226,7 @@ Response body:
 
 Request body:
 
-- u32 (4 bytes) - Identifier for the configuration to get diagnostics for.
+- u32 (4 bytes) - Identifier for the configuration to get diagnostics for
 
 Response body:
 
@@ -237,18 +239,20 @@ Request body:
 
 - u32 (4 bytes) - File path content length
 - File path
+- u32 (4 bytes) - Start byte index to format
+- u32 (4 bytes) - End byte index to format
+- u32 (4 bytes) - Configuration identifier
+- u32 (4 bytes) - Override configuration length -- TODO: Is this necessary anymore?
+- JSON override configuration
 - u32 (4 bytes) - File text content length
 - File text
-- u32 (4 bytes) - Configuration identifier
-- u32 (4 bytes) - Override configuration -- TODO: Is this necessary anymore?
-- JSON override configuration
 
 Response body:
 
 - u32 (4 bytes) - Response Kind
   - `0` - No Change
   - `1` - Change
-    - u32 (4 bytes) - Content length.
+    - u32 (4 bytes) - Content length of the changed text
     - Formatted file text
 
 #### `9` - Cancel Format
@@ -266,7 +270,7 @@ Request body:
 - u32 (4 bytes) - Response Kind
   - `0` - No Change
   - `1` - Change
-    - u32 (4 bytes) - Content length.
+    - u32 (4 bytes) - Content length
     - Formatted file text
 
 ### Creating a `.exe-plugin` file

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -115,6 +115,8 @@ Implementing a Process plugin is easy if you're using Rust as there are several 
 
 ## Schema Version 4 Overview (Not Yet Released)
 
+Process plugins are expected to read and respond to messages on a single thread, then spawn formatting threads/tasks for doing concurrent formatting.
+
 ### Schema Version Establishment
 
 To maintain compatibility with past dprint clients, an initial schema version establishment phase occurs that is the same as past schema versions.
@@ -182,37 +184,52 @@ Response body:
 - u32 (4 bytes) - Content length
 - License text
 
-#### `4` - Get Resolved Configuration
+#### `4` - Register Configuration
 
-Response body:
-
-- u32 (4 bytes) - Content length
-- JSON serialized resolved configuration
-
-#### `5` - Set Global Configuration
+Stores configuration in memory in the process plugin.
 
 Request body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized global configuration
-
-Response body: None
-
-#### `6` - Set Plugin Configuration
-
-Request body:
-
 - u32 (4 bytes) - Content length
 - JSON serialized plugin configuration
 
+Response body:
+
+- u32 (4 bytes) - Identifier for this configuration.
+
+#### `5` - Release Configuration
+
+Releases configuration from memory in the process plugin.
+
+Request body:
+
+- u32 (4 bytes) - Identifier for the configuration.
+
 Response body: None
 
-#### `7` - Get Configuration Diagnostics
+#### `6` - Get Configuration Diagnostics
+
+Request body:
+
+- u32 (4 bytes) - Identifier for the configuration to get diagnostics for.
 
 Response body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized array of diagnostics
+
+#### `7` - Get Resolved Configuration
+
+Request body:
+
+- u32 (4 bytes) - Identifier for the configuration to get diagnostics for.
+
+Response body:
+
+- u32 (4 bytes) - Content length
+- JSON serialized resolved configuration
 
 #### `8` - Format Text
 
@@ -222,7 +239,8 @@ Request body:
 - File path
 - u32 (4 bytes) - File text content length
 - File text
-- u32 (4 bytes) - Override configuration
+- u32 (4 bytes) - Configuration identifier
+- u32 (4 bytes) - Override configuration -- TODO: Is this necessary anymore?
 - JSON override configuration
 
 Response body:

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -262,6 +262,9 @@ Message body:
   - `1` - Change
     - u32 (4 bytes) - Content length
     - Formatted file text
+  - `2` - Error
+    - u32 (4 bytes) - Error length
+    - Error message text
 
 ### Creating a `.exe-plugin` file
 

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -124,9 +124,9 @@ To maintain compatibility with past dprint clients, an initial schema version es
 1. An initial `0` (4 bytes) is sent asking for the schema version.
 2. At this point, the client responds with `0` (4 bytes) for success, then `4` (4 bytes) for the schema version.
 
-### Requests
+### Messages
 
-Requests are sent from the client to the plugin in the following format:
+Messages are sent from the client to the plugin in the following format:
 
 ```
 <ID><KIND>[<BODY>]<SUCCESS_BYTES>
@@ -164,7 +164,7 @@ Responses are sent from the plugin to the client and could include format reques
     - File text.
 - `SUCCESS_BYTES` - 4 bytes (255, 255, 255, 255)
 
-### Request Kinds
+### Message Kinds
 
 #### `1` - Close
 
@@ -186,24 +186,20 @@ Response body:
 
 #### `4` - Register Configuration
 
-Stores configuration in memory in the process plugin.
+Stores configuration in memory in the process plugin. The identifier of the configuration is the request identifier.
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - Content length
 - JSON serialized global configuration
 - u32 (4 bytes) - Content length
 - JSON serialized plugin configuration
 
-Response body:
-
-- u32 (4 bytes) - Identifier for this configuration.
-
 #### `5` - Release Configuration
 
 Releases configuration from memory in the process plugin.
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - Identifier for the configuration
 
@@ -211,7 +207,7 @@ Response body: None
 
 #### `6` - Get Configuration Diagnostics
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - Identifier for the configuration to get diagnostics for
 
@@ -222,7 +218,7 @@ Response body:
 
 #### `7` - Get Resolved Configuration
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - Identifier for the configuration to get diagnostics for
 
@@ -233,7 +229,7 @@ Response body:
 
 #### `8` - Format Text
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - File path content length
 - File path
@@ -261,11 +257,11 @@ No response.
 
 The plugin may still respond with a completed formatting request, but the CLI will ignore it.
 
-#### `10` - Host Format Request Response
+#### `10` - Host Format Response
 
 The response should use the same identifier as the host formatting request.
 
-Request body:
+Message body:
 
 - u32 (4 bytes) - Response Kind
   - `0` - No Change

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -124,8 +124,6 @@ To maintain compatibility with past dprint clients, an initial schema version es
 1. An initial `0` (4 bytes) is sent asking for the schema version.
 2. At this point, the client responds with `0` (4 bytes) for success, then `4` (4 bytes) for the schema version.
 
-After this point, the schema version can no longer be asked for.
-
 ### Requests
 
 Requests are sent from the client to the plugin in the following format:
@@ -259,7 +257,9 @@ Response body:
 
 The request should use the same identifier as the format request.
 
-There is no response sent for this though the plugin may respond with a
+No response.
+
+The plugin may still respond with a completed formatting request, but the CLI will ignore it.
 
 #### `10` - Host Format Request Response
 
@@ -272,6 +272,16 @@ Request body:
   - `1` - Change
     - u32 (4 bytes) - Content length
     - Formatted file text
+
+#### `11` - Set max threads
+
+The CLI may tell the process plugin it can increase the number of threads it's using for formatting. To start, process plugins should be capped at 1 thread.
+
+Request body:
+
+- u32 (4 bytes) - Max number of threads.
+
+No response.
 
 ### Creating a `.exe-plugin` file
 

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -132,7 +132,7 @@ Messages are sent from the client to the plugin in the following format:
 <ID><KIND>[<BODY>]<SUCCESS_BYTES>
 ```
 
-- `ID` - u32 (4 bytes) - Number for the request or the ID of the host format request
+- `ID` - u32 (4 bytes) - Identifier that relates to the body.
 - `KIND` - u32 (4 bytes) - Kind of request
 - `BODY` - Depends on the kind and may be optional
 - `SUCCESS_BYTES` - 4 bytes (255, 255, 255, 255)
@@ -145,7 +145,7 @@ Responses are sent from the plugin to the client and could include format reques
 <ID><KIND><BODY><SUCCESS_BYTES>
 ```
 
-- `ID` - Which request this response is for or a new ID for a host format request.
+- `ID` - Identifier that relates to the message or a new ID for a host format request.
 - `KIND` - u32 (4 bytes) - `0` for success, `1` for failure, `2` for host format request.
 - `BODY`
   - When `KIND` is `0`:
@@ -199,17 +199,13 @@ Message body:
 
 Releases configuration from memory in the process plugin.
 
-Message body:
-
-- u32 (4 bytes) - Identifier for the configuration
+Message body: None, uses id
 
 Response body: None
 
 #### `6` - Get Configuration Diagnostics
 
-Message body:
-
-- u32 (4 bytes) - Identifier for the configuration to get diagnostics for
+Message body: None, uses id
 
 Response body:
 
@@ -218,9 +214,7 @@ Response body:
 
 #### `7` - Get Resolved Configuration
 
-Message body:
-
-- u32 (4 bytes) - Identifier for the configuration to get diagnostics for
+Message body: None, uses id
 
 Response body:
 


### PR DESCRIPTION
This is the documentation for #478 that I will implement soon.

This schema version introduces cancellation, concurrent formatting requests, and range formatting. After this change is implemented, dprint will no longer create multiple processes for process plugins in order to do concurrent formatting. Instead, it will be up to the process plugin to do this. This will help reduce memory and should speed up formatting. The downside is that clients will be more complicated.

Todo:

- [x] Cancel host formats.