### PR TITLE
fix(development): show panic message when spec panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-development"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "console",

--- a/crates/development/Cargo.toml
+++ b/crates/development/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-development"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/crates/development/src/spec_helpers.rs
+++ b/crates/development/src/spec_helpers.rs
@@ -70,8 +70,11 @@ pub fn run_specs(
     let file_path_buf = PathBuf::from(&spec.file_name);
     let format = |file_text: &str| {
       let result = catch_unwind(AssertUnwindSafe(|| format_text(&file_path_buf, file_text, &spec.config)));
-      let result = result.unwrap_or_else(|err| panic!("Panic in spec '{}' in {}.\n\n{:?}", spec.message, file_path.display(), err));
-      result.unwrap_or_else(|err| panic!("Could not parse spec '{}' in {}. Message: {:#}", spec.message, file_path.display(), err,))
+      if result.is_err() {
+        eprintln!("Panic in spec '{}' in {}\n", spec.message, file_path.display());
+      }
+      let result = result.unwrap();
+      result.unwrap_or_else(|err| panic!("Could not parse spec '{}' in {}\nMessage: {:#}", spec.message, file_path.display(), err,))
     };
 
     if spec.is_trace {


### PR DESCRIPTION
I'm not sure why it wasn't formatting the panic message. This fixes it by unwrapping.