### PR TITLE
Fix hang on install in Node 19+

### DIFF
--- a/deployment/npm/install_api.js
+++ b/deployment/npm/install_api.js
@@ -91,6 +91,13 @@ function install() {
       const proxyUrl = getProxyUrl(url);
       if (proxyUrl != null) {
         options.agent = new HttpsProxyAgent(proxyUrl);
+      } else {
+        // Node 19+ defaults keepAlive to true for `https.get`, but contains a bug
+        // that prevents the process from exiting. Work around this by explicitly
+        // disabling keepAlive.
+        //
+        // See: https://github.com/nodejs/node/issues/47228
+        options.agent = new https.Agent({ keepAlive: false });
       }
 
       https.get(url, options, function(response) {


### PR DESCRIPTION
Node 19+ contain a bug where keepAlive'd sockets prevent the process from exiting in a timely manner without an explicit `process.exit()`. This leads to `npm install` hanging for 2 minutes running `install.js`. See: https://github.com/nodejs/node/issues/47228

For now, a workaround is to disable keepAlive. Another solution might be to add an explicit `process.exit(0)` somewhere, but I was less sure of that.

I don't think this is required for the proxy agent in the previous branch; as far as I'm aware, `https-proxy-agent` does not support `keepAlive`.