### PR TITLE
fix(npm): use x64 build for aarch64-pc-windows-msvc

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -29,9 +29,13 @@ const profileDataItems: ProfileData[] = [{
   target: "x86_64-pc-windows-msvc",
   runTests: true,
 }, {
+  os: OperatingSystem.Windows,
+  target: "aarch64-pc-windows-msvc",
+  runTests: false,
+}, {
   os: OperatingSystem.Linux,
   target: "x86_64-unknown-linux-gnu",
-  runTests: true,
+  cross: true,
 }, {
   os: OperatingSystem.Linux,
   target: "x86_64-unknown-linux-musl",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -29,10 +29,6 @@ const profileDataItems: ProfileData[] = [{
   target: "x86_64-pc-windows-msvc",
   runTests: true,
 }, {
-  os: OperatingSystem.Windows,
-  target: "aarch64-pc-windows-msvc",
-  cross: true,
-}, {
   os: OperatingSystem.Linux,
   target: "x86_64-unknown-linux-gnu",
   runTests: true,
@@ -300,15 +296,14 @@ const ci = {
           shell: "pwsh",
           run: ["cd website/src/assets", "./install.ps1"].join("\n"),
         },
-        // temporary until 0.47.2 is released
-        // {
-        //   name: "Test npm",
-        //   if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')",
-        //   run: [
-        //     "cd deployment/npm",
-        //     "deno run -A build.ts 0.45.1",
-        //   ].join("\n"),
-        // },
+        {
+          name: "Test npm",
+          if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')",
+          run: [
+            "cd deployment/npm",
+            "deno run -A build.ts 0.45.1",
+          ].join("\n"),
+        },
       ],
     },
     draft_release: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -31,11 +31,11 @@ const profileDataItems: ProfileData[] = [{
 }, {
   os: OperatingSystem.Windows,
   target: "aarch64-pc-windows-msvc",
-  runTests: false,
+  cross: true,
 }, {
   os: OperatingSystem.Linux,
   target: "x86_64-unknown-linux-gnu",
-  cross: true,
+  runTests: true,
 }, {
   os: OperatingSystem.Linux,
   target: "x86_64-unknown-linux-musl",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -52,16 +52,16 @@ const profiles = profileDataItems.map(profile => {
     ...profile,
     zipChecksumEnvVarName: `ZIP_CHECKSUM_${profile.target.toUpperCase().replaceAll("-", "_")}`,
     get installerChecksumEnvVarName() {
-      if (profile.os !== OperatingSystem.Windows) {
-        throw new Error("Check for windows before accessing.");
+      if (profile.target !== "x86_64-pc-windows-msvc") {
+        throw new Error("Check for windows x86_64 before accessing.");
       }
       return `INSTALLER_CHECKSUM_${profile.target.toUpperCase().replaceAll("-", "_")}`;
     },
     artifactsName: `${profile.target}-artifacts`,
     zipFileName: `dprint-${profile.target}.zip`,
     get installerFileName() {
-      if (profile.os !== OperatingSystem.Windows) {
-        throw new Error("Check for windows before accessing.");
+      if (profile.target !== "x86_64-pc-windows-msvc") {
+        throw new Error("Check for windows x86_64 before accessing.");
       }
       return `dprint-${profile.target}-installer.exe`;
     },
@@ -105,7 +105,7 @@ const ci = {
             profile.zipChecksumEnvVarName,
             "${{steps.pre_release_" + profile.target.replaceAll("-", "_") + ".outputs.ZIP_CHECKSUM}}",
           ]);
-          if (profile.os === OperatingSystem.Windows) {
+          if (profile.target === "x86_64-pc-windows-msvc") {
             entries.push([
               profile.installerChecksumEnvVarName,
               "${{steps.pre_release_" + profile.target.replaceAll("-", "_") + ".outputs.INSTALLER_CHECKSUM}}",
@@ -216,7 +216,7 @@ const ci = {
         {
           name: "Create installer (Windows x86_64)",
           uses: "joncloud/makensis-action@v2.0",
-          if: "startsWith(matrix.config.os, 'windows') && startsWith(github.ref, 'refs/tags/')",
+          if: "matrix.config.target == 'x86_64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')",
           with: { "script-file": "${{ github.workspace }}/deployment/installer/dprint-installer.nsi" },
         },
         // zip files
@@ -237,11 +237,16 @@ const ci = {
                   `echo \"::set-output name=ZIP_CHECKSUM::$(shasum -a 256 ${profile.zipFileName} | awk '{print $1}')\"`,
                 ];
               case OperatingSystem.Windows:
+                const installerSteps = profile.target === "x86_64-pc-windows-msvc"
+                  ? [
+                    `mv deployment/installer/${profile.installerFileName} target/${profile.target}/release/${profile.installerFileName}`,
+                    `echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/${profile.target}/release/${profile.installerFileName} | awk '{print $1}')"`,
+                  ]
+                  : [];
                 return [
                   `Compress-Archive -CompressionLevel Optimal -Force -Path target/${profile.target}/release/dprint.exe -DestinationPath target/${profile.target}/release/${profile.zipFileName}`,
-                  `mv deployment/installer/${profile.installerFileName} target/${profile.target}/release/${profile.installerFileName}`,
                   `echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/${profile.target}/release/${profile.zipFileName} | awk '{print $1}')"`,
-                  `echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/${profile.target}/release/${profile.installerFileName} | awk '{print $1}')"`,
+                  ...installerSteps,
                 ];
               default: {
                 const _assertNever: never = profile.os;
@@ -262,7 +267,7 @@ const ci = {
             const paths = [
               `target/${profile.target}/release/${profile.zipFileName}`,
             ];
-            if (profile.os === OperatingSystem.Windows) {
+            if (profile.target === "x86_64-pc-windows-msvc") {
               paths.push(
                 `target/${profile.target}/release/${profile.installerFileName}`,
               );
@@ -321,7 +326,7 @@ const ci = {
             const output = [
               `echo "${profile.zipFileName}: \${{needs.build.outputs.${profile.zipChecksumEnvVarName}}}"`,
             ];
-            if (profile.os === OperatingSystem.Windows) {
+            if (profile.target === "x86_64-pc-windows-msvc") {
               output.push(`echo "${profile.installerFileName}: \${{needs.build.outputs.${profile.installerChecksumEnvVarName}}}"`);
             }
             return output;
@@ -334,7 +339,7 @@ const ci = {
             const output = [
               `echo "\${{needs.build.outputs.${profile.zipChecksumEnvVarName}}} ${profile.zipFileName}" ${op} SHASUMS256.txt`,
             ];
-            if (profile.os === OperatingSystem.Windows) {
+            if (profile.target === "x86_64-pc-windows-msvc") {
               output.push(`echo "\${{needs.build.outputs.${profile.installerChecksumEnvVarName}}} ${profile.installerFileName}" >> SHASUMS256.txt`);
             }
             return output;
@@ -352,7 +357,7 @@ const ci = {
                 const output = [
                   `${profile.artifactsName}/${profile.zipFileName}`,
                 ];
-                if (profile.os === OperatingSystem.Windows) {
+                if (profile.target === "x86_64-pc-windows-msvc") {
                   output.push(
                     `${profile.artifactsName}/${profile.installerFileName}`,
                   );
@@ -378,7 +383,7 @@ ${
                 const output = [
                   [`${profile.zipFileName}`, profile.zipChecksumEnvVarName],
                 ];
-                if (profile.os === OperatingSystem.Windows) {
+                if (profile.target === "x86_64-pc-windows-msvc") {
                   output.push(
                     [`${profile.installerFileName}`, profile.installerChecksumEnvVarName],
                   );

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -296,18 +296,19 @@ const ci = {
         },
         {
           name: "Test powershell installer (Windows)",
-          if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.config.os, 'windows')",
+          if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/') && matrix.config.target == 'x86_64-pc-windows-msvc'",
           shell: "pwsh",
           run: ["cd website/src/assets", "./install.ps1"].join("\n"),
         },
-        {
-          name: "Test npm",
-          if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')",
-          run: [
-            "cd deployment/npm",
-            "deno run -A build.ts 0.45.1",
-          ].join("\n"),
-        },
+        // temporary until 0.47.2 is released
+        // {
+        //   name: "Test npm",
+        //   if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')",
+        //   run: [
+        //     "cd deployment/npm",
+        //     "deno run -A build.ts 0.45.1",
+        //   ].join("\n"),
+        // },
       ],
     },
     draft_release: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
           - os: windows-latest
             run_tests: "false"
             target: aarch64-pc-windows-msvc
-            cross: "false"
-          - os: ubuntu-20.04
-            run_tests: "false"
-            target: x86_64-unknown-linux-gnu
             cross: "true"
+          - os: ubuntu-20.04
+            run_tests: "true"
+            target: x86_64-unknown-linux-gnu
+            cross: "false"
           - os: ubuntu-20.04
             run_tests: "false"
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,14 @@ jobs:
             run_tests: "true"
             target: x86_64-pc-windows-msvc
             cross: "false"
-          - os: ubuntu-20.04
-            run_tests: "true"
-            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            run_tests: "false"
+            target: aarch64-pc-windows-msvc
             cross: "false"
+          - os: ubuntu-20.04
+            run_tests: "false"
+            target: x86_64-unknown-linux-gnu
+            cross: "true"
           - os: ubuntu-20.04
             run_tests: "false"
             target: x86_64-unknown-linux-musl
@@ -56,6 +60,8 @@ jobs:
       ZIP_CHECKSUM_AARCH64_APPLE_DARWIN: "${{steps.pre_release_aarch64_apple_darwin.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
       INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.INSTALLER_CHECKSUM}}"
+      ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC: "${{steps.pre_release_aarch64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
+      INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC: "${{steps.pre_release_aarch64_pc_windows_msvc.outputs.INSTALLER_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_x86_64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL: "${{steps.pre_release_x86_64_unknown_linux_musl.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_aarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
@@ -145,6 +151,14 @@ jobs:
           mv deployment/installer/dprint-x86_64-pc-windows-msvc-installer.exe target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
           echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip | awk '{print $1}')"
           echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe | awk '{print $1}')"
+      - name: Pre-release (aarch64-pc-windows-msvc)
+        id: pre_release_aarch64_pc_windows_msvc
+        if: "matrix.config.target == 'aarch64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
+        run: |-
+          Compress-Archive -CompressionLevel Optimal -Force -Path target/aarch64-pc-windows-msvc/release/dprint.exe -DestinationPath target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
+          mv deployment/installer/dprint-aarch64-pc-windows-msvc-installer.exe target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe
+          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip | awk '{print $1}')"
+          echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe | awk '{print $1}')"
       - name: Pre-release (x86_64-unknown-linux-gnu)
         id: pre_release_x86_64_unknown_linux_gnu
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
@@ -193,6 +207,14 @@ jobs:
           path: |-
             target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip
             target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
+      - name: Upload artifacts (aarch64-pc-windows-msvc)
+        if: "matrix.config.target == 'aarch64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
+        uses: actions/upload-artifact@v2
+        with:
+          name: aarch64-pc-windows-msvc-artifacts
+          path: |-
+            target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
+            target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe
       - name: Upload artifacts (x86_64-unknown-linux-gnu)
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v2
@@ -248,6 +270,8 @@ jobs:
           echo "dprint-aarch64-apple-darwin.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}}"
           echo "dprint-x86_64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-pc-windows-msvc-installer.exe: ${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
+          echo "dprint-aarch64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}"
+          echo "dprint-aarch64-pc-windows-msvc-installer.exe: ${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}"
           echo "dprint-x86_64-unknown-linux-musl.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}"
           echo "dprint-aarch64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}"
@@ -258,6 +282,8 @@ jobs:
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}} dprint-aarch64-apple-darwin.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc-installer.exe" >> SHASUMS256.txt
+          echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}} dprint-aarch64-pc-windows-msvc.zip" >> SHASUMS256.txt
+          echo "${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}} dprint-aarch64-pc-windows-msvc-installer.exe" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}} dprint-x86_64-unknown-linux-gnu.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}} dprint-x86_64-unknown-linux-musl.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}} dprint-aarch64-unknown-linux-gnu.zip" >> SHASUMS256.txt
@@ -272,6 +298,8 @@ jobs:
             aarch64-apple-darwin-artifacts/dprint-aarch64-apple-darwin.zip
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc.zip
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc-installer.exe
+            aarch64-pc-windows-msvc-artifacts/dprint-aarch64-pc-windows-msvc.zip
+            aarch64-pc-windows-msvc-artifacts/dprint-aarch64-pc-windows-msvc-installer.exe
             x86_64-unknown-linux-gnu-artifacts/dprint-x86_64-unknown-linux-gnu.zip
             x86_64-unknown-linux-musl-artifacts/dprint-x86_64-unknown-linux-musl.zip
             aarch64-unknown-linux-gnu-artifacts/dprint-aarch64-unknown-linux-gnu.zip
@@ -294,6 +322,8 @@ jobs:
             |dprint-aarch64-apple-darwin.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}}|
             |dprint-x86_64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-pc-windows-msvc-installer.exe|${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
+            |dprint-aarch64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}|
+            |dprint-aarch64-pc-windows-msvc-installer.exe|${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}|
             |dprint-x86_64-unknown-linux-musl.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}|
             |dprint-aarch64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}|

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
       INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.INSTALLER_CHECKSUM}}"
       ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC: "${{steps.pre_release_aarch64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
-      INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC: "${{steps.pre_release_aarch64_pc_windows_msvc.outputs.INSTALLER_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_x86_64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL: "${{steps.pre_release_x86_64_unknown_linux_musl.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_aarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
@@ -126,7 +125,7 @@ jobs:
         run: "cargo run -p dprint --locked --target ${{matrix.config.target}} -- check"
       - name: Create installer (Windows x86_64)
         uses: joncloud/makensis-action@v2.0
-        if: "startsWith(matrix.config.os, 'windows') && startsWith(github.ref, 'refs/tags/')"
+        if: "matrix.config.target == 'x86_64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
         with:
           script-file: "${{ github.workspace }}/deployment/installer/dprint-installer.nsi"
       - name: Pre-release (x86_64-apple-darwin)
@@ -148,17 +147,15 @@ jobs:
         if: "matrix.config.target == 'x86_64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
         run: |-
           Compress-Archive -CompressionLevel Optimal -Force -Path target/x86_64-pc-windows-msvc/release/dprint.exe -DestinationPath target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip
-          mv deployment/installer/dprint-x86_64-pc-windows-msvc-installer.exe target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
           echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip | awk '{print $1}')"
+          mv deployment/installer/dprint-x86_64-pc-windows-msvc-installer.exe target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
           echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe | awk '{print $1}')"
       - name: Pre-release (aarch64-pc-windows-msvc)
         id: pre_release_aarch64_pc_windows_msvc
         if: "matrix.config.target == 'aarch64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
         run: |-
           Compress-Archive -CompressionLevel Optimal -Force -Path target/aarch64-pc-windows-msvc/release/dprint.exe -DestinationPath target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
-          mv deployment/installer/dprint-aarch64-pc-windows-msvc-installer.exe target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe
           echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip | awk '{print $1}')"
-          echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe | awk '{print $1}')"
       - name: Pre-release (x86_64-unknown-linux-gnu)
         id: pre_release_x86_64_unknown_linux_gnu
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
@@ -212,9 +209,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: aarch64-pc-windows-msvc-artifacts
-          path: |-
-            target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
-            target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc-installer.exe
+          path: target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
       - name: Upload artifacts (x86_64-unknown-linux-gnu)
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v2
@@ -271,7 +266,6 @@ jobs:
           echo "dprint-x86_64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-pc-windows-msvc-installer.exe: ${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
           echo "dprint-aarch64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}"
-          echo "dprint-aarch64-pc-windows-msvc-installer.exe: ${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}"
           echo "dprint-x86_64-unknown-linux-musl.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}"
           echo "dprint-aarch64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}"
@@ -283,7 +277,6 @@ jobs:
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc-installer.exe" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}} dprint-aarch64-pc-windows-msvc.zip" >> SHASUMS256.txt
-          echo "${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}} dprint-aarch64-pc-windows-msvc-installer.exe" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}} dprint-x86_64-unknown-linux-gnu.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}} dprint-x86_64-unknown-linux-musl.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}} dprint-aarch64-unknown-linux-gnu.zip" >> SHASUMS256.txt
@@ -299,7 +292,6 @@ jobs:
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc.zip
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc-installer.exe
             aarch64-pc-windows-msvc-artifacts/dprint-aarch64-pc-windows-msvc.zip
-            aarch64-pc-windows-msvc-artifacts/dprint-aarch64-pc-windows-msvc-installer.exe
             x86_64-unknown-linux-gnu-artifacts/dprint-x86_64-unknown-linux-gnu.zip
             x86_64-unknown-linux-musl-artifacts/dprint-x86_64-unknown-linux-musl.zip
             aarch64-unknown-linux-gnu-artifacts/dprint-aarch64-unknown-linux-gnu.zip
@@ -323,7 +315,6 @@ jobs:
             |dprint-x86_64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-pc-windows-msvc-installer.exe|${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
             |dprint-aarch64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}|
-            |dprint-aarch64-pc-windows-msvc-installer.exe|${{needs.build.outputs.INSTALLER_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}|
             |dprint-x86_64-unknown-linux-musl.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}|
             |dprint-aarch64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}|

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
             run_tests: "true"
             target: x86_64-pc-windows-msvc
             cross: "false"
-          - os: windows-latest
-            run_tests: "false"
-            target: aarch64-pc-windows-msvc
-            cross: "true"
           - os: ubuntu-20.04
             run_tests: "true"
             target: x86_64-unknown-linux-gnu
@@ -60,7 +56,6 @@ jobs:
       ZIP_CHECKSUM_AARCH64_APPLE_DARWIN: "${{steps.pre_release_aarch64_apple_darwin.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
       INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC: "${{steps.pre_release_x86_64_pc_windows_msvc.outputs.INSTALLER_CHECKSUM}}"
-      ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC: "${{steps.pre_release_aarch64_pc_windows_msvc.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_x86_64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL: "${{steps.pre_release_x86_64_unknown_linux_musl.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_aarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
@@ -150,12 +145,6 @@ jobs:
           echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip | awk '{print $1}')"
           mv deployment/installer/dprint-x86_64-pc-windows-msvc-installer.exe target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
           echo "::set-output name=INSTALLER_CHECKSUM::$(shasum -a 256 target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe | awk '{print $1}')"
-      - name: Pre-release (aarch64-pc-windows-msvc)
-        id: pre_release_aarch64_pc_windows_msvc
-        if: "matrix.config.target == 'aarch64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
-        run: |-
-          Compress-Archive -CompressionLevel Optimal -Force -Path target/aarch64-pc-windows-msvc/release/dprint.exe -DestinationPath target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
-          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip | awk '{print $1}')"
       - name: Pre-release (x86_64-unknown-linux-gnu)
         id: pre_release_x86_64_unknown_linux_gnu
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
@@ -204,12 +193,6 @@ jobs:
           path: |-
             target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc.zip
             target/x86_64-pc-windows-msvc/release/dprint-x86_64-pc-windows-msvc-installer.exe
-      - name: Upload artifacts (aarch64-pc-windows-msvc)
-        if: "matrix.config.target == 'aarch64-pc-windows-msvc' && startsWith(github.ref, 'refs/tags/')"
-        uses: actions/upload-artifact@v2
-        with:
-          name: aarch64-pc-windows-msvc-artifacts
-          path: target/aarch64-pc-windows-msvc/release/dprint-aarch64-pc-windows-msvc.zip
       - name: Upload artifacts (x86_64-unknown-linux-gnu)
         if: "matrix.config.target == 'x86_64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v2
@@ -246,6 +229,11 @@ jobs:
         run: |-
           cd website/src/assets
           ./install.ps1
+      - name: Test npm
+        if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')"
+        run: |-
+          cd deployment/npm
+          deno run -A build.ts 0.45.1
   draft_release:
     name: draft_release
     if: "startsWith(github.ref, 'refs/tags/')"
@@ -260,7 +248,6 @@ jobs:
           echo "dprint-aarch64-apple-darwin.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}}"
           echo "dprint-x86_64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-pc-windows-msvc-installer.exe: ${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}"
-          echo "dprint-aarch64-pc-windows-msvc.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}"
           echo "dprint-x86_64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}"
           echo "dprint-x86_64-unknown-linux-musl.zip: ${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}"
           echo "dprint-aarch64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}"
@@ -271,7 +258,6 @@ jobs:
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}} dprint-aarch64-apple-darwin.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}} dprint-x86_64-pc-windows-msvc-installer.exe" >> SHASUMS256.txt
-          echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}} dprint-aarch64-pc-windows-msvc.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}} dprint-x86_64-unknown-linux-gnu.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}} dprint-x86_64-unknown-linux-musl.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}} dprint-aarch64-unknown-linux-gnu.zip" >> SHASUMS256.txt
@@ -286,7 +272,6 @@ jobs:
             aarch64-apple-darwin-artifacts/dprint-aarch64-apple-darwin.zip
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc.zip
             x86_64-pc-windows-msvc-artifacts/dprint-x86_64-pc-windows-msvc-installer.exe
-            aarch64-pc-windows-msvc-artifacts/dprint-aarch64-pc-windows-msvc.zip
             x86_64-unknown-linux-gnu-artifacts/dprint-x86_64-unknown-linux-gnu.zip
             x86_64-unknown-linux-musl-artifacts/dprint-x86_64-unknown-linux-musl.zip
             aarch64-unknown-linux-gnu-artifacts/dprint-aarch64-unknown-linux-gnu.zip
@@ -309,7 +294,6 @@ jobs:
             |dprint-aarch64-apple-darwin.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_APPLE_DARWIN}}|
             |dprint-x86_64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-pc-windows-msvc-installer.exe|${{needs.build.outputs.INSTALLER_CHECKSUM_X86_64_PC_WINDOWS_MSVC}}|
-            |dprint-aarch64-pc-windows-msvc.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_PC_WINDOWS_MSVC}}|
             |dprint-x86_64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_GNU}}|
             |dprint-x86_64-unknown-linux-musl.zip|${{needs.build.outputs.ZIP_CHECKSUM_X86_64_UNKNOWN_LINUX_MUSL}}|
             |dprint-aarch64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}|

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,16 +241,11 @@ jobs:
           chmod +x install.sh
           ./install.sh
       - name: Test powershell installer (Windows)
-        if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.config.os, 'windows')"
+        if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/') && matrix.config.target == 'x86_64-pc-windows-msvc'"
         shell: pwsh
         run: |-
           cd website/src/assets
           ./install.ps1
-      - name: Test npm
-        if: "matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/')"
-        run: |-
-          cd deployment/npm
-          deno run -A build.ts 0.45.1
   draft_release:
     name: draft_release
     if: "startsWith(github.ref, 'refs/tags/')"

--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -126,7 +126,9 @@ struct ProcessPluginFile {
   #[serde(rename = "darwin-aarch64")]
   darwin_aarch64: Option<ProcessPluginPath>,
   #[serde(rename = "windows-x86_64")]
-  windows: Option<ProcessPluginPath>,
+  windows_x64_64: Option<ProcessPluginPath>,
+  #[serde(rename = "windows-aarch64")]
+  windows_aarch64: Option<ProcessPluginPath>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -223,7 +225,8 @@ fn get_os_path<'a>(plugin_file: &'a ProcessPluginFile, environment: &impl Enviro
       _ => None,
     },
     "windows" => match arch.as_str() {
-      "x86_64" => plugin_file.windows.as_ref(),
+      "x86_64" => plugin_file.windows_x64_64.as_ref(),
+      "aarch64" => plugin_file.windows_aarch64.as_ref().or(plugin_file.windows_x64_64.as_ref()),
       _ => None,
     },
     _ => bail!("Unsupported operating system: {}", os),

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -198,6 +198,10 @@ impl TestProcessPluginFileBuilder {
       "reference": "https://github.com/dprint/test-process-plugin/releases/0.1.0/test-process-plugin.zip",
       "checksum": "{3}"
   }},
+  "windows-aarch64": {{
+      "reference": "https://github.com/dprint/test-process-plugin/releases/0.1.0/test-process-plugin.zip",
+      "checksum": "{3}"
+  }},
   "linux-aarch64": {{
       "reference": "https://github.com/dprint/test-process-plugin/releases/0.1.0/test-process-plugin.zip",
       "checksum": "{3}"

--- a/deployment/npm/build.ts
+++ b/deployment/npm/build.ts
@@ -13,6 +13,10 @@ const packages: Package[] = [{
   os: "win32",
   cpu: "x64",
 }, {
+  zipFileName: "dprint-aarch64-pc-windows-msvc.zip",
+  os: "win32",
+  cpu: "arm64",
+}, {
   zipFileName: "dprint-x86_64-apple-darwin.zip",
   os: "darwin",
   cpu: "x64",
@@ -143,7 +147,7 @@ await $`mkdir -p ${dprintDir} ${scopeDir}`;
 {
   $.logStep("Verifying packages...");
   const testPlatform = Deno.build.os == "windows"
-    ? "@dprint/win32-x64"
+    ? (Deno.build.arch === "x86_64" ? "@dprint/win32-x64" : "@dprint/win32-arm64")
     : Deno.build.os === "darwin"
     ? (Deno.build.arch === "x86_64" ? "@dprint/darwin-x64" : "@dprint/darwin-arm64")
     : "@dprint/linux-x64-glibc";

--- a/deployment/npm/build.ts
+++ b/deployment/npm/build.ts
@@ -13,7 +13,8 @@ const packages: Package[] = [{
   os: "win32",
   cpu: "x64",
 }, {
-  zipFileName: "dprint-aarch64-pc-windows-msvc.zip",
+  // use x64_64 until there's an arm64 build
+  zipFileName: "dprint-x86_64-pc-windows-msvc.zip",
   os: "win32",
   cpu: "arm64",
 }, {


### PR DESCRIPTION
A native build isn't possible at the moment, so I'm updating the npm build to use the x64 build.

Closes https://github.com/dprint/dprint/issues/886