### PR TITLE
docs: swap oxc and biome config

### DIFF
--- a/website/src/plugins/biome/config.md
+++ b/website/src/plugins/biome/config.md
@@ -1,19 +1,19 @@
 ---
-title: Configuration - Oxc
-description: Documentation on the configuration file for the Oxc code formatting plugin for dprint.
+title: Configuration - Biome
+description: Documentation on the configuration file for the Biome code formatting plugin for dprint.
 layout: layouts/documentation.njk
 ---
 
 <nav class="breadcrumb" aria-label="breadcrumbs">
   <ul>
     <li><a href="/plugins">Plugins</a></li>
-    <li><a href="/plugins/oxc">Oxc</a></li>
-    <li><a href="/plugins/oxc/config">Configuration</a></li>
+    <li><a href="/plugins/biome">Biome</a></li>
+    <li><a href="/plugins/biome/config">Configuration</a></li>
   </ul>
 </nav>
 
-# Oxc - Configuration
+# Biome - Configuration
 
-<div class="plugin-config-table" data-url="https://plugins.dprint.dev/dprint/dprint-plugin-oxc/latest/schema.json">
+<div class="plugin-config-table" data-url="https://plugins.dprint.dev/dprint/dprint-plugin-biome/latest/schema.json">
   Loading...
 </div>

--- a/website/src/plugins/oxc/config.md
+++ b/website/src/plugins/oxc/config.md
@@ -1,19 +1,19 @@
 ---
-title: Configuration - Biome
-description: Documentation on the configuration file for the Biome code formatting plugin for dprint.
+title: Configuration - Oxc
+description: Documentation on the configuration file for the Oxc code formatting plugin for dprint.
 layout: layouts/documentation.njk
 ---
 
 <nav class="breadcrumb" aria-label="breadcrumbs">
   <ul>
     <li><a href="/plugins">Plugins</a></li>
-    <li><a href="/plugins/biome">Biome</a></li>
-    <li><a href="/plugins/biome/config">Configuration</a></li>
+    <li><a href="/plugins/oxc">Oxc</a></li>
+    <li><a href="/plugins/oxc/config">Configuration</a></li>
   </ul>
 </nav>
 
-# Biome - Configuration
+# Oxc - Configuration
 
-<div class="plugin-config-table" data-url="https://plugins.dprint.dev/dprint/dprint-plugin-biome/latest/schema.json">
+<div class="plugin-config-table" data-url="https://plugins.dprint.dev/dprint/dprint-plugin-oxc/latest/schema.json">
   Loading...
 </div>


### PR DESCRIPTION
Currently https://dprint.dev/plugins/biome/config/ points to oxc config and https://dprint.dev/plugins/oxc/config/ points to biome config