### PR TITLE
fix: macro syntax error

### DIFF
--- a/crates/core/src/plugins/wasm/mod.rs
+++ b/crates/core/src/plugins/wasm/mod.rs
@@ -62,7 +62,7 @@ pub mod macros {
   #[macro_export]
   macro_rules! generate_plugin_code {
     ($wasm_plugin_struct:ident, $wasm_plugin_creation:expr) => {
-      generate_plugin_code!($wasm_plugin_struct, $wasm_plugin_creation, Configuration)
+      generate_plugin_code!($wasm_plugin_struct, $wasm_plugin_creation, Configuration);
     };
     ($wasm_plugin_struct:ident, $wasm_plugin_creation:expr, $wasm_plugin_config:ident) => {
       struct RefStaticCell<T: Default>(std::cell::OnceCell<StaticCell<T>>);


### PR DESCRIPTION
The error was introduced in https://github.com/dprint/dprint/commit/9c6686af5e5bd91bdddb0c807537d4325edf5e51

```rust
error: macros that expand to items must be delimited with braces or followed by a semicolon
  --> C:\Users\Balthild\.cargo\registry\src\index.crates.io-6f17d22bba15001f\dprint-core-0.67.1\src\plugins\wasm\mod.rs:65:28
   |
63 |   macro_rules! generate_plugin_code {
   |   --------------------------------- in this expansion of `generate_plugin_code!`
64 |     ($wasm_plugin_struct:ident, $wasm_plugin_creation:expr) => {
65 |       generate_plugin_code!($wasm_plugin_struct, $wasm_plugin_creation, Configuration)
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
  ::: src\wasm_plugin.rs:65:1
   |
65 | generate_plugin_code!(TypeScriptPluginHandler, TypeScriptPluginHandler);
   | ----------------------------------------------------------------------- in this macro invocation
```