### PR TITLE
fix: handle multiple processes writing to Wasm cache at the same time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "parking_lot",
  "path-clean",
  "pretty_assertions",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -26,6 +26,7 @@ indexmap = { version = "1.9.2", features = ["serde-1"] }
 jsonc-parser = { version = "0.21.0" }
 once_cell = "1.17.1"
 parking_lot = "0.12.1"
+rand = "0.8.5"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sha2 = "0.10.6"

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -92,10 +92,6 @@ impl Environment for RealEnvironment {
     }
   }
 
-  fn write_file(&self, file_path: impl AsRef<Path>, file_text: &str) -> Result<()> {
-    self.write_file_bytes(file_path, file_text.as_bytes())
-  }
-
   fn write_file_bytes(&self, file_path: impl AsRef<Path>, bytes: &[u8]) -> Result<()> {
     log_verbose!(self, "Writing file: {}", file_path.as_ref().display());
     match fs::write(&file_path, bytes) {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -321,10 +321,6 @@ impl Environment for TestEnvironment {
     }
   }
 
-  fn write_file(&self, file_path: impl AsRef<Path>, file_text: &str) -> Result<()> {
-    self.write_file_bytes(file_path, file_text.as_bytes())
-  }
-
   fn write_file_bytes(&self, file_path: impl AsRef<Path>, bytes: &[u8]) -> Result<()> {
     let file_path = self.clean_path(file_path);
     let mut files = self.files.lock();

--- a/crates/dprint/src/incremental/incremental_file.rs
+++ b/crates/dprint/src/incremental/incremental_file.rs
@@ -108,7 +108,7 @@ fn write_incremental(file_path: impl AsRef<Path>, file_data: &IncrementalFileDat
       return;
     }
   };
-  if let Err(err) = environment.write_file(&file_path, &json_text) {
+  if let Err(err) = environment.atomic_write_file_bytes(&file_path, json_text.as_bytes()) {
     environment.log_stderr(&format!("Error saving incremental file {}: {}", file_path.as_ref().display(), err));
   }
 }

--- a/crates/dprint/src/plugins/cache_manifest.rs
+++ b/crates/dprint/src/plugins/cache_manifest.rs
@@ -114,7 +114,7 @@ pub fn read_manifest(environment: &impl Environment) -> PluginCacheManifest {
 pub fn write_manifest(manifest: &PluginCacheManifest, environment: &impl Environment) -> Result<()> {
   let file_path = get_manifest_file_path(environment);
   let serialized_manifest = serde_json::to_string(&manifest)?;
-  environment.write_file(file_path, &serialized_manifest)
+  environment.atomic_write_file_bytes(file_path, serialized_manifest.as_bytes())
 }
 
 fn get_manifest_file_path(environment: &impl Environment) -> PathBuf {

--- a/crates/dprint/src/plugins/implementations/wasm/setup_wasm_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/setup_wasm_plugin.rs
@@ -26,7 +26,7 @@ pub fn setup_wasm_plugin<TEnvironment: Environment>(url_or_file_path: &PathSourc
   let plugin_info = compile_result.plugin_info;
   let plugin_cache_file_path = get_file_path_from_plugin_info(&plugin_info, environment);
   environment.mk_dir_all(plugin_cache_file_path.parent().unwrap())?;
-  environment.write_file_bytes(&plugin_cache_file_path, &compile_result.bytes)?;
+  environment.atomic_write_file_bytes(&plugin_cache_file_path, &compile_result.bytes)?;
 
   Ok(SetupPluginResult {
     plugin_info,


### PR DESCRIPTION
Do an "atomic write" for more operations where it writes to a temporary file then renames.