### PR TITLE
feat: add loongarch64-unknown-linux support

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -57,6 +57,14 @@ const profileDataItems: ProfileData[] = [{
   os: OperatingSystem.Linux,
   target: "riscv64gc-unknown-linux-gnu",
   cross: true,
+}, {
+  os: OperatingSystem.Linux,
+  target: "loongarch64-unknown-linux-gnu",
+  cross: true,
+}, {
+  os: OperatingSystem.Linux,
+  target: "loongarch64-unknown-linux-musl",
+  cross: true,
 }];
 const profiles = profileDataItems.map(profile => {
   return {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
             run_tests: "false"
             target: riscv64gc-unknown-linux-gnu
             cross: "true"
+          - os: ubuntu-22.04
+            run_tests: "false"
+            target: loongarch64-unknown-linux-gnu
+            cross: "true"
+          - os: ubuntu-22.04
+            run_tests: "false"
+            target: loongarch64-unknown-linux-musl
+            cross: "true"
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
@@ -65,6 +73,8 @@ jobs:
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_aarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL: "${{steps.pre_release_aarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM}}"
       ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU: "${{steps.pre_release_riscv64gc_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
+      ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU: "${{steps.pre_release_loongarch64_unknown_linux_gnu.outputs.ZIP_CHECKSUM}}"
+      ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL: "${{steps.pre_release_loongarch64_unknown_linux_musl.outputs.ZIP_CHECKSUM}}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -197,6 +207,20 @@ jobs:
           cd target/riscv64gc-unknown-linux-gnu/release
           zip -r dprint-riscv64gc-unknown-linux-gnu.zip dprint
           echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-riscv64gc-unknown-linux-gnu.zip | awk '{print $1}')"
+      - name: Pre-release (loongarch64-unknown-linux-gnu)
+        id: pre_release_loongarch64_unknown_linux_gnu
+        if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.target == 'loongarch64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/'))"
+        run: |-
+          cd target/loongarch64-unknown-linux-gnu/release
+          zip -r dprint-loongarch64-unknown-linux-gnu.zip dprint
+          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-loongarch64-unknown-linux-gnu.zip | awk '{print $1}')"
+      - name: Pre-release (loongarch64-unknown-linux-musl)
+        id: pre_release_loongarch64_unknown_linux_musl
+        if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.target == 'loongarch64-unknown-linux-musl' && startsWith(github.ref, 'refs/tags/'))"
+        run: |-
+          cd target/loongarch64-unknown-linux-musl/release
+          zip -r dprint-loongarch64-unknown-linux-musl.zip dprint
+          echo "::set-output name=ZIP_CHECKSUM::$(shasum -a 256 dprint-loongarch64-unknown-linux-musl.zip | awk '{print $1}')"
       - name: Upload artifacts (x86_64-apple-darwin)
         if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.target == 'x86_64-apple-darwin' && startsWith(github.ref, 'refs/tags/'))"
         uses: actions/upload-artifact@v4
@@ -247,6 +271,18 @@ jobs:
         with:
           name: riscv64gc-unknown-linux-gnu-artifacts
           path: target/riscv64gc-unknown-linux-gnu/release/dprint-riscv64gc-unknown-linux-gnu.zip
+      - name: Upload artifacts (loongarch64-unknown-linux-gnu)
+        if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.target == 'loongarch64-unknown-linux-gnu' && startsWith(github.ref, 'refs/tags/'))"
+        uses: actions/upload-artifact@v4
+        with:
+          name: loongarch64-unknown-linux-gnu-artifacts
+          path: target/loongarch64-unknown-linux-gnu/release/dprint-loongarch64-unknown-linux-gnu.zip
+      - name: Upload artifacts (loongarch64-unknown-linux-musl)
+        if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.target == 'loongarch64-unknown-linux-musl' && startsWith(github.ref, 'refs/tags/'))"
+        uses: actions/upload-artifact@v4
+        with:
+          name: loongarch64-unknown-linux-musl-artifacts
+          path: target/loongarch64-unknown-linux-musl/release/dprint-loongarch64-unknown-linux-musl.zip
       - name: Test shell installer
         if: "(matrix.config.target != 'aarch64-unknown-linux-gnu' && matrix.config.target != 'aarch64-unknown-linux-musl' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && (matrix.config.run_tests == 'true' && !startsWith(github.ref, 'refs/tags/'))"
         run: |-
@@ -278,6 +314,8 @@ jobs:
           echo "dprint-aarch64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}"
           echo "dprint-aarch64-unknown-linux-musl.zip: ${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL}}"
           echo "dprint-riscv64gc-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU}}"
+          echo "dprint-loongarch64-unknown-linux-gnu.zip: ${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU}}"
+          echo "dprint-loongarch64-unknown-linux-musl.zip: ${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL}}"
       - name: Create SHASUMS256.txt file
         run: |-
           echo "${{needs.build.outputs.ZIP_CHECKSUM_X86_64_APPLE_DARWIN}} dprint-x86_64-apple-darwin.zip" > SHASUMS256.txt
@@ -289,6 +327,8 @@ jobs:
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}} dprint-aarch64-unknown-linux-gnu.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL}} dprint-aarch64-unknown-linux-musl.zip" >> SHASUMS256.txt
           echo "${{needs.build.outputs.ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU}} dprint-riscv64gc-unknown-linux-gnu.zip" >> SHASUMS256.txt
+          echo "${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU}} dprint-loongarch64-unknown-linux-gnu.zip" >> SHASUMS256.txt
+          echo "${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL}} dprint-loongarch64-unknown-linux-musl.zip" >> SHASUMS256.txt
       - name: Draft release
         uses: softprops/action-gh-release@v2
         env:
@@ -304,6 +344,8 @@ jobs:
             aarch64-unknown-linux-gnu-artifacts/dprint-aarch64-unknown-linux-gnu.zip
             aarch64-unknown-linux-musl-artifacts/dprint-aarch64-unknown-linux-musl.zip
             riscv64gc-unknown-linux-gnu-artifacts/dprint-riscv64gc-unknown-linux-gnu.zip
+            loongarch64-unknown-linux-gnu-artifacts/dprint-loongarch64-unknown-linux-gnu.zip
+            loongarch64-unknown-linux-musl-artifacts/dprint-loongarch64-unknown-linux-musl.zip
             SHASUMS256.txt
           body: |
             ## Changes
@@ -327,4 +369,6 @@ jobs:
             |dprint-aarch64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_GNU}}|
             |dprint-aarch64-unknown-linux-musl.zip|${{needs.build.outputs.ZIP_CHECKSUM_AARCH64_UNKNOWN_LINUX_MUSL}}|
             |dprint-riscv64gc-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_RISCV64GC_UNKNOWN_LINUX_GNU}}|
+            |dprint-loongarch64-unknown-linux-gnu.zip|${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU}}|
+            |dprint-loongarch64-unknown-linux-musl.zip|${{needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL}}|
           draft: true

--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -125,6 +125,10 @@ struct ProcessPluginFile {
   linux_riscv64: Option<ProcessPluginPath>,
   #[serde(rename = "linux-riscv64-musl")]
   linux_riscv64_musl: Option<ProcessPluginPath>,
+  #[serde(rename = "linux-loongarch64")]
+  linux_loongarch64: Option<ProcessPluginPath>,
+  #[serde(rename = "linux-loongarch64-musl")]
+  linux_loongarch64_musl: Option<ProcessPluginPath>,
   #[serde(rename = "darwin-x86_64")]
   darwin_x86_64: Option<ProcessPluginPath>,
   #[serde(rename = "darwin-aarch64")]
@@ -217,12 +221,14 @@ fn get_os_path<'a>(plugin_file: &'a ProcessPluginFile, environment: &impl Enviro
       "x86_64" => plugin_file.linux_x86_64.as_ref(),
       "aarch64" => plugin_file.linux_aarch64.as_ref().or(plugin_file.linux_x86_64.as_ref()),
       "riscv64" => plugin_file.linux_riscv64.as_ref(),
+      "loongarch64" => plugin_file.linux_loongarch64.as_ref(),
       _ => None,
     },
     "linux-musl" => match arch.as_str() {
       "x86_64" => plugin_file.linux_x86_64_musl.as_ref(),
       "aarch64" => plugin_file.linux_aarch64_musl.as_ref().or(plugin_file.linux_x86_64_musl.as_ref()),
       "riscv64" => plugin_file.linux_riscv64_musl.as_ref(),
+      "loongarch64" => plugin_file.linux_loongarch64_musl.as_ref(),
       _ => None,
     },
     "macos" => match arch.as_str() {

--- a/deployment/npm/build.ts
+++ b/deployment/npm/build.ts
@@ -5,7 +5,7 @@ import decompress from "npm:decompress@4.2.1";
 interface Package {
   zipFileName: string;
   os: "win32" | "darwin" | "linux";
-  cpu: "x64" | "arm64" | "riscv64";
+  cpu: "x64" | "arm64" | "riscv64" | "loong64";
   libc?: "glibc" | "musl";
 }
 
@@ -51,6 +51,16 @@ const packages: Package[] = [{
   os: "linux",
   cpu: "riscv64",
   libc: "glibc",
+}, {
+  zipFileName: "dprint-loongarch64-unknown-linux-gnu.zip",
+  os: "linux",
+  cpu: "loong64",
+  libc: "glibc",
+}, {
+  zipFileName: "dprint-loongarch64-unknown-linux-musl.zip",
+  os: "linux",
+  cpu: "loong64",
+  libc: "musl",
 }];
 
 const markdownText = `# dprint

--- a/deployment/npm/install_api.js
+++ b/deployment/npm/install_api.js
@@ -81,8 +81,8 @@ function getTarget() {
 
 function getArch() {
   const arch = os.arch();
-  if (arch !== "arm64" && arch !== "x64" && arch !== "riscv64") {
-    throw new Error("Unsupported architecture " + os.arch() + ". Only x64, aarch64, and riscv64 binaries are available.");
+  if (arch !== "arm64" && arch !== "x64" && arch !== "riscv64" && arch !== "loong64") {
+    throw new Error("Unsupported architecture " + os.arch() + ". Only x64, aarch64, riscv64 and loong64 binaries are available.");
   }
   return arch;
 }


### PR DESCRIPTION
This PR adds basic support for `loongarch64-unknown-linux-[gnu,musl]`.

Note that plugins won't work on loongarch64 yet, as dprint uses wasmer-compiler-cranelift on all targets currently and has no loongarch64 support. However, as wasmer-compiler-llvm supports loongarch64 and is the recommended backend for production according to [wasmer's documentation](https://github.com/wasmerio/wasmer/blob/main/lib/compiler-cranelift/README.md), I would like to switch to this backend for at least loongarch64 but would like to hear about your opinions (on whether we should just switch to wasmer-compiler-llvm outright).

P.S., I have smoke tested dprint with wasmer-compiler-llvm backend on loongarch64, using dprint's repository and most plugins works out of the box - with the exception that the `exec` plugin needs prebuilt binaries and the typescript plugin would crash with an unreachable error, which I will try to investigate further.