### PR TITLE
docs: update detection of AST specific config properties

### DIFF
--- a/website/playground/src/plugins/getPluginDefaultConfig.ts
+++ b/website/playground/src/plugins/getPluginDefaultConfig.ts
@@ -15,18 +15,19 @@ export async function getPluginDefaultConfig(configSchemaUrl: string, signal: Ab
       if (propertyName === "$schema" || propertyName === "deno" || propertyName === "locked") {
         continue;
       }
+      const property = json.properties[propertyName];
+      const derivedPropName = property["$ref"]?.replace("#/definitions/", "");
 
       const lastSegment = propertyName.split(".").pop()!;
-      const astSpecific = lastSegment !== propertyName && json.properties[lastSegment] != null;
+      const astSpecific = (derivedPropName !== propertyName && derivedPropName in json.properties)
+        || (lastSegment !== propertyName && lastSegment in json.properties);
       if (astSpecific) {
         continue;
       }
 
-      const property = json.properties[propertyName];
       let defaultValue: string | boolean | number | undefined;
 
-      if (property["$ref"]) {
-        const derivedPropName = property["$ref"].replace("#/definitions/", "");
+      if (derivedPropName) {
         const definition = json.definitions[derivedPropName];
         if (definition != null) {
           defaultValue = definition?.default;

--- a/website/playground/src/plugins/getPluginDefaultConfig.ts
+++ b/website/playground/src/plugins/getPluginDefaultConfig.ts
@@ -15,11 +15,22 @@ export async function getPluginDefaultConfig(configSchemaUrl: string, signal: Ab
       if (propertyName === "$schema" || propertyName === "deno" || propertyName === "locked") {
         continue;
       }
+
+      const lastSegment = propertyName.split(".").pop()!;
+      const astSpecific = lastSegment !== propertyName && json.properties[lastSegment] != null;
+      if (astSpecific) {
+        continue;
+      }
+
       const property = json.properties[propertyName];
       let defaultValue: string | boolean | number | undefined;
 
       if (property["$ref"]) {
-        defaultValue = json.definitions[propertyName]?.default;
+        const derivedPropName = property["$ref"].replace("#/definitions/", "");
+        const definition = json.definitions[derivedPropName];
+        if (definition != null) {
+          defaultValue = definition?.default;
+        }
       } else {
         defaultValue = property.default;
       }

--- a/website/src/scripts/plugin-config-table-replacer.js
+++ b/website/src/scripts/plugin-config-table-replacer.js
@@ -141,15 +141,21 @@ function getDprintPluginConfig(configSchemaUrl) {
       const property = json.properties[propertyName];
 
       if (property["$ref"]) {
-        const lastSegment = propertyName.split(".").pop();
-        const astSpecific = lastSegment !== propertyName && json.properties[lastSegment] != null;
-
         const derivedPropName = property["$ref"].replace("#/definitions/", "");
+
+        const lastSegment = propertyName.split(".").pop();
+        let parentProperty;
+        if (derivedPropName !== propertyName && derivedPropName in json.properties) {
+          parentProperty = derivedPropName;
+        } else if (lastSegment !== propertyName && lastSegment in json.properties) {
+          parentProperty = lastSegment;
+        }
+
         const definition = json.definitions[derivedPropName];
-        if (astSpecific) {
-          ensurePropertyName(lastSegment);
-          const isSameDefinition = property["$ref"] === json.properties[lastSegment]["$ref"];
-          properties[lastSegment].astSpecificProperties.push({
+        if (parentProperty) {
+          ensurePropertyName(parentProperty);
+          const isSameDefinition = property["$ref"] === json.properties[parentProperty]["$ref"];
+          properties[parentProperty].astSpecificProperties.push({
             propertyName,
             definition: isSameDefinition ? null : definition,
           });


### PR DESCRIPTION
The generated default config in the [playground](https://dprint.dev/playground/#code/Q/plugin/typescript) is slightly inconsistent:
* Some properties are missing:
  * `module.sortImportDeclarations`
  * `module.sortExportDeclarations`
  * `exportDeclaration.sortNamedExports`
  * `importDeclaration.sortNamedImports`
  * `exportDeclaration.forceSingleLine`
  * `importDeclaration.forceSingleLine`
  * `exportDeclaration.forceMultiLine`
  * `importDeclaration.forceMultiLine`
* Detecting AST specific properties differs between the playground and the website:
  * This PR unifies the logic
  * We now regard more properties as AST specific by assuming properties of form `a.b` are an AST specific property of `a` if `a` exists.
    * This leads to properties like `arguments.preferHanging` being (correctly) regarded as AST specific property of `preferHanging`
    * Currently this logic aligns well with the current configuration, but can we assume this will still be the case in the future?
  * I am not too sure about how I display AST specific properties with a different definition than the parent currently. Will be happy about feedback here!
  