### PR TITLE
docs: support Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Repos:
 - [dprint-plugin-ruff](https://github.com/dprint/dprint-plugin-ruff) - Ruff (Python) wrapper plugin.
 - [dprint-plugin-exec](https://github.com/dprint/dprint-plugin-exec) - Formats code with any CLI executable.
 - [Malva](https://github.com/g-plane/malva) - CSS/SCSS/Sass/Less formatter
-- [markup_fmt](https://dprint.dev/plugins/markup_fmt/) - HTML, Vue, Svelte, Astro, Jinja, Twig, Nunjucks, and Vento formatter.
+- [markup_fmt](https://github.com/g-plane/markup_fmt) - HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter.
 - [pretty_yaml](https://github.com/g-plane/pretty_yaml) - YAML formatter.
 
 ## Notes

--- a/website/src/plugins/markup_fmt.md
+++ b/website/src/plugins/markup_fmt.md
@@ -13,7 +13,7 @@ layout: layouts/documentation.njk
 
 # Markup_fmt Plugin
 
-Adapter plugin that formats HTML, Vue, Svelte, Astro, Jinja, Twig, Nunjucks, and Vento files via [markup_fmt](https://github.com/g-plane/markup_fmt).
+Adapter plugin that formats HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento files via [markup_fmt](https://github.com/g-plane/markup_fmt).
 
 ## Install and Setup
 


### PR DESCRIPTION
Since v0.11.0, markup_fmt supports Angular. This PR updates documentation pages.

---

Off topic: I made some logos for dprint in #893 . Can you check them? If you don't like them, I will close that issue.