### PR TITLE
fix: add `allowTrailingCommas: true` to dprint.json and dprint.jsonc schemas

### DIFF
--- a/website/src/assets/schemas/v0.json
+++ b/website/src/assets/schemas/v0.json
@@ -86,5 +86,6 @@
   "additionalProperties": {
     "description": "Plugin configuration.",
     "type": "object"
-  }
+  },
+  "allowTrailingCommas": true
 }


### PR DESCRIPTION
This fixes part of Issue https://github.com/dprint/dprint-vscode/issues/94 . (Or so I assume. I haven't tested that.) The other part of that issue will be fixed by PR https://github.com/dprint/dprint-vscode/pull/95 when that is merged and deployed.

This changes https://dprint.dev/schemas/v0.json , which the dprint vscode plugin uses in its calculation of the json schema.