### PR TITLE
perf: lazily create ureq agents

### DIFF
--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -56,9 +56,7 @@ impl RealEnvironment {
       log_level: options.log_level,
     }));
     let progress_bars = ProgressBars::new(&logger).map(Arc::new);
-    let url_downloader = Arc::new(RealUrlDownloader::new(progress_bars.clone(), logger.clone(), |env_var_name| {
-      std::env::var(env_var_name).ok()
-    })?);
+    let url_downloader = Arc::new(RealUrlDownloader::new(progress_bars.clone(), logger.clone())?);
     let environment = RealEnvironment {
       url_downloader,
       logger,


### PR DESCRIPTION
I actually did a flamegraph on Mac. I didn't notice it was slow because I use Windows, which was way faster at this.

Before:

```
% time dprint check --incremental=false ./data/package-template.json
0.10s user 0.02s system 65% cpu 0.173 total
```

After:

```
% time ../dprint/target/release/dprint check --incremental=false ./data/package-template.json
0.01s user 0.01s system 67% cpu 0.023 total
```