### PR TITLE
fix: do not panic modifying dprint.json with crlf newlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e5c37d50ba0a604b82dc7ab76d66f5b98ed80c6150e0f7c394b6aa4e9ce5bd"
+checksum = "90576e8cfcca1176ef07b458f7f7bd00569e373144eb13fc88b8fe620d3f03b3"
 dependencies = [
  "indexmap 2.2.6",
  "serde_json",

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -26,7 +26,7 @@ dunce = "=1.0.4"
 fs3 = "=0.5.0"
 ignore = "=0.4.22"
 indexmap = { version = "=2.2.6", features = ["serde"] }
-jsonc-parser = { version = "=0.25.0", features = ["cst", "preserve_order"] }
+jsonc-parser = { version = "=0.25.2", features = ["cst", "preserve_order"] }
 once_cell = "=1.19.0"
 parking_lot = "=0.12.3"
 percent-encoding = "=2.3.1"


### PR DESCRIPTION
https://github.com/dprint/jsonc-parser/pull/49