### PR TITLE
Add stable formatting feature to LSP implementation

### DIFF
--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -453,7 +453,6 @@ async fn ensure_stable_format_text<TEnvironment: Environment>(
       }
     }
 
-    // 前回と同じ結果になった場合は安定したと判断
     if !had_next_change || next_formatted_text == formatted_text {
       return Ok(formatted_text);
     } else {


### PR DESCRIPTION
## Overview
I identified a functional difference between CLI and LSP implementations regarding stable formatting. While the CLI applies complete formatting in a single run, the LSP implementation required multiple format operations to achieve the same result. I reported this issue in [dprint/dprint-vscode#101](https://github.com/dprint/dprint-vscode/issues/101).

This change adds the "ensure_stable_format" functionality to the LSP implementation, similar to what exists in the CLI version, allowing complete formatting to be applied in a single operation.

## Changes
- Added `ensure_stable_format_text` function that repeatedly formats until the result stabilizes
- Added cancellation support to respect user cancellation requests
- Added appropriate logging for debugging purposes
- Set the feature to be enabled by default (with a TODO for future configuration options)

## Related Issue
Fixes [dprint/dprint-vscode#101](https://github.com/dprint/dprint-vscode/issues/101)

---

This is my first contribution to the dprint project, so I'd appreciate any feedback on how to improve this implementation.