### PR TITLE
docs: enable all features on docs.rs

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,9 @@ process = ["communication", "serde_json", "libc", "winapi"]
 wasm = ["serde_json"]
 tracing = ["formatting"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 anyhow = "1.0.69"
 async-trait = { version = "0.1.72", optional = true }


### PR DESCRIPTION
I was reading about [Wasm plugins](https://github.com/dprint/dprint/blob/main/docs/wasm-plugin-development.md) and wondered why I couldn't find the `plugins` module on https://docs.rs/dprint-core. I think it's just because the feature isn't enabled by default.