### PR TITLE
fix(install): add support for the musl build in install script

### DIFF
--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -18,7 +18,6 @@ else
 	"Linux aarch64") target="aarch64-unknown-linux-gnu" ;;
 	*)
 		is_musl=$(ldd /bin/sh | grep 'musl' || true)
-		echo "Testing: $is_musl"
 		if [ -z "$is_musl" ]; then
 			target="x86_64-unknown-linux-gnu"
 		else

--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -17,6 +17,7 @@ else
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
 	"Linux aarch64") target="aarch64-unknown-linux-gnu" ;;
 	*)
+		echo "Running"
 		is_musl=$(ldd /bin/sh | grep 'musl')
 		echo "Testing: $is_musl"
 		if [ -z "$is_musl" ]; then
@@ -26,8 +27,6 @@ else
 		fi ;;
 	esac
 fi
-
-echo "HERE"
 
 if [ $# -eq 0 ]; then
 	dprint_uri="https://github.com/dprint/dprint/releases/latest/download/dprint-${target}.zip"

--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -17,8 +17,7 @@ else
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
 	"Linux aarch64") target="aarch64-unknown-linux-gnu" ;;
 	*)
-		echo "Running"
-		is_musl=$(ldd /bin/sh | grep 'musl')
+		is_musl=$(ldd /bin/sh | grep 'musl' || true)
 		echo "Testing: $is_musl"
 		if [ -z "$is_musl" ]; then
 			target="x86_64-unknown-linux-gnu"

--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -18,6 +18,7 @@ else
 	"Linux aarch64") target="aarch64-unknown-linux-gnu" ;;
 	*)
 		is_musl=$(ldd /bin/sh | grep 'musl')
+		echo "Testing: $is_musl"
 		if [ -z "$is_musl" ]; then
 			target="x86_64-unknown-linux-gnu"
 		else
@@ -25,6 +26,8 @@ else
 		fi ;;
 	esac
 fi
+
+echo "HERE"
 
 if [ $# -eq 0 ]; then
 	dprint_uri="https://github.com/dprint/dprint/releases/latest/download/dprint-${target}.zip"

--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -16,7 +16,13 @@ else
 	"Darwin x86_64") target="x86_64-apple-darwin" ;;
 	"Darwin arm64") target="aarch64-apple-darwin" ;;
 	"Linux aarch64") target="aarch64-unknown-linux-gnu" ;;
-	*) target="x86_64-unknown-linux-gnu" ;;
+	*)
+		is_musl=$(ldd /bin/sh | grep 'musl')
+		if [ -z "$is_musl" ]; then
+			target="x86_64-unknown-linux-gnu"
+		else
+			target="x86_64-unknown-linux-musl"
+		fi ;;
 	esac
 fi
 


### PR DESCRIPTION
This change adds a check for musl to determine whether to download the glibc or musl version of dprint on x86_64 Linux.