### PR TITLE
fix: mac aarch64

### DIFF
--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -190,7 +190,7 @@ fn get_os_path<'a>(plugin_file: &'a ProcessPluginFile, environment: &impl Enviro
     },
     "macos" => match arch.as_str() {
       "x86_64" => plugin_file.darwin_x86_64.as_ref(),
-      "aarc64" => plugin_file.darwin_aarch64.as_ref().or(plugin_file.darwin_x86_64.as_ref()),
+      "aarch64" => plugin_file.darwin_aarch64.as_ref().or(plugin_file.darwin_x86_64.as_ref()),
       _ => None,
     },
     "windows" => match arch.as_str() {


### PR DESCRIPTION
fixed typo

Resolves https://github.com/dprint/dprint-plugin-roslyn/issues/8