### PR TITLE
Make install_api.js work under Node 12

### DIFF
--- a/deployment/npm/install_api.js
+++ b/deployment/npm/install_api.js
@@ -198,7 +198,7 @@ function install() {
 module.exports = {
   runInstall() {
     return install().catch(err => {
-      if (typeof err?.message === "string") {
+      if (err !== undefined && typeof err.message === "string") {
         console.error(err.message);
       } else {
         console.error(err);


### PR DESCRIPTION
I know that Node 12 is EOL, but I'd like to test it for some of my projects for now (plus for benchmarking reasons). But this piece of syntax exists in dprint's postinstall script, so if I install my deps, this will error out (even though I don't actually run dprint; it's just in my devDeps).