### PR TITLE
fix: init message should handle when dprint version has newer wasm plugin support

### DIFF
--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -8,7 +8,7 @@ pub async fn get_init_config_file_text(environment: &impl Environment) -> Result
   let info = match read_info_file(environment).await {
     Ok(info) => {
       // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
-      if info.plugin_system_schema_version != wasm::PLUGIN_SYSTEM_SCHEMA_VERSION {
+      if info.plugin_system_schema_version > wasm::PLUGIN_SYSTEM_SCHEMA_VERSION {
         log_error!(
           environment,
           concat!(

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -8,7 +8,7 @@ pub async fn get_init_config_file_text(environment: &impl Environment) -> Result
   let info = match read_info_file(environment).await {
     Ok(info) => {
       // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
-      if info.plugin_system_schema_version > wasm::PLUGIN_SYSTEM_SCHEMA_VERSION {
+      if wasm::PLUGIN_SYSTEM_SCHEMA_VERSION < info.plugin_system_schema_version {
         log_error!(
           environment,
           concat!(


### PR DESCRIPTION
Closes #878