### PR TITLE
fix(lsp): debug log duration of format request

### DIFF
--- a/crates/dprint/src/commands/lsp/mod.rs
+++ b/crates/dprint/src/commands/lsp/mod.rs
@@ -283,14 +283,14 @@ impl<TEnvironment: Environment> Backend<TEnvironment> {
 
   async fn send_format_request(&self, uri: &Url, request: EditorFormatRequest) -> LspResult<Option<Vec<TextEdit>>> {
     let start_time = std::time::Instant::now();
-    log_debug!(self.environment, "Received format request for '{}'", uri);
+    log_debug!(self.environment, "Received format request for {}", uri);
     let mut drop_token = DropToken::new(request.token.clone());
     let result = self.send_format_request_inner(request).await;
     drop_token.completed();
     let result = match result {
       Ok(value) => Ok(value),
       Err(err) => {
-        log_error!(self.environment, "Failed formatting {}: {:#}", uri, err);
+        log_error!(self.environment, "Failed formatting '{}': {:#}", uri, err);
         Ok(None)
       }
     };


### PR DESCRIPTION
I've recently had this behaviour with vscode where it takes forever to do a formatting request when also running a cargo build. I logged out this and it seems dprint is responding very quickly < 100ms, so maybe a vscode or dprint-vscode issue.