### PR TITLE
fix(npm): hardlink main package executable to specific executable instead of copying

### DIFF
--- a/deployment/npm/install_api.js
+++ b/deployment/npm/install_api.js
@@ -36,7 +36,7 @@ module.exports = {
       // in order to make things faster the next time we run and to allow the
       // dprint vscode extension to easily pick this up, copy the executable
       // into the dprint package folder
-      atomicCopyFileSync(sourceExecutablePath, targetExecutablePath);
+      hardLinkOrCopy(sourceExecutablePath, targetExecutablePath);
       if (os.platform() !== "win32") {
         // chomd +x
         chmodX(targetExecutablePath);
@@ -144,7 +144,19 @@ function getLinuxFamily() {
  * @param sourcePath {string}
  * @param destinationPath {string}
  */
-function atomicCopyFileSync(sourcePath, destinationPath) {
+function hardLinkOrCopy(sourcePath, destinationPath) {
+  try {
+    fs.linkSync(sourcePath, destinationPath);
+  } catch {
+    atomicCopyFile(sourcePath, destinationPath);
+  }
+}
+
+/**
+ * @param sourcePath {string}
+ * @param destinationPath {string}
+ */
+function atomicCopyFile(sourcePath, destinationPath) {
   const crypto = require("crypto");
   const rand = crypto.randomBytes(4).toString("hex");
   const tempFilePath = destinationPath + "." + rand;


### PR DESCRIPTION
This will save a bit of space.