### PR TITLE
Support wrapping indent by adding indent times

### DIFF
--- a/crates/core/src/formatting/conditions.rs
+++ b/crates/core/src/formatting/conditions.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use super::print_items::*;
 use super::*;
 
-pub fn indent_times_if_start_of_line(items: PrintItems, indent_times: u8) -> Condition {
+pub fn indent_if_start_of_line(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   if_true_or(
     "indentIfStartOfLine",
@@ -13,7 +13,7 @@ pub fn indent_times_if_start_of_line(items: PrintItems, indent_times: u8) -> Con
   )
 }
 
-pub fn indent_times_if_start_of_line_or_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
+pub fn indent_if_start_of_line_or_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   conditions::if_true_or(
     "withIndentIfStartOfLineOrStartOfLineIndented",
@@ -23,7 +23,7 @@ pub fn indent_times_if_start_of_line_or_start_of_line_indented(items: PrintItems
   )
 }
 
-pub fn with_indent_times_if_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
+pub fn with_indent_if_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   if_true_or(
     "withIndentIfStartOfLineIndented",

--- a/crates/core/src/formatting/conditions.rs
+++ b/crates/core/src/formatting/conditions.rs
@@ -3,32 +3,32 @@ use std::rc::Rc;
 use super::print_items::*;
 use super::*;
 
-pub fn indent_if_start_of_line(items: PrintItems) -> Condition {
+pub fn indent_times_if_start_of_line(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   if_true_or(
     "indentIfStartOfLine",
     condition_resolvers::is_start_of_line(),
-    ir_helpers::with_indent(rc_path.into()),
+    ir_helpers::with_indent_times(rc_path.into(), indent_times),
     rc_path.into(),
   )
 }
 
-pub fn indent_if_start_of_line_or_start_of_line_indented(items: PrintItems) -> Condition {
+pub fn indent_times_if_start_of_line_or_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   conditions::if_true_or(
     "withIndentIfStartOfLineOrStartOfLineIndented",
     condition_resolvers::is_start_of_line_or_is_start_of_line_indented(),
-    ir_helpers::with_indent(rc_path.into()),
+    ir_helpers::with_indent_times(rc_path.into(), indent_times),
     rc_path.into(),
   )
 }
 
-pub fn with_indent_if_start_of_line_indented(items: PrintItems) -> Condition {
+pub fn with_indent_times_if_start_of_line_indented(items: PrintItems, indent_times: u8) -> Condition {
   let rc_path = items.into_rc_path();
   if_true_or(
     "withIndentIfStartOfLineIndented",
     condition_resolvers::is_start_of_line_indented(),
-    ir_helpers::with_indent(rc_path.into()),
+    ir_helpers::with_indent_times(rc_path.into(), indent_times),
     rc_path.into(),
   )
 }

--- a/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
+++ b/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
@@ -56,7 +56,7 @@ impl MultiLineOptions {
       newline_at_end: true,
       multi_line_indent_times,
       with_hanging_indent: BoolOrCondition::Bool(false),
-      hanging_indent_times: hanging_indent_times,
+      hanging_indent_times,
       maintain_line_breaks: false,
     }
   }

--- a/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
+++ b/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
@@ -31,9 +31,9 @@ pub enum BoolOrCondition {
 pub struct MultiLineOptions {
   pub newline_at_start: bool,
   pub newline_at_end: bool,
-  pub indent_times: u8,
-  pub with_hanging_indent: BoolOrCondition,
   pub hanging_indent_times: u8,
+  pub multi_line_indent_times: u8,
+  pub with_hanging_indent: BoolOrCondition,
   pub maintain_line_breaks: bool,
 }
 
@@ -43,18 +43,18 @@ impl MultiLineOptions {
     MultiLineOptions {
       newline_at_start: true,
       newline_at_end: false,
-      indent_times: 1,
+      multi_line_indent_times: 1,
       with_hanging_indent: BoolOrCondition::Bool(false),
       hanging_indent_times,
       maintain_line_breaks: false,
     }
   }
 
-  pub fn surround_newlines_indented_times(indent_times: u8, hanging_indent_times: u8) -> Self {
+  pub fn surround_newlines_indented(multi_line_indent_times: u8, hanging_indent_times: u8) -> Self {
     MultiLineOptions {
       newline_at_start: true,
       newline_at_end: true,
-      indent_times,
+      multi_line_indent_times,
       with_hanging_indent: BoolOrCondition::Bool(false),
       hanging_indent_times: hanging_indent_times,
       maintain_line_breaks: false,
@@ -65,33 +65,31 @@ impl MultiLineOptions {
     MultiLineOptions {
       newline_at_start: false,
       newline_at_end: false,
-      indent_times: 0,
+      multi_line_indent_times: 0,
       with_hanging_indent: BoolOrCondition::Bool(true),
       hanging_indent_times,
       maintain_line_breaks: false,
     }
   }
 
-  pub fn same_line_no_indent() -> Self {
+  pub fn same_line_no_indent(hanging_indent_times: u8) -> Self {
     MultiLineOptions {
       newline_at_start: false,
       newline_at_end: false,
-      indent_times: 0,
+      multi_line_indent_times: 0,
       with_hanging_indent: BoolOrCondition::Bool(false),
-      // CHECK: need arg?
-      hanging_indent_times: 0,
+      hanging_indent_times,
       maintain_line_breaks: false,
     }
   }
 
-  pub fn maintain_line_breaks() -> Self {
+  pub fn maintain_line_breaks(hanging_indent_times: u8) -> Self {
     MultiLineOptions {
       newline_at_start: false,
       newline_at_end: false,
-      indent_times: 0,
+      multi_line_indent_times: 0,
       with_hanging_indent: BoolOrCondition::Bool(false),
-      // CHECK: need arg?
-      hanging_indent_times: 0,
+      hanging_indent_times,
       maintain_line_breaks: true,
     }
   }
@@ -206,11 +204,11 @@ pub fn gen_separated_values(
             if multi_line_options.newline_at_start {
               items.push_signal(Signal::NewLine);
             }
-            for _ in 0..multi_line_options.indent_times {
+            for _ in 0..multi_line_options.multi_line_indent_times {
               items.push_signal(Signal::StartIndent);
             }
             items.extend(generated_values_items.into());
-            for _ in 0..multi_line_options.indent_times {
+            for _ in 0..multi_line_options.multi_line_indent_times {
               items.push_signal(Signal::FinishIndent);
             }
             if multi_line_options.newline_at_end {
@@ -363,7 +361,7 @@ pub fn gen_separated_values(
               match &multi_line_options.with_hanging_indent {
                 BoolOrCondition::Bool(with_hanging_indent) => {
                   if *with_hanging_indent {
-                    items.push_condition(indent_times_if_start_of_line({
+                    items.push_condition(indent_if_start_of_line({
                       let mut items = PrintItems::new();
                       items.push_info(start_line_number);
                       items.push_info(start_is_start_of_line);
@@ -404,7 +402,7 @@ pub fn gen_separated_values(
             false_path: {
               let mut items = PrintItems::new();
               items.extend(single_line_separator.into()); // ex. Signal::SpaceOrNewLine
-              items.push_condition(indent_times_if_start_of_line({
+              items.push_condition(indent_if_start_of_line({
                 let mut items = PrintItems::new();
                 items.push_info(start_line_number);
                 items.push_info(start_is_start_of_line);

--- a/crates/core/src/formatting/ir_helpers/helpers.rs
+++ b/crates/core/src/formatting/ir_helpers/helpers.rs
@@ -34,7 +34,7 @@ pub fn with_queued_indent(item: PrintItems) -> PrintItems {
   items
 }
 
-pub fn with_indent_times(item: PrintItems, times: u32) -> PrintItems {
+pub fn with_indent_times(item: PrintItems, times: u8) -> PrintItems {
   if item.is_empty() {
     return item;
   }

--- a/crates/core/src/formatting/ir_helpers/helpers.rs
+++ b/crates/core/src/formatting/ir_helpers/helpers.rs
@@ -23,14 +23,18 @@ pub fn with_indent(item: PrintItems) -> PrintItems {
 }
 
 pub fn with_queued_indent(item: PrintItems) -> PrintItems {
+  with_queued_indent_times(item, 1)
+}
+
+pub fn with_queued_indent_times(item: PrintItems, indent_times: u8) -> PrintItems {
   if item.is_empty() {
     return item;
   }
 
   let mut items = PrintItems::new();
-  items.push_signal(Signal::QueueStartIndent);
+  for _ in 0..indent_times { items.push_signal(Signal::QueueStartIndent); }
   items.extend(item);
-  items.push_signal(Signal::FinishIndent);
+  for _ in 0..indent_times { items.push_signal(Signal::FinishIndent); }
   items
 }
 
@@ -142,7 +146,7 @@ fn gen_from_string_line(line: &str) -> PrintItems {
 /// Surrounds the items with newlines and indentation if its on multiple lines.
 /// Note: This currently inserts a possible newline at the start, but that might change or be made
 /// conditional in the future.
-pub fn surround_with_newlines_indented_if_multi_line(inner_items: PrintItems, indent_width: u8) -> PrintItems {
+pub fn surround_with_newlines_indented_if_multi_line(inner_items: PrintItems, indent_width: u8, indent_times: u8) -> PrintItems {
   if inner_items.is_empty() {
     return inner_items;
   }
@@ -161,7 +165,7 @@ pub fn surround_with_newlines_indented_if_multi_line(inner_items: PrintItems, in
   let mut condition = Condition::new(
     "newlineIfMultiLine",
     ConditionProperties {
-      true_path: Some(surround_with_new_lines(with_indent(inner_items.into()))),
+      true_path: Some(surround_with_new_lines(with_indent_times(inner_items.into(), indent_times))),
       false_path: Some({
         let mut items = PrintItems::new();
         items.push_condition(conditions::if_above_width(indent_width, Signal::PossibleNewLine.into()));


### PR DESCRIPTION
# Problem

We would like plugins to be able to indent multiple times in specific circumstances. For example, [implementing VSCode's wrapping indent for Typescript.](https://github.com/dprint/dprint-plugin-typescript/pull/486)

# Solution

```diff
pub struct MultiLineOptions {
  pub newline_at_start: bool,
  pub newline_at_end: bool,
+ pub hanging_indent_times: u8,
- pub indent_times: u8,
+ pub multi_line_indent_times: u8,
  pub with_hanging_indent: BoolOrCondition,
  pub maintain_line_breaks: bool,
}
```

1. Add `hanging_indent_times` to `MultiLineOptions`
2. For each of the `MultiLineOptions` helpers, add `hanging_indent_times` as an argument. For `surround_newlines_indented`, which is already given an `indent_times` in multi-line mode, I've renamed it to `multi_line_indent_times` to make it more clear.