### PR TITLE
fix: resolve 'system' newline global config in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.63.3"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.63.3"
+version = "0.64.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -18,7 +18,7 @@ console_static_text = "0.7.1"
 # don't upgrade to 0.26 https://github.com/crossterm-rs/crossterm/issues/752
 crossterm = "0.25.0" # manually retest everything when bumping this crate
 dirs = "4.0.0"
-dprint-core = { path = "../core", version = "0.63.3", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "0.64.0", features = ["process", "wasm"] }
 dunce = "1.0.3"
 fs3 = "0.5.0"
 ignore = "0.4.20"

--- a/crates/dprint/src/configuration/get_global_config.rs
+++ b/crates/dprint/src/configuration/get_global_config.rs
@@ -89,6 +89,26 @@ mod tests {
   }
 
   #[test]
+  fn should_get_global_for_system_new_line_kind() {
+    let mut config_map = ConfigMap::new();
+    config_map.insert(String::from("newLineKind"), ConfigMapValue::from_str("system"));
+    assert_result(
+      config_map,
+      GlobalConfiguration {
+        line_width: None,
+        use_tabs: None,
+        indent_width: None,
+        new_line_kind: Some(if cfg!(windows) {
+          NewLineKind::CarriageReturnLineFeed
+        } else {
+          NewLineKind::LineFeed
+        }),
+      },
+      &[],
+    );
+  }
+
+  #[test]
   fn should_diagnostic_on_unexpected_object_properties() {
     let mut config_map = ConfigMap::new();
     config_map.insert(String::from("test"), ConfigMapValue::PluginConfig(Default::default()));


### PR DESCRIPTION
Note: In order for this to work it requires dprint 0.43.0 and for the newline kind configuration to be set at the top level.

The reason the bug occurs is because the plugins get compiled to wasm and so they have no concept of operating system at that point. The fix is to resolve this in the CLI and then passed the resolved global config to the plugins. This also means I will be removing the "system" config from the wasm plugins gradually in the future.

All that said, I highly recommend that Windows devs just use LF newlines. I work on Windows and that's what I do and it's absolutely fine. It leads to less complexity. Just make sure your git config is to check-out newlines "as-is" instead of having it mess with stuff by converting newlines.

Related https://github.com/dprint/dprint-plugin-typescript/issues/499

Closes #776