### PR TITLE
Parse playground config with JSON5 instead of JSON

### DIFF
--- a/website/playground/package-lock.json
+++ b/website/playground/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@dprint/formatter": "^0.4.1",
         "allotment": "^1.20.2",
+        "json5": "^2.2.3",
         "lz-string": "^1.4.4",
         "monaco-editor": "^0.31.1",
         "react": "^17.0.2",
@@ -10334,12 +10335,9 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -23334,12 +23332,9 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@dprint/formatter": "^0.4.1",
     "allotment": "^1.20.2",
+    "json5": "^2.2.3",
     "lz-string": "^1.4.4",
     "monaco-editor": "^0.31.1",
     "react": "^17.0.2",

--- a/website/playground/src/Playground.tsx
+++ b/website/playground/src/Playground.tsx
@@ -1,5 +1,6 @@
 import type { FileMatchingInfo, PluginInfo } from "@dprint/formatter";
 import { Allotment } from "allotment";
+import JSON5 from "json5";
 import React, { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { CodeEditor, ExternalLink } from "./components";
 import { Spinner } from "./components";
@@ -60,7 +61,7 @@ export function Playground({
     const timeout = setTimeout(() => {
       let config;
       try {
-        config = JSON.parse(configText);
+        config = JSON5.parse(configText);
         if (config.lineWidth == null) {
           config.lineWidth = 80;
         }
@@ -75,7 +76,7 @@ export function Playground({
 
   const lineWidth = useMemo(() => {
     try {
-      const lineWidth = parseInt(JSON.parse(configText).lineWidth, 10);
+      const lineWidth = parseInt(JSON5.parse(configText).lineWidth, 10);
       if (!isNaN(lineWidth)) {
         return lineWidth;
       }


### PR DESCRIPTION
Every time I go to make a playground link for a bug report, I get confused and then realize that I copied my own config into the editor with comments, which then silently fails.

This PR instead uses `JSON5.parse`. Technically, dprint supports JSONC (so, maybe `jsonc-parser` would be better?), but I honestly don't know that the feature sets are any different and JSON5 was already a transitive dep with an API more similar to `JSON.parse`.