### PR TITLE
install by proto toolchain manager

### DIFF
--- a/proto-plugin.toml
+++ b/proto-plugin.toml
@@ -1,0 +1,25 @@
+name = "dprint"
+type = "cli"
+
+[platform.linux]
+download-file = "dprint-{arch}-unknown-linux-{libc}.zip"
+
+[platform.macos]
+download-file = "dprint-{arch}-apple-darwin.tar.xz"
+
+[platform.windows]
+download-file = "dprint-{arch}-pc-windows-msvc.zip"
+
+[install]
+checksum-url = "https://github.com/dprint/dprint/releases/download/{version}/SHASUMS256.txt"
+download-url = "https://github.com/dprint/dprint/releases/download/{version}/{download_file}"
+
+[install.arch]
+aarch64 = "aarch64"
+x86_64 = "x86_64"
+
+[resolve]
+git-url = "https://github.com/dprint/dprint/"
+git-tag-pattern = "((\\d+)\\.(\\d+)\\.(\\d+))"
+
+


### PR DESCRIPTION
Adding this plugin schema file allows dprint to be installed by proto. This may be a bit forward but I'm loving [proto](https://moonrepo.dev/proto) in my ci and dev env as a toolchain version manager and love dprint!

The schema is dependent on the release tag and artifact naming conventions so ya, could be nice to hand it off to dprint.  Im happy to host it in a project of mine so not hurt feelings if this PR is rejected.

 
```toml
# example  .prototools with a dprint plugin

dprint = "0.36.1"

[plugins]
dprint ="schema:https://raw.githubusercontent.com/dprint/dprint/main/proto-plugin.toml"
```