### PR TITLE
fix: statically link the c runtime on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# statically link the c runtime https://github.com/rust-lang/rust/issues/100874
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Closes #593