### PR TITLE
Allow building from source if no prebuilt binary is available

### DIFF
--- a/deployment/npm/bin.js
+++ b/deployment/npm/bin.js
@@ -8,21 +8,23 @@ const fs = require("fs");
 
 const exePath = path.join(__dirname, os.platform() === "win32" ? "dprint.exe" : "dprint");
 
-if (!fs.existsSync(exePath)) {
-  try {
-    const resolvedExePath = require("./install_api").runInstall();
-    runDprintExe(resolvedExePath);
-  } catch (err) {
-    if (err !== undefined && typeof err.message === "string") {
-      console.error(err.message);
-    } else {
-      console.error(err);
+(async () => {
+  if (!fs.existsSync(exePath)) {
+    try {
+      const resolvedExePath = await require("./install_api").runInstall();
+      runDprintExe(resolvedExePath);
+    } catch (err) {
+      if (err !== undefined && typeof err.message === "string") {
+        console.error(err.message);
+      } else {
+        console.error(err);
+      }
+      process.exit(1);
     }
-    process.exit(1);
+  } else {
+    runDprintExe(exePath);
   }
-} else {
-  runDprintExe(exePath);
-}
+})();
 
 /** @param exePath {string} */
 function runDprintExe(exePath) {

--- a/deployment/npm/build.ts
+++ b/deployment/npm/build.ts
@@ -65,6 +65,10 @@ if (version == null) {
 // setup dprint packages
 {
   $.logStep(`Setting up dprint ${version}...`);
+  let optionalDependencies = packages
+    .map((pkg) => `@dprint/${getPackageNameNoScope(pkg)}`)
+    .reduce((obj, pkgName) => ({ ...obj, [pkgName]: version }), {});
+  optionalDependencies["yauzl"] = "^2.10.0";
   const pkgJson = {
     "name": "dprint",
     "version": version,
@@ -89,9 +93,7 @@ if (version == null) {
     "scripts": {
       "postinstall": "node ./install.js",
     },
-    optionalDependencies: packages
-      .map(pkg => `@dprint/${getPackageNameNoScope(pkg)}`)
-      .reduce((obj, pkgName) => ({ ...obj, [pkgName]: version }), {}),
+    optionalDependencies,
   };
   currentDir.join("bin.js").copyFileToDirSync(dprintDir);
   currentDir.join("install_api.js").copyFileToDirSync(dprintDir);


### PR DESCRIPTION
Prebuilts are limited to several platforms, so it is better to support building dprint from source when they are not available on current platform. As TypeScript now requires dprint to build, it should ease new platforms like RISC-V to build it.

WebAssembly plugins are portable across platforms. Native plugins (like `dprint-plugin-prettier` and `-exec`) still rely on fixed prebuilts. Is there any elegant solution to it? I would like to help and contribute my code for extending dprint's cross-platform ability, if there's a good way of doing it.