### PR TITLE
Fix installing from npm in paths with spaces

### DIFF
--- a/deployment/npm/install.js
+++ b/deployment/npm/install.js
@@ -28,7 +28,7 @@ if (os.platform() === "win32") {
   if (!fs.existsSync("dprint")) {
     const installScriptPath = path.join(__dirname, "install.sh");
     fs.chmodSync(installScriptPath, "755");
-    child_process.execSync(`${installScriptPath} ${info.version}`, {
+    child_process.execSync(`"${installScriptPath}" ${info.version}`, {
       stdio: "inherit",
       cwd: __dirname,
     });


### PR DESCRIPTION
The install script will fail if the current path contains spaces.

For example, the path `/Users/my name/dprint-project` will produce the error `/bin/sh: /Users/my: No such file or directory` when executing `/Users/my name/dprint-project/node_modules/dprint/install.sh x.x.x` with `exec`. The correct command should be `"/Users/my name/dprint-project/node_modules/dprint/install.sh" x.x.x`.