### PR TITLE
fix: improve globbing on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,6 @@ dependencies = [
  "twox-hash",
  "url",
  "wasmer",
- "wild",
  "winreg",
  "zip",
 ]
@@ -811,12 +810,6 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -2362,15 +2355,6 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
-]
-
-[[package]]
-name = "wild"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035793abb854745033f01a07647a79831eba29ec0be377205f2a25b0aa830020"
-dependencies = [
- "glob",
 ]
 
 [[package]]

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -30,7 +30,6 @@ tokio-util = { version = "0.7.0" }
 twox-hash = "1.6.3"
 url = "2.2.2"
 wasmer = "=2.3.0"
-wild = "2.0.4"
 zip = "0.6.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/dprint/src/main.rs
+++ b/crates/dprint/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
 }
 
 async fn run(runtime_handle: tokio::runtime::Handle) -> Result<()> {
-  let args = arg_parser::parse_args(wild::args().collect(), RealStdInReader)?;
+  let args = arg_parser::parse_args(std::env::args().collect(), RealStdInReader)?;
   let environment = RealEnvironment::new(RealEnvironmentOptions {
     is_verbose: args.verbose,
     is_stdout_machine_readable: args.is_stdout_machine_readable(),


### PR DESCRIPTION
Related to #552. Using wild here doesn't make sense because the arguments are provided as patterns to a glob pattern matcher. It also caused doing stuff like `dprint output-file-paths "*.ts"` to not work on Windows, so removing.