### PR TITLE
feat: add `allow-no-files` flag and config option

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -86,7 +86,7 @@ pub async fn output_format_times<TEnvironment: Environment>(
   let config = resolve_config_from_args(args, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver).await?;
   let file_paths = get_and_resolve_file_paths(&config, &cmd.patterns, environment).await?;
-  let file_paths_by_plugin = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
+  let file_paths_by_plugin = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path, false)?;
   plugin_pools.set_plugins(plugins, &config.base_path)?;
   let durations: Arc<Mutex<Vec<(PathBuf, u128)>>> = Arc::new(Mutex::new(Vec::new()));
 
@@ -119,8 +119,9 @@ pub async fn check<TEnvironment: Environment>(
 ) -> Result<()> {
   let config = resolve_config_from_args(args, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver).await?;
+  let allow_no_files = cmd.allow_no_files || config.allow_no_files.unwrap_or(false);
   let file_paths = get_and_resolve_file_paths(&config, &cmd.patterns, environment).await?;
-  let file_paths_by_plugin = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
+  let file_paths_by_plugin = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path, allow_no_files)?;
   plugin_pools.set_plugins(plugins, &config.base_path)?;
 
   let incremental_file = get_incremental_file(cmd.incremental, &config, &plugin_pools, environment);
@@ -181,8 +182,9 @@ pub async fn format<TEnvironment: Environment>(
 ) -> Result<()> {
   let config = resolve_config_from_args(args, environment)?;
   let plugins = resolve_plugins_and_err_if_empty(args, &config, environment, plugin_resolver).await?;
+  let allow_no_files = cmd.allow_no_files || config.allow_no_files.unwrap_or(false);
   let file_paths = get_and_resolve_file_paths(&config, &cmd.patterns, environment).await?;
-  let file_paths_by_plugins = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path)?;
+  let file_paths_by_plugins = get_file_paths_by_plugins_and_err_if_empty(&plugins, file_paths, &config.base_path, allow_no_files)?;
   plugin_pools.set_plugins(plugins, &config.base_path)?;
 
   let incremental_file = get_incremental_file(cmd.incremental, &config, &plugin_pools, environment);

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -34,9 +34,10 @@ pub fn get_file_paths_by_plugins_and_err_if_empty(
   plugins: &[Box<dyn Plugin>],
   file_paths: Vec<PathBuf>,
   config_base_path: &CanonicalizedPathBuf,
+  allow_no_files: bool,
 ) -> Result<HashMap<PluginNames, Vec<PathBuf>>> {
   let result = get_file_paths_by_plugins(plugins, file_paths, config_base_path)?;
-  if result.is_empty() {
+  if !allow_no_files && result.is_empty() {
     bail!("No files found to format with the specified plugins. You may want to try using `dprint output-file-paths` to see which files it's finding.");
   }
   Ok(result)

--- a/website/src/assets/schemas/v0.json
+++ b/website/src/assets/schemas/v0.json
@@ -77,6 +77,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "allow_no_files": {
+      "description": "Do not exit with error when passed files are excluded.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": {


### PR DESCRIPTION
This option allows to exit `drpint` process with code `0` when there is some file passed to input and this file is also added to `excludes` property or cli arg.

For example, let's take `tsconfig.json`. I can mark it as excluded, but when my pre-commit hook will pass this file to `dprint fmt`, I got an error `No files found to format with the specified plugins`. But when I pass `--allow-no-files` or set this option in config, I can ran `dprint fmt` whout any issue.