### PR TITLE
feat: add updateUrl to editor-info command output

### DIFF
--- a/crates/dprint/src/commands/editor/mod.rs
+++ b/crates/dprint/src/commands/editor/mod.rs
@@ -55,6 +55,8 @@ pub async fn output_editor_info<TEnvironment: Environment>(
     #[serde(skip_serializing_if = "Option::is_none")]
     config_schema_url: Option<String>,
     help_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    update_url: Option<String>,
   }
 
   let mut plugins = Vec::new();
@@ -77,6 +79,7 @@ pub async fn output_editor_info<TEnvironment: Environment>(
         Some(plugin.info().config_schema_url.trim().to_string())
       },
       help_url: plugin.info().help_url.trim().to_string(),
+      update_url: plugin.info().update_url.clone(),
     });
   }
 
@@ -352,8 +355,8 @@ mod test {
     final_output.push_str(&environment.cli_version());
     final_output.push_str(r#"","configSchemaUrl":"https://dprint.dev/schemas/v0.json","plugins":["#);
     final_output
-      .push_str(r#"{"name":"test-plugin","version":"0.2.0","configKey":"test-plugin","fileExtensions":["txt"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/test/schema.json","helpUrl":"https://dprint.dev/plugins/test"},"#);
-    final_output.push_str(r#"{"name":"test-process-plugin","version":"0.1.0","configKey":"testProcessPlugin","fileExtensions":["txt_ps"],"fileNames":["test-process-plugin-exact-file"],"helpUrl":"https://dprint.dev/plugins/test-process"}]}"#);
+      .push_str(r#"{"name":"test-plugin","version":"0.2.0","configKey":"test-plugin","fileExtensions":["txt"],"fileNames":[],"configSchemaUrl":"https://plugins.dprint.dev/test/schema.json","helpUrl":"https://dprint.dev/plugins/test","updateUrl":"https://plugins.dprint.dev/dprint/test-plugin/latest.json"},"#);
+    final_output.push_str(r#"{"name":"test-process-plugin","version":"0.1.0","configKey":"testProcessPlugin","fileExtensions":["txt_ps"],"fileNames":["test-process-plugin-exact-file"],"helpUrl":"https://dprint.dev/plugins/test-process","updateUrl":"https://plugins.dprint.dev/dprint/test-process-plugin/latest.json"}]}"#);
     assert_eq!(environment.take_stdout_messages(), vec![final_output]);
     let mut stderr_messages = environment.take_stderr_messages();
     stderr_messages.sort();

--- a/docs/editor-extension-development.md
+++ b/docs/editor-extension-development.md
@@ -27,7 +27,8 @@ Outputs something like:
         "config_key": "test",
         "fileExtensions": ["txt"],
         "fileNames": [],
-        "helpUrl": "https://dprint.dev/plugins/test-plugin"
+        "helpUrl": "https://dprint.dev/plugins/test-plugin",
+        "updateUrl": "https://plugins.dprint.dev/test/latest.json"
     }, {
         "name": "javascript-plugin",
         "version": "0.2.1",
@@ -35,7 +36,8 @@ Outputs something like:
         "fileExtensions": ["js"],
         "fileNames": [],
         "configSchemaUrl": "https://dprint.dev/schemas/javascript-plugin.json",
-        "helpUrl": "https://dprint.dev/plugins/javascript-plugin"
+        "helpUrl": "https://dprint.dev/plugins/javascript-plugin",
+        "updateUrl": "https://plugins.dprint.dev/javascript/latest.json"
     }]
 }
 ```
@@ -63,6 +65,8 @@ interface PluginInfo {
   // will be `undefined` when the plugin does not have a schema url
   configSchemaUrl?: string;
   helpUrl: string;
+  // will be `undefined` when the plugin does not have an update url
+  updateUrl?: string;
 }
 ```
 


### PR DESCRIPTION
Adds the `updateUrl` field to the plugin information returned by the `editor-info` command, allowing editor extensions to access plugin update URLs directly.

The field is optional and will be omitted when a plugin does not have an update URL.