### PR TITLE
fix: add description for deprecated subcommands

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -537,10 +537,12 @@ EXAMPLES:
     )
     .subcommand(
       Command::new("editor-info")
+        .about("Deprecated. Use lsp subcommand instead.")
         .hide(true)
     )
     .subcommand(
       Command::new("editor-service")
+        .about("Deprecated. Use lsp subcommand instead.")
         .hide(true)
         .arg(
           Arg::new("parent-pid")


### PR DESCRIPTION
## Description

In my understanding, removing hidden subcommands from complete requires newer clap_complete with the `unstable-dynamic` flag enabled.

https://github.com/clap-rs/clap/blob/6784054536a18549d90221ecd300084f02ca6386/clap_complete/CHANGELOG.md#L209-L217

I did try it, but I haven't realized it yet. So I'm sending this PR instead.

Even after adding this `about`, `--help` does not display them.

## Test

```bash
zsh --no-rcs
```

```zsh
autoload -Uz compinit
compinit

source <(./target/debug/dprint completions zsh)
```

## Before

```console
% dprint
check                                -- Checks for any files that haven't been formatted.
clear-cache                          -- Deletes the plugin cache directory.
completions                          -- Generate shell completions script for dprint
config                               -- Functionality related to the configuration file.
editor-service          editor-info  --
fmt                                  -- Formats the source files and writes the result to the file system.
help                                 -- Print this message or the help of the given subcommand(s)
init                                 -- Initializes a configuration file in the current directory.
license                              -- Outputs the software license.
lsp                                  -- Starts up a language server for formatting files.
output-file-paths                    -- Prints the resolved file paths for the plugins based on the args and configuration.
output-format-times                  -- Prints the amount of time it takes to format each file. Use this for debugging.
output-resolved-config               -- Prints the resolved configuration for the plugins based on the args and configuration.
upgrade                              -- Upgrades the dprint executable.
```

## After

```console
% dprint
check                                -- Checks for any files that haven't been formatted.
clear-cache                          -- Deletes the plugin cache directory.
completions                          -- Generate shell completions script for dprint
config                               -- Functionality related to the configuration file.
editor-service          editor-info  -- Deprecated. Use lsp subcommand instead.
fmt                                  -- Formats the source files and writes the result to the file system.
help                                 -- Print this message or the help of the given subcommand(s)
init                                 -- Initializes a configuration file in the current directory.
license                              -- Outputs the software license.
lsp                                  -- Starts up a language server for formatting files.
output-file-paths                    -- Prints the resolved file paths for the plugins based on the args and configuration.
output-format-times                  -- Prints the amount of time it takes to format each file. Use this for debugging.
output-resolved-config               -- Prints the resolved configuration for the plugins based on the args and configuration.
upgrade                              -- Upgrades the dprint executable.
```