### PR TITLE
fix(playground): don't use TS for 3rd plugins

### DIFF
--- a/website/playground/src/plugins/getPluginUrls.ts
+++ b/website/playground/src/plugins/getPluginUrls.ts
@@ -27,6 +27,6 @@ export function getLanguageFromPluginUrl(url: string) {
     case "dockerfile":
       return language;
     default:
-      return undefined;
+      return "plaintext";
   }
 }


### PR DESCRIPTION
Added `plaintext` for fallback when using 3rd plugins.