### PR TITLE
docs(website): add scoop installation for Windows

### DIFF
--- a/website/install.md
+++ b/website/install.md
@@ -20,6 +20,13 @@ Install using one of the methods below.
       ```powershell
       iwr https://dprint.dev/install.ps1 -useb | iex
       ```
+
+- [Scoop](https://scoop.sh/) (Windows):
+
+      ```powershell
+      scoop install dprint
+      ```
+
 - [Homebrew](https://brew.sh/) (Mac):
 
       ```bash


### PR DESCRIPTION
`dprint` is now in the scoop main bucket.

Relates to ScoopInstaller/Main#3521