### PR TITLE
fix: error in more cases when cannot pre-allocate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "console_static_text"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00bd3837aa7e8dc15766ded788486eba8aee03dab4e56f7c7051012a81c23"
+checksum = "55d8a913e62f6444b79e038be3eb09839e9cfc34d55d85f9336460710647d2f6"
 dependencies = [
  "unicode-width 0.1.12",
  "vte",

--- a/crates/core/src/communication/reader_writer.rs
+++ b/crates/core/src/communication/reader_writer.rs
@@ -29,8 +29,9 @@ impl<TRead: Read + Unpin> MessageReader<TRead> {
 
   #[allow(clippy::read_zero_byte_vec)]
   pub fn read_bytes(&mut self, size: usize) -> Result<Vec<u8>> {
-    let mut buf = Vec::with_capacity(size);
+    let mut buf = Vec::new();
     if size > 0 {
+      buf.try_reserve_exact(size)?;
       unsafe {
         buf.set_len(size);
       }

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -17,7 +17,7 @@ description = "Binary for dprint code formatter—a pluggable and configurable c
 anyhow = "=1.0.86"
 clap = "=4.5.4"
 clap_complete = "=4.5.2"
-console_static_text = "=0.8.2"
+console_static_text = "=0.8.3"
 crossterm = "=0.27.0" # manually retest everything when bumping this crate
 dirs = "=5.0.1"
 dissimilar = "=1.0.9"

--- a/crates/dprint/src/commands/general.rs
+++ b/crates/dprint/src/commands/general.rs
@@ -172,7 +172,7 @@ mod test {
       vec![
         get_expected_help_text(),
         "\nPLUGINS HELP:",
-        "    test-plugin         https://dprint.dev/plugins/test\n    test-process-plugin https://dprint.dev/plugins/test-process"
+        "    test-plugin         https://dprint.dev/plugins/test\r\n    test-process-plugin https://dprint.dev/plugins/test-process"
       ]
     );
   }

--- a/crates/dprint/src/plugins/implementations/wasm/instance/v4.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/instance/v4.rs
@@ -408,7 +408,9 @@ impl InitializedWasmPluginInstanceV4 {
   }
 
   fn receive_bytes(&mut self, len: usize) -> Result<Vec<u8>> {
-    let mut bytes: Vec<u8> = vec![0; len];
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(len)?;
+    bytes.resize(len, 0);
     self.read_bytes_from_shared_bytes(&mut bytes)?;
     Ok(bytes)
   }

--- a/crates/dprint/src/utils/extract_zip.rs
+++ b/crates/dprint/src/utils/extract_zip.rs
@@ -27,7 +27,8 @@ pub fn extract_zip(message: &str, zip_bytes: &[u8], dir_path: &Path, environment
             if let Some(parent_dir_path) = file_path.parent() {
               environment.mk_dir_all(parent_dir_path)?;
             }
-            let mut file_bytes = Vec::with_capacity(file.size() as usize);
+            let mut file_bytes = Vec::new();
+            file_bytes.try_reserve_exact(file.size() as usize)?;
             file.read_to_end(&mut file_bytes)?;
             environment.write_file_bytes(&file_path, &file_bytes)?;
           } else {

--- a/crates/dprint/src/utils/url.rs
+++ b/crates/dprint/src/utils/url.rs
@@ -165,7 +165,8 @@ fn inner_download(url: &Url, retry_count: u8, agent: &ureq::Agent, progress_bars
 }
 
 fn read_response(url: &Url, retry_count: u8, reader: &mut impl Read, total_size: usize, progress_bars: Option<&ProgressBars>) -> Result<Vec<u8>> {
-  let mut final_bytes = Vec::with_capacity(total_size);
+  let mut final_bytes = Vec::new();
+  final_bytes.try_reserve_exact(total_size)?;
   if let Some(progress_bars) = &progress_bars {
     let mut buf: [u8; 512] = [0; 512]; // ensure progress bars update often
     let mut message = format!("Downloading {}", url);


### PR DESCRIPTION
Error instead of panic when a plugin or dprint sends a format request or response that the receiver doesn't have memory to allocate.