### PR TITLE
docs: update wasm plugin example

### DIFF
--- a/docs/wasm-plugin-development.md
+++ b/docs/wasm-plugin-development.md
@@ -10,7 +10,7 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
 
    ```toml
    dprint-core = { version = "...", features = ["wasm"] }
-   serde = { version = "1.0.117", features = ["derive"] }
+   serde = { version = "1.0", features = ["derive"] }
    serde_json = { version = "1.0", features = ["preserve_order"] }
    ```
 
@@ -41,25 +41,25 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
    use dprint_core::configuration::get_unknown_property_diagnostics;
    use dprint_core::configuration::get_value;
    use dprint_core::configuration::ConfigKeyMap;
-   use dprint_core::configuration::ConfigurationDiagnostic;
    use dprint_core::configuration::GlobalConfiguration;
    use dprint_core::configuration::ResolveConfigurationResult;
    use dprint_core::generate_plugin_code;
-   use dprint_core::plugins::PluginHandler;
+   use dprint_core::plugins::SyncPluginHandler;
    use dprint_core::plugins::PluginInfo;
+   use std::path::Path;
 
    use crate::configuration::Configuration; // import the Configuration from above
 
    pub struct MyPluginHandler {}
 
    impl MyPluginHandler {
-     fn new() -> Self {
+     const fn new() -> Self {
        MyPluginHandler {}
      }
    }
 
-   impl PluginHandler<Configuration> for MyPluginHandler {
-     fn get_plugin_info(&mut self) -> PluginInfo {
+   impl SyncPluginHandler<Configuration> for MyPluginHandler {
+     fn plugin_info(&mut self) -> PluginInfo {
        PluginInfo {
          name: env!("CARGO_PKG_NAME").to_string(),
          version: env!("CARGO_PKG_VERSION").to_string(),
@@ -68,10 +68,11 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
          file_names: vec![],
          help_url: "".to_string(),          // fill this in
          config_schema_url: "".to_string(), // leave this empty for now
+         update_url: None,                  // leave this empty for now
        }
      }
 
-     fn get_license_text(&mut self) -> String {
+     fn license_text(&mut self) -> String {
        "License text goes here.".to_string()
      }
 
@@ -84,18 +85,18 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
        diagnostics.extend(get_unknown_property_diagnostics(config));
 
        ResolveConfigurationResult {
-         config: Configuration { ending, line_width },
+         config: Configuration { line_width },
          diagnostics,
        }
      }
 
-     fn format_text(
+     fn format(
        &mut self,
        file_path: &Path,
        file_text: &str,
        config: &Configuration,
-       mut format_with_host: impl FnMut(&Path, String, &ConfigKeyMap) -> Result<String>,
-     ) -> Result<String> {
+       mut format_with_host: impl FnMut(&Path, String, &ConfigKeyMap) -> Result<Option<String>>,
+     ) -> Result<Option<String>> {
        // format here
      }
    }

--- a/docs/wasm-plugin-development.md
+++ b/docs/wasm-plugin-development.md
@@ -44,8 +44,8 @@ Implementing a Wasm plugin is easier if you're using Rust as there are several h
    use dprint_core::configuration::GlobalConfiguration;
    use dprint_core::configuration::ResolveConfigurationResult;
    use dprint_core::generate_plugin_code;
+   use·dprint_core::plugins::PluginInfo;
    use dprint_core::plugins::SyncPluginHandler;
-   use dprint_core::plugins::PluginInfo;
    use std::path::Path;
 
    use crate::configuration::Configuration; // import the Configuration from above


### PR DESCRIPTION
It:
- de-pins the serde patch version
- Uses the `sync` plugin handler