### PR TITLE
feat: Add shell completions generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +665,7 @@ version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "console_static_text",
  "crossterm",
  "dirs",

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -13,7 +13,7 @@ description = "Binary for dprint code formatter—a pluggable and configurable c
 [dependencies]
 anyhow = "1.0.69"
 clap = "4.3.8"
-clap_complete = { version = "4.3.1", optional = true }
+clap_complete = "4.3.1"
 console_static_text = "0.7.1"
 # don't upgrade to 0.26 https://github.com/crossterm-rs/crossterm/issues/752
 crossterm = "0.25.0" # manually retest everything when bumping this crate
@@ -51,7 +51,3 @@ winreg = "0.10.1"
 [dev-dependencies]
 path-clean = "0.1.0"
 pretty_assertions = "1.3.0"
-
-[features]
-default = ["completions_generator"]
-completions_generator = ["dep:clap_complete"]

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -12,7 +12,8 @@ description = "Binary for dprint code formatter—a pluggable and configurable c
 
 [dependencies]
 anyhow = "1.0.69"
-clap = "4.1.4"
+clap = "4.3.8"
+clap_complete = { version = "4.3.1", optional = true }
 console_static_text = "0.7.1"
 # don't upgrade to 0.26 https://github.com/crossterm-rs/crossterm/issues/752
 crossterm = "0.25.0" # manually retest everything when bumping this crate
@@ -50,3 +51,7 @@ winreg = "0.10.1"
 [dev-dependencies]
 path-clean = "0.1.0"
 pretty_assertions = "1.3.0"
+
+[features]
+default = ["completions_generator"]
+completions_generator = ["dep:clap_complete"]

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -56,6 +56,8 @@ pub enum SubCommand {
   EditorInfo,
   EditorService(EditorServiceSubCommand),
   StdInFmt(StdInFmtSubCommand),
+  #[cfg(feature = "completions_generator")]
+  GenerateCompletions,
   Upgrade,
   #[cfg(target_os = "windows")]
   Hidden(HiddenSubCommand),
@@ -195,6 +197,19 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
     ("editor-service", matches) => SubCommand::EditorService(EditorServiceSubCommand {
       parent_pid: matches.get_one::<String>("parent-pid").and_then(|v| v.parse::<u32>().ok()).unwrap(),
     }),
+    #[cfg(feature = "completions_generator")]
+    ("generate-completions", matches) => {
+      let mut cmd = create_cli_parser(false);
+
+      clap_complete::generate(
+        matches.get_one::<clap_complete::Shell>("shell").unwrap().to_owned(),
+        &mut cmd,
+        "dprint",
+        &mut std::io::stdout(),
+      );
+
+      SubCommand::GenerateCompletions
+    }
     ("upgrade", _) => SubCommand::Upgrade,
     #[cfg(target_os = "windows")]
     ("hidden", matches) => SubCommand::Hidden(match matches.subcommand().unwrap() {
@@ -271,18 +286,18 @@ fn validate_plugin_args_when_no_files(plugins: &[String]) -> Result<()> {
 }
 
 fn create_cli_parser(is_outputting_main_help: bool) -> clap::Command {
-  use clap::Arg;
-  use clap::Command;
-  let app = Command::new("dprint");
+  use clap::{Arg, Command};
+
+  let mut app = Command::new("dprint");
 
   // hack to get this to display the way I want
-  let app = if is_outputting_main_help {
+  app = if is_outputting_main_help {
     app.disable_help_subcommand(true).disable_version_flag(true).disable_help_flag(true)
   } else {
     app.subcommand_required(true)
   };
 
-  app
+  app = app
     .bin_name("dprint")
     .version(env!("CARGO_PKG_VERSION"))
     .author("Copyright 2020-2023 by David Sherret")
@@ -460,27 +475,27 @@ EXAMPLES:
         .help("Prints additional diagnostic information.")
         .global(true)
         .num_args(0)
-    )
-    .subcommand(
-      Command::new("hidden")
-        .hide(true)
-        .subcommand(
-          Command::new("windows-install")
-            .arg(
-              Arg::new("install-path")
-                .num_args(1)
-                .required(true)
-            )
-        )
-        .subcommand(
-          Command::new("windows-uninstall")
-            .arg(
-              Arg::new("install-path")
-                .num_args(1)
-                .required(true)
-            )
-        )
-    )
+    );
+
+  #[cfg(target_os = "windows")]
+  let app = app.subcommand(
+    Command::new("hidden")
+      .hide(true)
+      .subcommand(Command::new("windows-install").arg(Arg::new("install-path").num_args(1).required(true)))
+      .subcommand(Command::new("windows-uninstall").arg(Arg::new("install-path").num_args(1).required(true))),
+  );
+
+  #[cfg(feature = "completions_generator")]
+  let app = app.subcommand(
+    Command::new("generate-completions").about("Generate shell completions script for dprint").arg(
+      Arg::new("shell")
+        .action(clap::ArgAction::Set)
+        .value_parser(clap::value_parser!(clap_complete::Shell))
+        .default_value("bash"),
+    ),
+  );
+
+  app
 }
 
 trait ClapExtensions {

--- a/crates/dprint/src/main.rs
+++ b/crates/dprint/src/main.rs
@@ -40,6 +40,12 @@ fn main() {
 
 async fn run(runtime_handle: tokio::runtime::Handle) -> Result<(), AppError> {
   let args = arg_parser::parse_args(std::env::args().collect(), RealStdInReader)?;
+
+  #[cfg(feature = "completions_generator")]
+  if let arg_parser::SubCommand::GenerateCompletions = args.sub_command {
+    std::process::exit(0);
+  }
+
   let environment = RealEnvironment::new(RealEnvironmentOptions {
     is_verbose: args.verbose,
     is_stdout_machine_readable: args.is_stdout_machine_readable(),

--- a/crates/dprint/src/main.rs
+++ b/crates/dprint/src/main.rs
@@ -41,11 +41,6 @@ fn main() {
 async fn run(runtime_handle: tokio::runtime::Handle) -> Result<(), AppError> {
   let args = arg_parser::parse_args(std::env::args().collect(), RealStdInReader)?;
 
-  #[cfg(feature = "completions_generator")]
-  if let arg_parser::SubCommand::GenerateCompletions = args.sub_command {
-    std::process::exit(0);
-  }
-
   let environment = RealEnvironment::new(RealEnvironmentOptions {
     is_verbose: args.verbose,
     is_stdout_machine_readable: args.is_stdout_machine_readable(),

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -132,6 +132,8 @@ pub async fn run_cli<TEnvironment: Environment>(
     SubCommand::OutputFormatTimes(cmd) => commands::output_format_times(cmd, args, environment, plugin_resolver, plugin_pools).await,
     SubCommand::Check(cmd) => commands::check(cmd, args, environment, plugin_resolver, plugin_pools).await,
     SubCommand::Fmt(cmd) => commands::format(cmd, args, environment, plugin_resolver, plugin_pools).await,
+    #[cfg(feature = "completions_generator")]
+    SubCommand::GenerateCompletions => unreachable!(),
     SubCommand::Upgrade => commands::upgrade(environment).await,
     #[cfg(target_os = "windows")]
     SubCommand::Hidden(hidden_command) => match hidden_command {

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use thiserror::Error;
 
-use crate::arg_parser::ParseArgsError;
+use crate::arg_parser::{create_cli_parser, ParseArgsError};
 use crate::commands::CheckError;
 use crate::configuration::ResolveConfigFromArgsError;
 use crate::environment::Environment;
@@ -132,8 +132,13 @@ pub async fn run_cli<TEnvironment: Environment>(
     SubCommand::OutputFormatTimes(cmd) => commands::output_format_times(cmd, args, environment, plugin_resolver, plugin_pools).await,
     SubCommand::Check(cmd) => commands::check(cmd, args, environment, plugin_resolver, plugin_pools).await,
     SubCommand::Fmt(cmd) => commands::format(cmd, args, environment, plugin_resolver, plugin_pools).await,
-    #[cfg(feature = "completions_generator")]
-    SubCommand::GenerateCompletions => unreachable!(),
+    SubCommand::Completions(shell) => {
+      let mut cmd = create_cli_parser(false);
+
+      clap_complete::generate(shell.to_owned(), &mut cmd, "dprint", &mut std::io::stdout());
+
+      Ok(())
+    }
     SubCommand::Upgrade => commands::upgrade(environment).await,
     #[cfg(target_os = "windows")]
     SubCommand::Hidden(hidden_command) => match hidden_command {

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -210,6 +210,7 @@ SUBCOMMANDS:
   clear-cache             Deletes the plugin cache directory.
   upgrade                 Upgrades the dprint executable.
   license                 Outputs the software license.
+  generate-completions    Generate shell completions script for dprint
 
 More details at `dprint help <SUBCOMMAND>`
 

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -209,8 +209,8 @@ SUBCOMMANDS:
   output-format-times     Prints the amount of time it takes to format each file. Use this for debugging.
   clear-cache             Deletes the plugin cache directory.
   upgrade                 Upgrades the dprint executable.
+  completions             Generate shell completions script for dprint
   license                 Outputs the software license.
-  generate-completions    Generate shell completions script for dprint
 
 More details at `dprint help <SUBCOMMAND>`
 


### PR DESCRIPTION
This should add support for generating [tab completion](https://en.wikipedia.org/wiki/Command-line_completion) scripts in run-time using `clap_complete`.

---

It could be done in compile-time, but first we need to isolate the `create_cli_parser` function in a separate file so we can `include!()` it in the `build.rs` file without any complexity.