### PR TITLE
feat: incremental should ensure stable formatting

### DIFF
--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -93,6 +93,12 @@ impl SyncPluginHandler<Configuration> for TestWasmPlugin {
     } else if file_text == "should_panic" {
       self.has_panicked = true;
       panic!("Test panic")
+    } else if file_text == "unstable_fmt_then_error" {
+      Ok(Some("should_error".to_string()))
+    } else if file_text == "unstable_fmt_true" {
+      Ok(Some("unstable_fmt_false".to_string()))
+    } else if file_text == "unstable_fmt_false" {
+      Ok(Some("unstable_fmt_true".to_string()))
     } else if file_text.ends_with(&config.ending) {
       Ok(None)
     } else {


### PR DESCRIPTION
This improves incremental to only cache a file if the formatting of that file is stable (meaning, it does not change when formatted again).

This will make incremental formatting slightly slower, but I think it's worth it because then nobody will get unstable files in their incremental cache.

Closes #509