### PR TITLE
feat: Add vim key bindings for selection

### DIFF
--- a/crates/dprint/src/utils/logging/multi_select.rs
+++ b/crates/dprint/src/utils/logging/multi_select.rs
@@ -30,14 +30,14 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
 
     if let Event::Key(key_event) = read_terminal_key_press()? {
       match &key_event.code {
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
           if data.active_index == 0 {
             data.active_index = data.items.len() - 1;
           } else {
             data.active_index -= 1;
           }
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
           data.active_index = (data.active_index + 1) % data.items.len();
         }
         KeyCode::Char(' ') => {
@@ -48,7 +48,7 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
         KeyCode::Enter => {
           break;
         }
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
           logger.remove_refresh_item(LoggerRefreshItemKind::Selection);
           bail!("Selection cancelled.");
         }

--- a/crates/dprint/src/utils/logging/select.rs
+++ b/crates/dprint/src/utils/logging/select.rs
@@ -29,20 +29,20 @@ pub fn show_select(logger: &Logger, context_name: &str, prompt: &str, item_hangi
 
     if let Event::Key(key_event) = read_terminal_key_press()? {
       match &key_event.code {
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
           if data.active_index == 0 {
             data.active_index = data.items.len() - 1;
           } else {
             data.active_index -= 1;
           }
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
           data.active_index = (data.active_index + 1) % data.items.len();
         }
-        KeyCode::Enter => {
+        KeyCode::Enter | KeyCode::Char('l') => {
           break;
         }
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
           logger.remove_refresh_item(LoggerRefreshItemKind::Selection);
           bail!("Selection cancelled.");
         }


### PR DESCRIPTION
This PR adds vim key bindings to improve keyboard navigation and accessibility:

- Added 'k' as alternative to Up arrow for moving up
- Added 'j' as alternative to Down arrow for moving down
- Added 'q' as alternative to Escape for cancelling
- Added 'l' as alternative to Enter in single select for selecting

These vim-style bindings make the interface more accessible to users familiar with vim keybindings while maintaining existing arrow key navigation.

Testing:
- Verified all new key bindings work as expected
- Confirmed existing arrow key navigation still functions
- Tested cancel and confirm actions with both old and new bindings