### PR TITLE
feat: change CLI file patterns to be intersection with the config and excludes to be a union

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -607,7 +607,7 @@ impl ClapExtensions for clap::Command {
       )
       .arg(
         Arg::new("excludes-override")
-          .long("excludes")
+          .long("excludes-override")
           .value_name("patterns")
           .help("List of file patterns or directories in quotes to exclude when formatting. This overrides what is specified in the config file.")
           .num_args(1..),

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -182,8 +182,10 @@ pub async fn update_plugins_config_file<TEnvironment: Environment>(
   }
 
   let file_pattern_args = FilePatternArgs {
-    file_patterns: Vec::new(),
-    exclude_file_patterns: Vec::new(),
+    include_patterns: Vec::new(),
+    include_pattern_overrides: None,
+    exclude_patterns: Vec::new(),
+    exclude_pattern_overrides: None,
     allow_node_modules: false,
   };
   let scopes = resolve_plugins_scope_and_paths(args, &file_pattern_args, environment, plugin_resolver).await?;

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -1785,7 +1785,6 @@ mod test {
 
   #[test]
   fn should_format_for_stdin_with_absolute_paths() {
-    // it should not output anything when downloading plugins
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
       .with_default_config(|c| {
         c.add_includes("/src/**.*").add_remote_wasm_plugin();

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -1098,7 +1098,7 @@ mod test {
   #[cfg(target_os = "windows")]
   #[test]
   fn should_format_absolute_paths_on_windows() {
-    let file_path = "D:\\test\\other\\file1.txt"; // needs to be in the base directory
+    let file_path = "D:\\test\\other\\asdf\\file1.txt"; // needs to be in the base directory
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
       .with_local_config("D:\\test\\other\\dprint.json", |c| {
         c.add_includes("asdf/**/*.txt").add_remote_wasm_plugin();
@@ -1115,10 +1115,10 @@ mod test {
     assert_eq!(environment.read_file(&file_path).unwrap(), "text1_formatted");
   }
 
-  #[cfg(target_os = "linux")]
+  #[cfg(unix)]
   #[test]
-  fn should_format_absolute_paths_on_linux() {
-    let file_path = "/test/other/file1.txt"; // needs to be in the base directory
+  fn should_format_absolute_paths_on_unix() {
+    let file_path = "/test/other/asdf/file1.txt"; // needs to be in the base directory
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
       .with_local_config("/test/other/dprint.json", |c| {
         c.add_includes("asdf/**/*.txt").add_remote_wasm_plugin();
@@ -1128,7 +1128,7 @@ mod test {
       .initialize()
       .build();
 
-    run_test_cli(vec!["fmt", "--", "/test/other/file1.txt"], &environment).unwrap();
+    run_test_cli(vec!["fmt", "--", "/test/other/asdf/file1.txt"], &environment).unwrap();
 
     assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
     assert_eq!(environment.read_file(&file_path).unwrap(), "text1_formatted");

--- a/crates/dprint/src/commands/general.rs
+++ b/crates/dprint/src/commands/general.rs
@@ -275,7 +275,6 @@ mod test {
       .add_remote_wasm_plugin()
       .with_default_config(|config_file| {
         config_file
-          .add_includes("**/*.txt")
           .add_config_section(
             "test-plugin",
             r#"{

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -15,7 +15,6 @@ use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::plugins::parse_plugin_source_reference;
 use crate::plugins::PluginSourceReference;
-use crate::utils::is_negated_glob;
 use crate::utils::resolve_url_or_file_path;
 use crate::utils::PathSource;
 use crate::utils::PluginKind;
@@ -125,12 +124,8 @@ pub async fn resolve_config_from_path<TEnvironment: Environment>(
   }
   // =========
 
-  let mut includes = take_array_from_config_map(&mut config_map, "includes")?;
-  let mut excludes = take_array_from_config_map(&mut config_map, "excludes")?;
-
-  // Move the negated includes to the excludes so that when someone provides
-  // includes on the command line, then it will still ignore these
-  move_negated_includes_to_excludes(&mut includes, &mut excludes);
+  let includes = take_array_from_config_map(&mut config_map, "includes")?;
+  let excludes = take_array_from_config_map(&mut config_map, "excludes")?;
 
   let incremental = take_bool_from_config_map(&mut config_map, "incremental")?;
   config_map.remove("projectType"); // this was an old config property that's no longer used
@@ -147,24 +142,6 @@ pub async fn resolve_config_from_path<TEnvironment: Environment>(
 
   // resolve extends
   Ok(resolve_extends(resolved_config, extends, base_source, environment.clone()).await?)
-}
-
-fn move_negated_includes_to_excludes(includes: &mut Option<Vec<String>>, excludes: &mut Option<Vec<String>>) {
-  let Some(includes) = includes else {
-    return;
-  };
-  for i in (0..includes.len()).rev() {
-    if is_negated_glob(&includes[i]) {
-      let value = includes.remove(i);
-      if excludes.is_none() {
-        *excludes = Some(Vec::new());
-      }
-      // Make negated includes to have a higher priority than excludes.
-      // This means when checking if something is not matched, it will
-      // look at these first.
-      excludes.as_mut().unwrap().insert(0, value);
-    }
-  }
 }
 
 fn resolve_extends<TEnvironment: Environment>(

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -91,11 +91,11 @@ pub async fn get_and_resolve_file_paths<'a>(
 ) -> Result<GlobOutput> {
   let cwd = environment.cwd();
   let mut file_patterns = get_all_file_patterns(config, args, &cwd);
-  if file_patterns.includes.is_none() {
+  if file_patterns.config_includes.is_none() {
     // If no includes patterns were specified, derive one from the list of plugins
     // as this is a massive performance improvement, because it collects less file
     // paths to examine and match to plugins later.
-    file_patterns.includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), cwd.clone()));
+    file_patterns.config_includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), cwd.clone()));
   }
   get_and_resolve_file_patterns(config, file_patterns, environment).await
 }

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -8,7 +8,6 @@ use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::utils::is_absolute_pattern;
 use crate::utils::is_negated_glob;
-use crate::utils::make_absolute;
 use crate::utils::GlobMatcher;
 use crate::utils::GlobMatcherOptions;
 use crate::utils::GlobPattern;
@@ -50,8 +49,10 @@ pub fn get_patterns_as_glob_matcher(patterns: &[String], config_base_path: &Cano
   let (includes, excludes) = patterns.into_iter().partition(|p| !is_negated_glob(p));
   GlobMatcher::new(
     GlobPatterns {
-      includes: Some(GlobPattern::new_vec(includes, config_base_path.clone())),
-      excludes: GlobPattern::new_vec(excludes, config_base_path.clone()),
+      arg_includes: None,
+      config_includes: Some(GlobPattern::new_vec(includes, config_base_path.clone())),
+      arg_excludes: None,
+      config_excludes: GlobPattern::new_vec(excludes, config_base_path.clone()),
     },
     &GlobMatcherOptions {
       case_sensitive: !cfg!(windows),
@@ -62,55 +63,59 @@ pub fn get_patterns_as_glob_matcher(patterns: &[String], config_base_path: &Cano
 
 pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> GlobPatterns {
   GlobPatterns {
-    includes: get_include_file_patterns(config, args, cwd),
-    excludes: get_exclude_file_patterns(config, args, cwd),
+    config_includes: get_config_includes_file_patterns(config, args, cwd),
+    arg_includes: if args.include_patterns.is_empty() {
+      None
+    } else {
+      // resolve CLI patterns based on the current working directory
+      Some(GlobPattern::new_vec(
+        args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(),
+        cwd.clone(),
+      ))
+    },
+    config_excludes: get_config_exclude_file_patterns(config, args, cwd),
+    arg_excludes: if args.exclude_patterns.is_empty() {
+      None
+    } else {
+      // resolve CLI patterns based on the current working directory
+      Some(
+        GlobPattern::new_vec(args.exclude_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
+          .into_iter()
+          .map(|pattern| pattern.into_negated())
+          .collect(),
+      )
+    },
   }
 }
 
-fn get_include_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Option<Vec<GlobPattern>> {
+fn get_config_includes_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Option<Vec<GlobPattern>> {
   let mut file_patterns = Vec::new();
 
-  file_patterns.extend(if args.file_patterns.is_empty() {
-    GlobPattern::new_vec(process_config_patterns(config.includes.as_ref()?).collect(), config.base_path.clone())
-  } else {
-    let config_excludes_in_includes = config
-      .includes
-      .as_ref()
-      .map(|c| {
-        c.iter()
-          .filter(|p| is_negated_glob(p))
-          .map(|p| make_absolute(p, &config.base_path))
-          .collect::<Vec<_>>()
-      })
-      .unwrap_or_default();
-    // resolve CLI patterns based on the current working directory
-    GlobPattern::new_vec(
-      args
-        .file_patterns
-        .iter()
-        .map(|p| process_cli_pattern(p, cwd))
-        .chain(config_excludes_in_includes)
-        .collect(),
-      cwd.clone(),
-    )
+  file_patterns.extend(match &args.include_pattern_overrides {
+    Some(includes_overrides) => {
+      // resolve CLI patterns based on the current working directory
+      GlobPattern::new_vec(includes_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
+    }
+    None => GlobPattern::new_vec(process_config_patterns(config.includes.as_ref()?).collect(), config.base_path.clone()),
   });
 
   Some(file_patterns)
 }
 
-fn get_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Vec<GlobPattern> {
+fn get_config_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Vec<GlobPattern> {
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(
-    if args.exclude_file_patterns.is_empty() {
-      if let Some(excludes) = &config.excludes {
-        GlobPattern::new_vec(process_config_patterns(excludes).collect(), config.base_path.clone())
-      } else {
-        Vec::new()
+    match &args.exclude_pattern_overrides {
+      Some(exclude_overrides) => {
+        // resolve CLI patterns based on the current working directory
+        GlobPattern::new_vec(exclude_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
       }
-    } else {
-      // resolve CLI patterns based on the current working directory
-      GlobPattern::new_vec(args.exclude_file_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
+      None => config
+        .excludes
+        .as_ref()
+        .map(|excludes| GlobPattern::new_vec(process_config_patterns(excludes).collect(), config.base_path.clone()))
+        .unwrap_or_default(),
     }
     .into_iter()
     .map(|pattern| pattern.into_negated()),
@@ -119,10 +124,10 @@ fn get_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cw
   if !args.allow_node_modules {
     // glob walker will not search the children of a directory once it's ignored like this
     let node_modules_exclude = String::from("!**/node_modules");
-    let exclude_node_module_patterns = vec![
-      GlobPattern::new(node_modules_exclude.clone(), cwd.clone()),
-      GlobPattern::new(node_modules_exclude, config.base_path.clone()),
-    ];
+    let mut exclude_node_module_patterns = vec![GlobPattern::new(node_modules_exclude.clone(), cwd.clone())];
+    if !cwd.starts_with(&config.base_path) {
+      exclude_node_module_patterns.push(GlobPattern::new(node_modules_exclude, config.base_path.clone()));
+    }
     for node_modules_exclude in exclude_node_module_patterns {
       if !file_patterns.contains(&node_modules_exclude) {
         file_patterns.push(node_modules_exclude);

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -372,7 +372,7 @@ impl<TEnvironment: Environment> PluginsScopeAndPathsCollection<TEnvironment> {
 
     // ensure we found some files
     if !cli_args.sub_command.allow_no_files() {
-      let has_cli_file_patterns = cli_args.sub_command.file_patterns().map(|p| !p.file_patterns.is_empty()).unwrap_or(false);
+      let has_cli_file_patterns = cli_args.sub_command.file_patterns().map(|p| !p.include_patterns.is_empty()).unwrap_or(false);
       // when the user specifies a pattern on the command line, just ensure that one scope matched
       if has_cli_file_patterns {
         let all_empty = self.iter().all(|s| s.file_paths_by_plugins.is_empty());

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -32,9 +32,15 @@ pub struct GlobOptions {
 }
 
 pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOutput> {
-  if opts.file_patterns.includes.is_some() && opts.file_patterns.includes.as_ref().unwrap().iter().all(|p| p.is_negated()) {
+  if opts
+    .file_patterns
+    .arg_includes
+    .as_ref()
+    .map(|p| p.iter().all(|p| p.is_negated()))
+    .unwrap_or(false)
+  {
     // performance improvement (see issue #379)
-    log_debug!(environment, "Skipping negated globs: {:?}", opts.file_patterns.includes);
+    log_debug!(environment, "Skipping negated globs: {:?}", opts.file_patterns.arg_includes);
     return Ok(Default::default());
   }
 
@@ -358,8 +364,10 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
-          excludes: vec![GlobPattern::new("**/ignore".to_string(), root_dir)],
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
+          arg_excludes: None,
+          config_excludes: vec![GlobPattern::new("**/ignore".to_string(), root_dir)],
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },
@@ -381,8 +389,10 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
-          excludes: Vec::new(),
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },
@@ -402,8 +412,10 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
-          excludes: Vec::new(),
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },
@@ -425,11 +437,13 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![
+          arg_includes: None,
+          config_includes: Some(vec![
             GlobPattern::new("!**/*.*".to_string(), root_dir.clone()),
             GlobPattern::new("**/a.txt".to_string(), root_dir),
           ]),
-          excludes: Vec::new(),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },
@@ -453,12 +467,14 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![
+          arg_includes: None,
+          config_includes: Some(vec![
             GlobPattern::new("**/*.json".to_string(), root_dir.clone()),
             GlobPattern::new("!**/*.json".to_string(), root_dir.clone()),
             GlobPattern::new("**/a.json".to_string(), root_dir),
           ]),
-          excludes: Vec::new(),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },
@@ -483,12 +499,14 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/test/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![
+          arg_includes: None,
+          config_includes: Some(vec![
             GlobPattern::new("**/*.json".to_string(), test_dir.clone()),
             GlobPattern::new("!a/**/*.json".to_string(), test_dir.clone()),
             GlobPattern::new("a/b/**/*.json".to_string(), test_dir),
           ]),
-          excludes: Vec::new(),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/test/"),
       },
@@ -512,12 +530,14 @@ mod test {
       GlobOptions {
         start_dir: PathBuf::from("/"),
         file_patterns: GlobPatterns {
-          includes: Some(vec![
+          arg_includes: None,
+          config_includes: Some(vec![
             GlobPattern::new("**/*.*".to_string(), root_dir.clone()),
             GlobPattern::new("!dir/a/**/*".to_string(), root_dir.clone()),
             GlobPattern::new("dir/b/b/**/*".to_string(), root_dir),
           ]),
-          excludes: Vec::new(),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
         },
         pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
       },

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -28,47 +28,67 @@ pub enum GlobMatchesDetail {
 
 pub struct GlobMatcher {
   base_dir: CanonicalizedPathBuf,
-  include_matcher: Option<Override>,
-  exclude_matcher: Override,
+  config_include_matcher: Option<Override>,
+  arg_include_matcher: Option<Override>,
+  config_exclude_matcher: Override,
+  arg_exclude_matcher: Option<Override>,
 }
 
 impl GlobMatcher {
   pub fn new(patterns: GlobPatterns, opts: &GlobMatcherOptions) -> Result<GlobMatcher> {
     let base_dir = patterns
-      .includes
+      .config_includes
       .as_ref()
       .and_then(|includes| get_base_dir(includes.iter().map(|p| &p.base_dir)))
       .unwrap_or_else(|| opts.base_dir.clone());
 
     // map the includes and excludes to have a new base
-    let excludes = patterns
-      .excludes
+    let config_excludes = patterns
+      .config_excludes
       .into_iter()
       .filter_map(|pattern| pattern.into_non_negated().into_new_base(base_dir.clone()))
       .collect::<Vec<_>>();
-    let includes = patterns.includes.map(|includes| {
+    let config_includes = patterns.config_includes.map(|includes| {
       includes
         .into_iter()
         .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
         .collect::<Vec<_>>()
     });
+    let arg_includes = patterns.arg_includes.map(|includes| {
+      includes
+        .into_iter()
+        .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
+        .collect::<Vec<_>>()
+    });
+    let arg_excludes = patterns.arg_excludes.map(|excludes| {
+      excludes
+        .into_iter()
+        .filter_map(|pattern| pattern.into_non_negated().into_new_base(base_dir.clone()))
+        .collect::<Vec<_>>()
+    });
 
     Ok(GlobMatcher {
-      include_matcher: match includes {
+      config_include_matcher: match config_includes {
         Some(includes) => Some(build_override(&includes, opts, &base_dir)?),
         None => None,
       },
-      exclude_matcher: build_override(&excludes, opts, &base_dir)?,
+      arg_include_matcher: match arg_includes {
+        Some(includes) => Some(build_override(&includes, opts, &base_dir)?),
+        None => None,
+      },
+      config_exclude_matcher: build_override(&config_excludes, opts, &base_dir)?,
+      arg_exclude_matcher: match arg_excludes {
+        Some(excludes) => Some(build_override(&excludes, opts, &base_dir)?),
+        None => None,
+      },
       base_dir,
     })
   }
 
   /// Gets if the matcher only has excludes patterns.
   pub fn has_only_excludes(&self) -> bool {
-    (match &self.include_matcher {
-      Some(m) => m.is_empty(),
-      None => true,
-    }) && !self.exclude_matcher.is_empty()
+    (self.config_include_matcher.as_ref().map(|m| m.is_empty()).unwrap_or(true) && self.arg_include_matcher.as_ref().map(|m| m.is_empty()).unwrap_or(true))
+      && (!self.config_exclude_matcher.is_empty() || !self.arg_exclude_matcher.as_ref().map(|m| m.is_empty()).unwrap_or(true))
   }
 
   pub fn matches(&self, path: impl AsRef<Path>) -> bool {
@@ -97,9 +117,25 @@ impl GlobMatcher {
       Cow::Borrowed(path)
     };
 
-    if matches!(self.exclude_matcher.matched(&path, false), Match::Whitelist(_)) {
+    if matches!(self.config_exclude_matcher.matched(&path, false), Match::Whitelist(_))
+      || self
+        .arg_exclude_matcher
+        .as_ref()
+        .map(|m| matches!(m.matched(&path, false), Match::Whitelist(_)))
+        .unwrap_or(false)
+    {
       GlobMatchesDetail::Excluded
-    } else if self.include_matcher.is_none() || matches!(self.include_matcher.as_ref().unwrap().matched(&path, false), Match::Whitelist(_)) {
+    } else if self
+      .config_include_matcher
+      .as_ref()
+      .map(|m| matches!(m.matched(&path, false), Match::Whitelist(_)))
+      .unwrap_or(true)
+      && self
+        .arg_include_matcher
+        .as_ref()
+        .map(|m| matches!(m.matched(&path, false), Match::Whitelist(_)))
+        .unwrap_or(true)
+    {
       GlobMatchesDetail::Matched
     } else {
       GlobMatchesDetail::NotMatched
@@ -109,7 +145,12 @@ impl GlobMatcher {
   pub fn is_dir_ignored(&self, path: impl AsRef<Path>) -> bool {
     if path.as_ref().starts_with(&self.base_dir) {
       let path = path.as_ref().strip_prefix(&self.base_dir).unwrap();
-      matches!(self.exclude_matcher.matched(path, true), Match::Whitelist(_))
+      matches!(self.config_exclude_matcher.matched(path, true), Match::Whitelist(_))
+        || self
+          .arg_exclude_matcher
+          .as_ref()
+          .map(|m| matches!(m.matched(path, true), Match::Whitelist(_)))
+          .unwrap_or(false)
     } else {
       true
     }
@@ -126,8 +167,13 @@ impl GlobMatcher {
     if file_path.as_ref().starts_with(&self.base_dir) {
       for ancestor in file_path.as_ref().ancestors() {
         if let Ok(path) = ancestor.strip_prefix(&self.base_dir) {
-          if matches!(self.exclude_matcher.matched(path, true), Match::Whitelist(_)) {
+          if matches!(self.config_exclude_matcher.matched(path, true), Match::Whitelist(_)) {
             return false;
+          }
+          if let Some(arg_exclude_matcher) = &self.arg_exclude_matcher {
+            if matches!(arg_exclude_matcher.matched(path, true), Match::Whitelist(_)) {
+              return false;
+            }
           }
         } else {
           return true;
@@ -182,8 +228,10 @@ mod test {
     let cwd = CanonicalizedPathBuf::new_for_testing("/testing/dir");
     let glob_matcher = GlobMatcher::new(
       GlobPatterns {
-        includes: Some(vec![GlobPattern::new("*.ts".to_string(), cwd.clone())]),
-        excludes: vec![GlobPattern::new("no-match.ts".to_string(), cwd.clone())],
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("*.ts".to_string(), cwd.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![GlobPattern::new("no-match.ts".to_string(), cwd.clone())],
       },
       &GlobMatcherOptions {
         case_sensitive: true,
@@ -202,8 +250,10 @@ mod test {
     let cwd = CanonicalizedPathBuf::new_for_testing("/testing/dir");
     let glob_matcher = GlobMatcher::new(
       GlobPatterns {
-        includes: Some(vec![GlobPattern::new("/testing/dir/*.ts".to_string(), cwd.clone())]),
-        excludes: vec![GlobPattern::new("/testing/dir/no-match.ts".to_string(), cwd.clone())],
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("/testing/dir/*.ts".to_string(), cwd.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![GlobPattern::new("/testing/dir/no-match.ts".to_string(), cwd.clone())],
       },
       &GlobMatcherOptions {
         case_sensitive: true,
@@ -220,8 +270,10 @@ mod test {
     let cwd = CanonicalizedPathBuf::new_for_testing("\\?\\UNC\\wsl$\\Ubuntu\\home\\david");
     let glob_matcher = GlobMatcher::new(
       GlobPatterns {
-        includes: Some(vec![GlobPattern::new("*.ts".to_string(), cwd.clone())]),
-        excludes: vec![GlobPattern::new("no-match.ts".to_string(), cwd.clone())],
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("*.ts".to_string(), cwd.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![GlobPattern::new("no-match.ts".to_string(), cwd.clone())],
       },
       &GlobMatcherOptions {
         case_sensitive: true,
@@ -239,8 +291,10 @@ mod test {
     let cwd = CanonicalizedPathBuf::new_for_testing("/testing/dir");
     let glob_matcher = GlobMatcher::new(
       GlobPatterns {
-        includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), cwd.clone())]),
-        excludes: vec![GlobPattern::new("sub-dir".to_string(), cwd.clone())],
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), cwd.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![GlobPattern::new("sub-dir".to_string(), cwd.clone())],
       },
       &GlobMatcherOptions {
         case_sensitive: true,
@@ -260,10 +314,12 @@ mod test {
     let cwd = CanonicalizedPathBuf::new_for_testing("/sub-dir");
     let glob_matcher = GlobMatcher::new(
       GlobPatterns {
+        arg_includes: None,
         // notice cwd and base_dir are different. This will happen when the config
         // file is in an ancestor dir and the user has stepped into a folder
-        includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), cwd.clone())]),
-        excludes: vec![GlobPattern::new("**/dist".to_string(), base_dir.clone())],
+        config_includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), cwd.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![GlobPattern::new("**/dist".to_string(), base_dir.clone())],
       },
       &GlobMatcherOptions {
         case_sensitive: true,

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -126,12 +126,12 @@ impl GlobMatcher {
     {
       GlobMatchesDetail::Excluded
     } else if self
-      .config_include_matcher
+      .arg_include_matcher
       .as_ref()
       .map(|m| matches!(m.matched(&path, false), Match::Whitelist(_)))
       .unwrap_or(true)
       && self
-        .arg_include_matcher
+        .config_include_matcher
         .as_ref()
         .map(|m| matches!(m.matched(&path, false), Match::Whitelist(_)))
         .unwrap_or(true)

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -8,7 +8,7 @@ use super::non_negated_glob;
 #[derive(Debug)]
 pub struct GlobPatterns {
   pub arg_includes: Option<Vec<GlobPattern>>,
-  pub config_includes: Vec<GlobPattern>,
+  pub config_includes: Option<Vec<GlobPattern>>,
   pub arg_excludes: Option<Vec<GlobPattern>>,
   pub config_excludes: Vec<GlobPattern>,
 }

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -7,8 +7,10 @@ use super::non_negated_glob;
 
 #[derive(Debug)]
 pub struct GlobPatterns {
-  pub includes: Option<Vec<GlobPattern>>,
-  pub excludes: Vec<GlobPattern>,
+  pub arg_includes: Option<Vec<GlobPattern>>,
+  pub config_includes: Vec<GlobPattern>,
+  pub arg_excludes: Option<Vec<GlobPattern>>,
+  pub config_excludes: Vec<GlobPattern>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -1,3 +1,5 @@
+use crate::environment::CanonicalizedPathBuf;
+
 pub fn is_negated_glob(pattern: &str) -> bool {
   let mut chars = pattern.chars();
   let first_char = chars.next();
@@ -17,6 +19,22 @@ pub fn non_negated_glob(pattern: &str) -> &str {
 pub fn is_absolute_pattern(pattern: &str) -> bool {
   let pattern = if is_negated_glob(pattern) { &pattern[1..] } else { pattern };
   pattern.starts_with('/') || is_windows_absolute_pattern(pattern)
+}
+
+pub fn make_absolute(pattern: &str, base: &CanonicalizedPathBuf) -> String {
+  if is_absolute_pattern(pattern) {
+    pattern.to_string()
+  } else {
+    let base = base.to_string_lossy().to_string().replace('\\', "/");
+    let is_negated = is_negated_glob(pattern);
+    let pattern = if is_negated { &pattern[1..] } else { pattern };
+    format!(
+      "{}{}/{}",
+      if is_negated { "!" } else { "" },
+      base.trim_end_matches('/'),
+      pattern.trim_start_matches("./")
+    )
+  }
 }
 
 fn is_windows_absolute_pattern(pattern: &str) -> bool {
@@ -57,5 +75,20 @@ mod tests {
     assert_eq!(is_absolute_pattern("!/test.ts"), true);
     assert_eq!(is_absolute_pattern("D:/test.ts"), true);
     assert_eq!(is_absolute_pattern("!D:/test.ts"), true);
+  }
+
+  #[test]
+  fn test_make_absolute() {
+    #[track_caller]
+    fn run_test(pattern: &str, dir: &str, expected: &str) {
+      assert_eq!(make_absolute(pattern, &CanonicalizedPathBuf::new_for_testing(dir)), expected);
+    }
+
+    run_test("./test", "/sub_dir", "/sub_dir/test");
+    run_test("./test", "/sub_dir/", "/sub_dir/test");
+    run_test("!./test/**/*", "/sub_dir/", "!/sub_dir/test/**/*");
+    run_test("/test", "/sub_dir/", "/test");
+    run_test("d:/test", "/sub_dir/", "d:/test");
+    run_test("!d:/test", "/sub_dir/", "!d:/test");
   }
 }

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -30,10 +30,16 @@ After [setting up a configuration file](/setup), run the `fmt` command:
 dprint fmt
 ```
 
-Or to override the configuration file's `includes` and `excludes`, you may specify the file paths to format or not format here:
+To format a subset of the files the configuration file matches, you may specify the file paths to format or not format:
 
 ```sh
 dprint fmt **/*.js --excludes **/data
+```
+
+A rare use case, but to override/ignore the patterns in the config file, use the `--includes-override` and `--excludes-override` flags:
+
+```sh
+dprint fmt --includes-override **/*.js --excludes-override **/data
 ```
 
 ### Formatting Standard Input


### PR DESCRIPTION
The current behaviour of how the CLI file patterns just override the config is very confusing and doesn't work well.

This change does the following:

1. Paths provided to the CLI are now an intersection with the config includes patterns.
   - In other words, this only matches file patterns provided as CLI args that also match the config.
2. Paths provided as `--excludes` are now a union with the config excludes patterns.
   - In other words, this excludes patterns in addition to what's excluded in the config.
3. Added a new `--includes-override` flag for overriding the value in the config. This is the previous behaviour of providing includes on the CLI.
4. Added a new `--excludes-override` flag for overriding the "excludes" value in the config. This is the previous behaviour of `--excludes`.

Closes https://github.com/dprint/dprint/issues/801