### PR TITLE
fix: various improvements to the new process plugin system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
     # TEST
     - name: Test debug
       if: matrix.config.kind == 'test_debug'
-      run: cargo test --locked --all-features -- --nocapture
+      run: cargo test --locked --all-features
     - name: Test release
       if: matrix.config.kind == 'test_release'
-      run: cargo test --locked --all-features --release -- --nocapture
+      run: cargo test --locked --all-features --release
 
     # INSTALLER
     - name: Create installer (Windows x86_64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
     # TEST
     - name: Test debug
       if: matrix.config.kind == 'test_debug'
-      run: cargo test --locked --all-features
+      run: cargo test --locked --all-features -- --nocapture
     - name: Test release
       if: matrix.config.kind == 'test_release'
-      run: cargo test --locked --all-features --release
+      run: cargo test --locked --all-features --release -- --nocapture
 
     # INSTALLER
     - name: Create installer (Windows x86_64)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -353,7 +353,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio 0.7.14",
+ "mio",
  "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
@@ -505,10 +505,11 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bumpalo",
+ "crossbeam-channel",
  "indexmap",
  "libc",
  "parking_lot 0.12.0",
@@ -739,7 +740,7 @@ checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1007,20 +1008,6 @@ dependencies = [
  "log",
  "miow",
  "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1560,7 +1547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio 0.7.14",
+ "mio",
  "signal-hook",
 ]
 
@@ -1596,16 +1583,6 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "socket2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "socks"
@@ -1769,18 +1746,9 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "bytes",
- "libc",
- "memchr",
- "mio 0.8.1",
  "num_cpus",
- "once_cell",
- "parking_lot 0.12.0",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "winapi",
 ]
 
 [[package]]
@@ -1949,12 +1917,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.53.0"
+version = "0.53.1"
 dependencies = [
  "anyhow",
  "bumpalo",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.53.0"
+version = "0.53.1"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"
@@ -26,7 +26,7 @@ parking_lot = { version = "0.12.0", optional = true }
 rustc-hash = { version = "1.1.0", optional = true }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0", optional = true, features = ["preserve_order"] }
-tokio = { version = "1", optional = true, features = ["rt", "sync", "time"] }
+tokio = { version = "1", optional = true, features = ["rt", "time"] }
 tokio-util = { version = "0.7.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.52.1"
+version = "0.53.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"
@@ -13,13 +13,14 @@ description = "Core library for dprint."
 default = ["formatting"]
 
 formatting = ["bumpalo", "rustc-hash"]
-process = ["serde_json", "libc", "parking_lot", "tokio", "tokio-util", "winapi"]
+process = ["crossbeam-channel", "serde_json", "libc", "parking_lot", "tokio", "tokio-util", "winapi"]
 wasm = []
 tracing = ["formatting"]
 
 [dependencies]
 anyhow = "1.0.53"
 bumpalo = { version = "3.9.1", optional = true }
+crossbeam-channel = { version = "0.5.4", optional = true }
 indexmap = { version = "1.8.0", features = ["serde-1"] }
 parking_lot = { version = "0.12.0", optional = true }
 rustc-hash = { version = "1.1.0", optional = true }

--- a/crates/core/src/plugins/process/communication.rs
+++ b/crates/core/src/plugins/process/communication.rs
@@ -1,47 +1,46 @@
+use std::io::Read;
+use std::io::Write;
+
 use anyhow::bail;
 use anyhow::Result;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWrite;
-use tokio::io::AsyncWriteExt;
 
 const SUCCESS_BYTES: &[u8; 4] = &[255, 255, 255, 255];
 
-pub struct MessageReader<TRead: AsyncRead + Unpin> {
+pub struct MessageReader<TRead: Read + Unpin> {
   reader: TRead,
 }
 
-impl<TRead: AsyncRead + Unpin> MessageReader<TRead> {
+impl<TRead: Read + Unpin> MessageReader<TRead> {
   pub fn new(reader: TRead) -> Self {
     Self { reader }
   }
 
   /// Reads a u32 value.
-  pub async fn read_u32(&mut self) -> Result<u32> {
+  pub fn read_u32(&mut self) -> Result<u32> {
     let mut int_buf: [u8; 4] = [0; 4];
-    self.reader.read_exact(&mut int_buf).await?;
+    self.reader.read_exact(&mut int_buf)?;
     Ok(u32::from_be_bytes(int_buf))
   }
 
   /// Reads a u32 value followed by a buffer.
-  pub async fn read_sized_bytes(&mut self) -> Result<Vec<u8>> {
-    let size = self.read_u32().await? as usize;
-    self.read_bytes(size).await
+  pub fn read_sized_bytes(&mut self) -> Result<Vec<u8>> {
+    let size = self.read_u32()? as usize;
+    self.read_bytes(size)
   }
 
-  pub async fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
+  pub fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
     let mut buf = Vec::with_capacity(size);
     if size > 0 {
       unsafe {
         buf.set_len(size);
       }
-      self.reader.read_exact(&mut buf).await?;
+      self.reader.read_exact(&mut buf)?;
     }
     Ok(buf)
   }
 
-  pub async fn read_success_bytes(&mut self) -> Result<()> {
-    let read_bytes = self.inner_read_success_bytes().await?;
+  pub fn read_success_bytes(&mut self) -> Result<()> {
+    let read_bytes = self.inner_read_success_bytes()?;
     if &read_bytes != SUCCESS_BYTES {
       bail!(
         "Catastrophic error reading from process. Did not receive the success bytes at end of message. Found: {:?}",
@@ -51,42 +50,42 @@ impl<TRead: AsyncRead + Unpin> MessageReader<TRead> {
     Ok(())
   }
 
-  async fn inner_read_success_bytes(&mut self) -> Result<[u8; 4]> {
+  fn inner_read_success_bytes(&mut self) -> Result<[u8; 4]> {
     let mut read_buf: [u8; 4] = [0; 4];
-    self.reader.read_exact(&mut read_buf).await?;
+    self.reader.read_exact(&mut read_buf)?;
     Ok(read_buf)
   }
 }
 
-pub struct MessageWriter<TWrite: AsyncWrite + Unpin> {
+pub struct MessageWriter<TWrite: Write + Unpin> {
   writer: TWrite,
 }
 
-impl<TWrite: AsyncWrite + Unpin> MessageWriter<TWrite> {
+impl<TWrite: Write + Unpin> MessageWriter<TWrite> {
   pub fn new(writer: TWrite) -> Self {
     Self { writer }
   }
 
-  pub async fn send_u32(&mut self, value: u32) -> Result<()> {
-    self.writer.write_all(&value.to_be_bytes()).await?;
+  pub fn send_u32(&mut self, value: u32) -> Result<()> {
+    self.writer.write_all(&value.to_be_bytes())?;
     Ok(())
   }
 
-  pub async fn send_sized_bytes(&mut self, bytes: &[u8]) -> Result<()> {
-    self.send_u32(bytes.len() as u32).await?;
+  pub fn send_sized_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+    self.send_u32(bytes.len() as u32)?;
     if !bytes.is_empty() {
-      self.writer.write_all(bytes).await?;
+      self.writer.write_all(bytes)?;
     }
     Ok(())
   }
 
-  pub async fn send_success_bytes(&mut self) -> Result<()> {
-    self.writer.write_all(SUCCESS_BYTES).await?;
-    self.writer.flush().await?;
+  pub fn send_success_bytes(&mut self) -> Result<()> {
+    self.writer.write_all(SUCCESS_BYTES)?;
+    self.writer.flush()?;
     Ok(())
   }
 
-  pub async fn flush(&mut self) -> Result<()> {
-    Ok(self.writer.flush().await?)
+  pub fn flush(&mut self) -> Result<()> {
+    Ok(self.writer.flush()?)
   }
 }

--- a/crates/core/src/plugins/process/communicator.rs
+++ b/crates/core/src/plugins/process/communicator.rs
@@ -171,8 +171,11 @@ impl ProcessPluginCommunicator {
     } else {
       // attempt to exit nicely
       tokio::select! {
+        // we wait for acknowledgement in order to give the process
+        // plugin a chance to clean up (ex. in case it has spawned
+        // any processes it needs to kill or something like that)
         _ = self.send_with_acknowledgement(MessageBody::Close) => {}
-        _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        _ = tokio::time::sleep(Duration::from_millis(250)) => {}
       }
       self.context.poisoner.poison();
     }

--- a/crates/core/src/plugins/process/communicator.rs
+++ b/crates/core/src/plugins/process/communicator.rs
@@ -148,16 +148,13 @@ impl ProcessPluginCommunicator {
       }
     });
 
-    tokio::task::spawn_blocking({
-      let poisoner = poisoner.clone();
-      move || {
-        while let Ok(message) = message_rx.recv() {
-          if message.write(&mut stdin_writer).is_err() {
-            break;
-          }
+    tokio::task::spawn_blocking(move || {
+      while let Ok(message) = message_rx.recv() {
+        if message.write(&mut stdin_writer).is_err() {
+          break;
         }
-        poisoner.poison();
       }
+      poisoner.poison();
     });
 
     Ok(Self {

--- a/crates/core/src/plugins/process/message_processor.rs
+++ b/crates/core/src/plugins/process/message_processor.rs
@@ -1,12 +1,13 @@
 use anyhow::anyhow;
 use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use serde::Serialize;
 use std::future::Future;
+use std::io::Read;
+use std::io::Write;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncWrite;
 use tokio_util::sync::CancellationToken;
 
 use super::communication::MessageReader;
@@ -34,171 +35,176 @@ pub async fn handle_process_stdio_messages<THandler: AsyncPluginHandler>(handler
   // ensure all process plugins exit on panic on any tokio task
   setup_exit_process_panic_hook();
 
-  let mut stdin_reader = MessageReader::new(tokio::io::stdin());
-  let mut stdout_writer = MessageWriter::new(tokio::io::stdout());
+  tokio::task::spawn_blocking(move || {
+    let mut stdin_reader = MessageReader::new(std::io::stdin());
+    let mut stdout_writer = MessageWriter::new(std::io::stdout());
 
-  schema_establishment_phase(&mut stdin_reader, &mut stdout_writer).await?;
+    schema_establishment_phase(&mut stdin_reader, &mut stdout_writer)?;
 
-  let handler = Arc::new(handler);
-  let stdout_message_writer = StdoutMessageWriter::new(stdout_writer);
-  let context: ProcessContext<THandler::Configuration> = ProcessContext::new(stdout_message_writer);
-  let host = Arc::new(ProcessHost { context: context.clone() });
+    let handler = Arc::new(handler);
+    let stdout_message_writer = StdoutMessageWriter::new(stdout_writer);
+    let context: ProcessContext<THandler::Configuration> = ProcessContext::new(stdout_message_writer);
+    let host = Arc::new(ProcessHost { context: context.clone() });
 
-  // read messages over stdin
-  loop {
-    let message = Message::read(&mut stdin_reader).await?;
+    // read messages over stdin
+    loop {
+      let message = Message::read(&mut stdin_reader).with_context(|| "Error reading message from stdin.")?;
 
-    match message.body {
-      MessageBody::Close => {
-        return Ok(());
-      }
-      MessageBody::IsAlive => {
-        handle_message(&context, message.id, || Ok(MessageBody::Success(message.id)));
-      }
-      MessageBody::GetPluginInfo => {
-        handle_message(&context, message.id, || {
-          let plugin_info = handler.plugin_info();
-          let data = serde_json::to_vec(&plugin_info)?;
-          Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
-        });
-      }
-      MessageBody::GetLicenseText => {
-        handle_message(&context, message.id, || {
-          let data = handler.license_text().into_bytes();
-          Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
-        });
-      }
-      MessageBody::RegisterConfig(body) => {
-        handle_message(&context, message.id, || {
-          let global_config: GlobalConfiguration = serde_json::from_slice(&body.global_config)?;
-          let config_map: ConfigKeyMap = serde_json::from_slice(&body.plugin_config)?;
-          let result = handler.resolve_config(config_map.clone(), global_config.clone());
-          context.configs.store(
-            body.config_id,
-            Arc::new(StoredConfig {
-              config: Arc::new(result.config),
-              diagnostics: Arc::new(result.diagnostics),
-              config_map,
-              global_config,
-            }),
-          );
-          Ok(MessageBody::Success(message.id))
-        });
-      }
-      MessageBody::ReleaseConfig(config_id) => {
-        handle_message(&context, message.id, || {
-          context.configs.take(config_id);
-          Ok(MessageBody::Success(message.id))
-        });
-      }
-      MessageBody::GetConfigDiagnostics(config_id) => {
-        handle_message(&context, message.id, || {
-          let diagnostics = context.configs.get_cloned(config_id).map(|c| c.diagnostics.clone()).unwrap_or_default();
-          let data = serde_json::to_vec(&*diagnostics)?;
-          Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
-        });
-      }
-      MessageBody::GetResolvedConfig(config_id) => {
-        handle_message(&context, message.id, || {
-          let data = match context.configs.get_cloned(config_id) {
-            Some(config) => serde_json::to_vec(&*config.config)?,
-            None => bail!("Did not find configuration for id: {}", config_id),
-          };
-          Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
-        });
-      }
-      MessageBody::Format(body) => {
-        // now parse
-        let token = Arc::new(CancellationToken::new());
-        let request = FormatRequest {
-          file_path: body.file_path,
-          range: body.range,
-          config: match context.configs.get_cloned(body.config_id) {
-            Some(config) => {
-              if body.override_config.is_empty() {
-                config.config.clone()
-              } else {
-                let mut config_map = config.config_map.clone();
-                let override_config_map: ConfigKeyMap = serde_json::from_slice(&body.override_config)?;
-                for (key, value) in override_config_map {
-                  config_map.insert(key, value);
-                }
-                let result = handler.resolve_config(config_map, config.global_config.clone());
-                Arc::new(result.config)
-              }
-            }
-            None => {
-              send_error_response(&context, message.id, anyhow!("Did not find configuration for id: {}", body.config_id));
-              continue;
-            }
-          },
-          file_text: match String::from_utf8(body.file_text) {
-            Ok(text) => text,
-            Err(err) => {
-              send_error_response(&context, message.id, anyhow!("Error decoding text to utf8: {}", err));
-              continue;
-            }
-          },
-          token: token.clone(),
-        };
-
-        // start the task
-        context.cancellation_tokens.store(message.id, token.clone());
-        let context = context.clone();
-        let handler = handler.clone();
-        let host = host.clone();
-        tokio::task::spawn(async move {
-          let result = handler.format(request, host).await;
-          context.cancellation_tokens.take(message.id);
-          if !token.is_cancelled() {
-            let body = match result {
-              Ok(text) => MessageBody::FormatResponse(ResponseBody {
-                message_id: message.id,
-                data: text.map(|t| t.into_bytes()),
+      match message.body {
+        MessageBody::Close => {
+          handle_message(&context, message.id, || Ok(MessageBody::Success(message.id)));
+          return Ok(());
+        }
+        MessageBody::IsAlive => {
+          handle_message(&context, message.id, || Ok(MessageBody::Success(message.id)));
+        }
+        MessageBody::GetPluginInfo => {
+          handle_message(&context, message.id, || {
+            let plugin_info = handler.plugin_info();
+            let data = serde_json::to_vec(&plugin_info)?;
+            Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
+          });
+        }
+        MessageBody::GetLicenseText => {
+          handle_message(&context, message.id, || {
+            let data = handler.license_text().into_bytes();
+            Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
+          });
+        }
+        MessageBody::RegisterConfig(body) => {
+          handle_message(&context, message.id, || {
+            let global_config: GlobalConfiguration = serde_json::from_slice(&body.global_config)?;
+            let config_map: ConfigKeyMap = serde_json::from_slice(&body.plugin_config)?;
+            let result = handler.resolve_config(config_map.clone(), global_config.clone());
+            context.configs.store(
+              body.config_id,
+              Arc::new(StoredConfig {
+                config: Arc::new(result.config),
+                diagnostics: Arc::new(result.diagnostics),
+                config_map,
+                global_config,
               }),
-              Err(err) => MessageBody::Error(ResponseBody {
-                message_id: message.id,
-                data: format!("{}", err).into_bytes(),
-              }),
+            );
+            Ok(MessageBody::Success(message.id))
+          });
+        }
+        MessageBody::ReleaseConfig(config_id) => {
+          handle_message(&context, message.id, || {
+            context.configs.take(config_id);
+            Ok(MessageBody::Success(message.id))
+          });
+        }
+        MessageBody::GetConfigDiagnostics(config_id) => {
+          handle_message(&context, message.id, || {
+            let diagnostics = context.configs.get_cloned(config_id).map(|c| c.diagnostics.clone()).unwrap_or_default();
+            let data = serde_json::to_vec(&*diagnostics)?;
+            Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
+          });
+        }
+        MessageBody::GetResolvedConfig(config_id) => {
+          handle_message(&context, message.id, || {
+            let data = match context.configs.get_cloned(config_id) {
+              Some(config) => serde_json::to_vec(&*config.config)?,
+              None => bail!("Did not find configuration for id: {}", config_id),
             };
-            send_response_body(&context, body)
+            Ok(MessageBody::DataResponse(ResponseBody { message_id: message.id, data }))
+          });
+        }
+        MessageBody::Format(body) => {
+          // now parse
+          let token = Arc::new(CancellationToken::new());
+          let request = FormatRequest {
+            file_path: body.file_path,
+            range: body.range,
+            config: match context.configs.get_cloned(body.config_id) {
+              Some(config) => {
+                if body.override_config.is_empty() {
+                  config.config.clone()
+                } else {
+                  let mut config_map = config.config_map.clone();
+                  let override_config_map: ConfigKeyMap = serde_json::from_slice(&body.override_config)?;
+                  for (key, value) in override_config_map {
+                    config_map.insert(key, value);
+                  }
+                  let result = handler.resolve_config(config_map, config.global_config.clone());
+                  Arc::new(result.config)
+                }
+              }
+              None => {
+                send_error_response(&context, message.id, anyhow!("Did not find configuration for id: {}", body.config_id));
+                continue;
+              }
+            },
+            file_text: match String::from_utf8(body.file_text) {
+              Ok(text) => text,
+              Err(err) => {
+                send_error_response(&context, message.id, anyhow!("Error decoding text to utf8: {}", err));
+                continue;
+              }
+            },
+            token: token.clone(),
+          };
+
+          // start the task
+          context.cancellation_tokens.store(message.id, token.clone());
+          let context = context.clone();
+          let handler = handler.clone();
+          let host = host.clone();
+          tokio::task::spawn(async move {
+            let result = handler.format(request, host).await;
+            context.cancellation_tokens.take(message.id);
+            if !token.is_cancelled() {
+              let body = match result {
+                Ok(text) => MessageBody::FormatResponse(ResponseBody {
+                  message_id: message.id,
+                  data: text.map(|t| t.into_bytes()),
+                }),
+                Err(err) => MessageBody::Error(ResponseBody {
+                  message_id: message.id,
+                  data: format!("{}", err).into_bytes(),
+                }),
+              };
+              send_response_body(&context, body)
+            }
+          });
+        }
+        MessageBody::CancelFormat(message_id) => {
+          if let Some(token) = context.cancellation_tokens.take(message_id) {
+            token.cancel();
           }
-        });
-      }
-      MessageBody::CancelFormat(message_id) => {
-        if let Some(token) = context.cancellation_tokens.take(message_id) {
-          token.cancel();
         }
-      }
-      MessageBody::Error(body) => {
-        let text = String::from_utf8_lossy(&body.data);
-        if let Some(sender) = context.format_host_senders.take(body.message_id) {
-          sender.send(Err(anyhow!("{}", text))).unwrap();
-        } else {
-          eprintln!("Received error from CLI. {}", text);
+        MessageBody::Error(body) => {
+          let text = String::from_utf8_lossy(&body.data);
+          if let Some(sender) = context.format_host_senders.take(body.message_id) {
+            sender.send(Err(anyhow!("{}", text))).unwrap();
+          } else {
+            eprintln!("Received error from CLI. {}", text);
+          }
         }
-      }
-      MessageBody::FormatResponse(body) => {
-        let data = match body.data {
-          None => Ok(None),
-          Some(data) => match String::from_utf8(data) {
-            Ok(data) => Ok(Some(data)),
-            Err(err) => Err(anyhow!("Error deserializing success: {}", err)),
-          },
-        };
-        if let Some(sender) = context.format_host_senders.take(body.message_id) {
-          sender.send(data).unwrap();
+        MessageBody::FormatResponse(body) => {
+          let data = match body.data {
+            None => Ok(None),
+            Some(data) => match String::from_utf8(data) {
+              Ok(data) => Ok(Some(data)),
+              Err(err) => Err(anyhow!("Error deserializing success: {}", err)),
+            },
+          };
+          if let Some(sender) = context.format_host_senders.take(body.message_id) {
+            sender.send(data).unwrap();
+          }
         }
+        MessageBody::Success(_) | MessageBody::DataResponse(_) => {
+          // ignore
+        }
+        MessageBody::HostFormat(_) => {
+          send_error_response(&context, message.id, anyhow!("Cannot host format with a plugin."));
+        }
+        MessageBody::Unknown(message_kind) => panic!("Received unknown message kind: {}", message_kind),
       }
-      MessageBody::Success(_) | MessageBody::DataResponse(_) => {
-        // ignore
-      }
-      MessageBody::HostFormat(_) => {
-        send_error_response(&context, message.id, anyhow!("Cannot host format with a plugin."));
-      }
-      MessageBody::Unknown(message_kind) => panic!("Received unknown message kind: {}", message_kind),
     }
-  }
+  })
+  .await
+  .unwrap()
 }
 
 struct ProcessHost<TConfiguration: Serialize + Clone + Send + Sync> {
@@ -301,19 +307,16 @@ fn send_response_body<TConfiguration: Serialize + Clone + Send + Sync>(context: 
 }
 
 /// For backwards compatibility asking for the schema version.
-async fn schema_establishment_phase<TRead: AsyncRead + Unpin, TWrite: AsyncWrite + Unpin>(
-  stdin: &mut MessageReader<TRead>,
-  stdout: &mut MessageWriter<TWrite>,
-) -> Result<()> {
+fn schema_establishment_phase<TRead: Read + Unpin, TWrite: Write + Unpin>(stdin: &mut MessageReader<TRead>, stdout: &mut MessageWriter<TWrite>) -> Result<()> {
   // 1. An initial `0` (4 bytes) is sent asking for the schema version.
-  if stdin.read_u32().await? != 0 {
+  if stdin.read_u32()? != 0 {
     bail!("Expected a schema version request of `0`.");
   }
 
   // 2. The client responds with `0` (4 bytes) for success, then `4` (4 bytes) for the schema version.
-  stdout.send_u32(0).await?;
-  stdout.send_u32(PLUGIN_SCHEMA_VERSION).await?;
-  stdout.flush().await?;
+  stdout.send_u32(0)?;
+  stdout.send_u32(PLUGIN_SCHEMA_VERSION)?;
+  stdout.flush()?;
 
   Ok(())
 }

--- a/crates/core/src/plugins/process/utils.rs
+++ b/crates/core/src/plugins/process/utils.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -22,6 +23,19 @@ impl Poisoner {
 
   pub fn wait_poisoned(&self) -> WaitForCancellationFuture {
     self.0.cancelled()
+  }
+}
+
+#[derive(Default, Clone)]
+pub struct ArcFlag(Arc<AtomicBool>);
+
+impl ArcFlag {
+  pub fn raise(&self) {
+    self.0.store(true, Ordering::SeqCst)
+  }
+
+  pub fn is_raised(&self) -> bool {
+    self.0.load(Ordering::SeqCst)
   }
 }
 

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -15,7 +15,7 @@ clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
 dprint-cli-core = { path = "../cli-core", version = "0.12.0" }
-dprint-core = { path = "../core", version = "0.53.0", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "0.53.1", features = ["process", "wasm"] }
 dunce = "1.0.2"
 futures = "0.3.21"
 ignore = "0.4.18"
@@ -25,7 +25,7 @@ parking_lot = "0.11.2"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 similar = { version = "2.1.0", features = ["inline"] }
-tokio = { version = "1", features = ["rt", "sync", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.0" }
 twox-hash = "1.6.2"
 url = "2.2.2"

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -15,7 +15,7 @@ clap = "2.33.3"
 crossterm = "0.22.1"
 dirs = "4.0.0"
 dprint-cli-core = { path = "../cli-core", version = "0.12.0" }
-dprint-core = { path = "../core", version = "0.52.1", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "0.53.0", features = ["process", "wasm"] }
 dunce = "1.0.2"
 futures = "0.3.21"
 ignore = "0.4.18"
@@ -25,7 +25,7 @@ parking_lot = "0.11.2"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 similar = { version = "2.1.0", features = ["inline"] }
-tokio = { version = "1", features = ["full"] } # todo: reduce features
+tokio = { version = "1", features = ["rt", "sync", "time", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.0" }
 twox-hash = "1.6.2"
 url = "2.2.2"

--- a/crates/dprint/src/commands/editor/mod.rs
+++ b/crates/dprint/src/commands/editor/mod.rs
@@ -268,8 +268,10 @@ mod test {
       .push_str(r#"{"name":"test-plugin","version":"0.1.0","configKey":"test-plugin","fileExtensions":["txt"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/test/schema.json","helpUrl":"https://dprint.dev/plugins/test"},"#);
     final_output.push_str(r#"{"name":"test-process-plugin","version":"0.1.0","configKey":"testProcessPlugin","fileExtensions":["txt_ps"],"fileNames":["test-process-plugin-exact-file"],"helpUrl":"https://dprint.dev/plugins/test-process"}]}"#);
     assert_eq!(environment.take_stdout_messages(), vec![final_output]);
+    let mut stderr_messages = environment.take_stderr_messages();
+    stderr_messages.sort();
     assert_eq!(
-      environment.take_stderr_messages(),
+      stderr_messages,
       vec![
         "Compiling https://plugins.dprint.dev/test-plugin.wasm",
         "Extracting zip for test-process-plugin"

--- a/crates/dprint/src/commands/editor/mod.rs
+++ b/crates/dprint/src/commands/editor/mod.rs
@@ -223,7 +223,7 @@ impl<'a, TEnvironment: Environment> EditorService<'a, TEnvironment> {
 
     let has_config_changed = last_config.is_none() || last_config.unwrap() != config;
     if has_config_changed {
-      self.plugins_collection.drop_plugins(); // clear the existing plugins
+      self.plugins_collection.drop_and_shutdown_initialized().await; // clear the existing plugins
       let plugins = resolve_plugins(self.args, &config, self.environment, self.plugin_resolver).await?;
       self.plugins_collection.set_plugins(plugins, &config.base_path)?;
     }

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -763,6 +763,7 @@ mod test {
 
   #[test]
   fn should_error_config_diagnostic_multiple_plugins_same_file_via_associations() {
+    eprintln!("ENTERING");
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin()
       .with_local_config("/config.json", |c| {
         c.add_remote_wasm_plugin()
@@ -790,8 +791,10 @@ mod test {
       .write_file("/test.txt", "text")
       .write_file("/shared_file", "text")
       .build();
+    eprintln!("INITIALIZED");
 
     let error_message = run_test_cli(vec!["fmt", "--config", "/config.json"], &environment).err().unwrap();
+    eprintln!("FINISHED");
 
     assert_eq!(error_message.to_string(), "Had 1 error(s) formatting.");
     assert_eq!(environment.take_stdout_messages().len(), 0);

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -763,7 +763,6 @@ mod test {
 
   #[test]
   fn should_error_config_diagnostic_multiple_plugins_same_file_via_associations() {
-    eprintln!("ENTERING");
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin()
       .with_local_config("/config.json", |c| {
         c.add_remote_wasm_plugin()
@@ -791,10 +790,8 @@ mod test {
       .write_file("/test.txt", "text")
       .write_file("/shared_file", "text")
       .build();
-    eprintln!("INITIALIZED");
 
     let error_message = run_test_cli(vec!["fmt", "--config", "/config.json"], &environment).err().unwrap();
-    eprintln!("FINISHED");
 
     assert_eq!(error_message.to_string(), "Had 1 error(s) formatting.");
     assert_eq!(environment.take_stdout_messages().len(), 0);

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -323,11 +323,11 @@ mod test {
 
   #[test]
   fn should_handle_wasm_plugin_panicking() {
-    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin()
       .write_file("/file1.txt", "should_panic") // special text to make it panic
-      .write_file("/file2.txt", "test")
+      .write_file("/file2.txt_ps", "test")
       .build();
-    let error_message = run_test_cli(vec!["fmt", "**.txt"], &environment).err().unwrap();
+    let error_message = run_test_cli(vec!["fmt", "**.{txt,txt_ps}"], &environment).err().unwrap();
     assert_eq!(environment.take_stdout_messages().len(), 0);
     let logged_errors = environment.take_stderr_messages();
     assert_eq!(logged_errors.len(), 1);
@@ -338,7 +338,8 @@ mod test {
     );
     assert_eq!(&logged_errors[0][..expected_start_text.len()], expected_start_text);
     assert_eq!(error_message.to_string(), "Had 1 error(s) formatting.");
-    assert_eq!(environment.read_file("/file2.txt").unwrap(), "test_formatted");
+    // should still format with the other plugin
+    assert_eq!(environment.read_file("/file2.txt_ps").unwrap(), "test_formatted_process");
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -361,7 +361,7 @@ mod test {
       .build();
     run_test_cli(vec!["fmt", "/file.txt"], &environment).unwrap();
     assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
-    assert_eq!(environment.take_stderr_messages().len(), 0);
+    assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
     assert_eq!(environment.read_file(&file_path).unwrap(), "format this text_formatted_process");
   }
 

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -219,8 +219,9 @@ impl TestEnvironment {
     *self.runtime_handle.lock() = Some(handle);
   }
 
+  /// Remember to drop the plugins collection manually if using this with one.
   pub fn run_in_runtime<T>(&self, future: impl Future<Output = T>) -> T {
-    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread().enable_time().build().unwrap();
     self.set_runtime_handle(rt.handle().clone());
     rt.block_on(future)
   }

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -103,6 +103,6 @@ pub async fn get_and_resolve_file_paths(config: &ResolvedConfig, args: &CliArgs,
   let environment = environment.clone();
 
   // This is intensive so do it in a blocking task
-  // Eventually this could should maybe be changed to use tokio threads
+  // Eventually this could should maybe be changed to use tokio tasks
   tokio::task::spawn_blocking(move || glob(&environment, &base_dir, file_patterns)).await.unwrap()
 }

--- a/crates/dprint/src/plugins/collection.rs
+++ b/crates/dprint/src/plugins/collection.rs
@@ -228,11 +228,13 @@ impl<TEnvironment: Environment> PluginWrapper<TEnvironment> {
       match has_checked_diagnostics {
         Some(was_success) => {
           if !was_success {
+            instance.shutdown().await;
             return Ok(GetPluginResult::HadDiagnostics);
           }
         }
         None => {
           let result = output_plugin_config_diagnostics(self.name(), instance.clone(), error_logger).await;
+          instance.shutdown().await;
           *self.checked_diagnostics.lock() = Some(result.is_ok());
           if let Err(err) = result {
             self.environment.log_stderr(&err.to_string());

--- a/crates/dprint/src/plugins/collection.rs
+++ b/crates/dprint/src/plugins/collection.rs
@@ -234,10 +234,10 @@ impl<TEnvironment: Environment> PluginWrapper<TEnvironment> {
         }
         None => {
           let result = output_plugin_config_diagnostics(self.name(), instance.clone(), error_logger).await;
-          instance.shutdown().await;
           *self.checked_diagnostics.lock() = Some(result.is_ok());
           if let Err(err) = result {
             self.environment.log_stderr(&err.to_string());
+            instance.shutdown().await;
             return Ok(GetPluginResult::HadDiagnostics);
           }
         }

--- a/crates/dprint/src/plugins/implementations/mod.rs
+++ b/crates/dprint/src/plugins/implementations/mod.rs
@@ -65,6 +65,7 @@ mod test {
           .await
           .unwrap();
 
+        collection.drop_and_shutdown_initialized().await;
         assert_eq!(result, None);
       }
     });

--- a/crates/dprint/src/plugins/implementations/process/plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/plugin.rs
@@ -107,6 +107,10 @@ impl<TEnvironment: Environment> Plugin for ProcessPlugin<TEnvironment> {
     self.config.as_ref().expect("Call set_config first.")
   }
 
+  fn is_process_plugin(&self) -> bool {
+    true
+  }
+
   fn initialize(&self) -> BoxFuture<'static, Result<Arc<dyn InitializedPlugin>>> {
     let config = self.config.as_ref().expect("Call set_config first.");
     let plugin_name = self.plugin_info.name.clone();
@@ -158,5 +162,10 @@ impl<TEnvironment: Environment> InitializedPlugin for InitializedProcessPlugin<T
   fn format_text(&self, request: InitializedPluginFormatRequest) -> BoxFuture<'static, FormatResult> {
     let communicator = self.communicator.clone();
     async move { communicator.format_text(request).await }.boxed()
+  }
+
+  fn shutdown(&self) -> BoxFuture<'static, ()> {
+    let communicator = self.communicator.clone();
+    async move { communicator.shutdown().await }.boxed()
   }
 }

--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -98,6 +98,7 @@ pub async fn setup_process_plugin<TEnvironment: Environment>(
     )
     .await?;
     let plugin_info = communicator.plugin_info().await?;
+    communicator.shutdown().await;
 
     Ok(SetupPluginResult {
       plugin_info,

--- a/crates/test-process-plugin/Cargo.toml
+++ b/crates/test-process-plugin/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0.51"
 dprint-core = { path = "../core", features = ["process"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }

--- a/crates/test-process-plugin/Cargo.toml
+++ b/crates/test-process-plugin/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0.51"
 dprint-core = { path = "../core", features = ["process"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }

--- a/crates/test-process-plugin/Cargo.toml
+++ b/crates/test-process-plugin/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0.51"
 dprint-core = { path = "../core", features = ["process"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -10,7 +10,7 @@ Implementing a Process plugin is easy if you're using Rust as there are several 
 
    ```toml
    dprint-core = { version = "...", features = ["process"] }
-   tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
+   tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
    tokio-util = { version = "0.7.0" }
    serde = { version = "1.0.117", features = ["derive"] }
    serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -10,7 +10,7 @@ Implementing a Process plugin is easy if you're using Rust as there are several 
 
    ```toml
    dprint-core = { version = "...", features = ["process"] }
-   tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+   tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
    tokio-util = { version = "0.7.0" }
    serde = { version = "1.0.117", features = ["derive"] }
    serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/docs/process-plugin-development.md
+++ b/docs/process-plugin-development.md
@@ -10,7 +10,7 @@ Implementing a Process plugin is easy if you're using Rust as there are several 
 
    ```toml
    dprint-core = { version = "...", features = ["process"] }
-   tokio = { version = "1", features = ["full"] } # todo: reduce features
+   tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
    tokio-util = { version = "0.7.0" }
    serde = { version = "1.0.117", features = ["derive"] }
    serde_json = { version = "1.0", features = ["preserve_order"] }
@@ -194,7 +194,7 @@ Causes the process to shut down gracefully.
 
 Message body: None
 
-Response: No response
+Response: Success response, then shut down
 
 #### `4` - Active (CLI to Plugin, Plugin to CLI)
 


### PR DESCRIPTION
Closes #495, but mainly there's a dprint-plugin-prettier change that will fix that. This also reduces the number of threads used for formatting if there are process plugins and subtracts one for any messaging going on in the cli itself (seems to improve formatting speeds).