### PR TITLE
fix(core): add `WriterInfo.expect_newline_next`

### DIFF
--- a/crates/core/src/formatting/conditions.rs
+++ b/crates/core/src/formatting/conditions.rs
@@ -112,7 +112,7 @@ pub fn if_above_width_or(width: u8, true_items: PrintItems, false_items: PrintIt
     ConditionProperties {
       condition: Rc::new(move |context| {
         let writer_info = &context.writer_info;
-        let first_indent_col = writer_info.line_start_column_number + (width as u32);
+        let first_indent_col = writer_info.line_start_column_number() + (width as u32);
         Some(writer_info.column_number > first_indent_col)
       }),
       true_path: Some(true_items),

--- a/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
+++ b/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
@@ -422,7 +422,7 @@ fn get_is_start_standalone_line(start_info: Info) -> Condition {
     ConditionProperties {
       condition: Rc::new(move |condition_context| {
         let start_info = condition_context.get_resolved_info(&start_info)?;
-        Some(start_info.is_start_of_line())
+        Some(start_info.is_column_number_at_line_start())
       }),
       false_path: None,
       true_path: None,

--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -711,13 +711,17 @@ pub struct WriterInfo {
   pub column_number: u32,
   pub indent_level: u8,
   pub line_start_indent_level: u8,
-  pub line_start_column_number: u32,
+  pub indent_width: u8,
 }
 
 impl WriterInfo {
   /// Gets if the current column number equals the line start column number.
   pub fn is_start_of_line(&self) -> bool {
-    self.column_number == self.line_start_column_number
+    self.column_number == self.line_start_column_number()
+  }
+
+  pub fn line_start_column_number(&self) -> u32 {
+    (self.line_start_indent_level as u32) * (self.indent_width as u32)
   }
 
   /// Gets the line and column number.

--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -712,11 +712,18 @@ pub struct WriterInfo {
   pub indent_level: u8,
   pub line_start_indent_level: u8,
   pub indent_width: u8,
+  pub expect_newline_next: bool,
 }
 
 impl WriterInfo {
-  /// Gets if the current column number equals the line start column number.
+  /// Gets if the current column number equals the line start column number
+  /// or if a newline is expected next.
   pub fn is_start_of_line(&self) -> bool {
+    self.expect_newline_next || self.is_column_number_at_line_start()
+  }
+
+  /// Gets if the current column number is at the line start column number.
+  pub fn is_column_number_at_line_start(&self) -> bool {
     self.column_number == self.line_start_column_number()
   }
 

--- a/crates/core/src/formatting/printer.rs
+++ b/crates/core/src/formatting/printer.rs
@@ -163,14 +163,9 @@ impl<'a> Printer<'a> {
     }
   }
 
+  #[inline]
   pub fn get_writer_info(&self) -> WriterInfo {
-    WriterInfo {
-      line_start_indent_level: self.writer.get_line_start_indent_level(),
-      line_start_column_number: self.writer.get_line_start_column_number(),
-      line_number: self.writer.get_line_number(),
-      column_number: self.writer.get_line_column(),
-      indent_level: self.writer.get_indentation_level(),
-    }
+    self.writer.get_writer_info()
   }
 
   pub fn get_resolved_info(&self, info: &Info) -> Option<&WriterInfo> {

--- a/crates/core/src/formatting/writer.rs
+++ b/crates/core/src/formatting/writer.rs
@@ -24,7 +24,7 @@ impl<'a> WriterState<'a> {
       column_number: self.get_line_column(indent_width),
       indent_level: self.indent_level,
       line_start_indent_level: self.last_line_indent_level,
-      line_start_column_number: (self.last_line_indent_level as u32) * (indent_width as u32),
+      indent_width,
     }
   }
 

--- a/crates/core/src/formatting/writer.rs
+++ b/crates/core/src/formatting/writer.rs
@@ -25,6 +25,7 @@ impl<'a> WriterState<'a> {
       indent_level: self.indent_level,
       line_start_indent_level: self.last_line_indent_level,
       indent_width,
+      expect_newline_next: self.expect_newline_next,
     }
   }
 


### PR DESCRIPTION
When telling if we're at the start of a newline, it should take into account if there's a newline expected next.

This also reduces the size of `WriterInfo`.