### PR TITLE
fix: plugins that were in a directory with an `@` symbol couldn't be loaded

### DIFF
--- a/crates/cli-core/src/checksums.rs
+++ b/crates/cli-core/src/checksums.rs
@@ -22,22 +22,48 @@ pub fn verify_sha256_checksum(bytes: &[u8], checksum: &str) -> Result<()> {
   }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ChecksumPathOrUrl {
   pub path_or_url: String,
   pub checksum: Option<String>,
 }
 
 pub fn parse_checksum_path_or_url(text: &str) -> ChecksumPathOrUrl {
-  // todo: this should tell whether what follows the '@' symbol is a checksum
-  match text.rfind('@') {
-    Some(index) => ChecksumPathOrUrl {
-      path_or_url: text[..index].to_string(),
-      checksum: Some(text[index + 1..].to_string()),
-    },
-    None => ChecksumPathOrUrl {
-      path_or_url: text.to_string(),
-      checksum: None,
-    },
+  if let Some(index) = text.rfind('@') {
+    let path_or_url = text[..index].to_string();
+    if path_or_url.ends_with(".wasm") || path_or_url.ends_with(".json") {
+      return ChecksumPathOrUrl {
+        path_or_url,
+        checksum: Some(text[index + 1..].to_string()),
+      };
+    }
+  }
+
+  ChecksumPathOrUrl {
+    path_or_url: text.to_string(),
+    checksum: None,
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  pub fn parses_checksum_path_or_url() {
+    assert_eq!(
+      parse_checksum_path_or_url("./test/@test/test.wasm"),
+      ChecksumPathOrUrl {
+        path_or_url: "./test/@test/test.wasm".to_string(),
+        checksum: None,
+      }
+    );
+    assert_eq!(
+      parse_checksum_path_or_url("./test/test.wasm@ca9a97de84cbb2cd60534eb72c0455f3ca8704743917569ace70499136cf5c9c"),
+      ChecksumPathOrUrl {
+        path_or_url: "./test/test.wasm".to_string(),
+        checksum: Some("ca9a97de84cbb2cd60534eb72c0455f3ca8704743917569ace70499136cf5c9c".to_string()),
+      }
+    );
   }
 }

--- a/crates/dprint/src/plugins/types.rs
+++ b/crates/dprint/src/plugins/types.rs
@@ -127,12 +127,12 @@ mod tests {
   #[test]
   fn should_not_error_multiple_at_symbols() {
     let environment = TestEnvironment::new();
-    let plugin_text = "http://dprint.dev/wasm_plugin.wasm@other@checksum";
+    let plugin_text = "http://dprint.dev/@other/wasm_plugin.wasm@checksum";
     let result = parse_plugin_source_reference(&plugin_text, &PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/")), &environment).unwrap();
     assert_eq!(
       result,
       PluginSourceReference {
-        path_source: PathSource::new_remote_from_str("http://dprint.dev/wasm_plugin.wasm@other"),
+        path_source: PathSource::new_remote_from_str("http://dprint.dev/@other/wasm_plugin.wasm"),
         checksum: Some(String::from("checksum")),
       }
     );


### PR DESCRIPTION
Closes #556