### PR TITLE
chore: generate release artifact attestations

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -314,6 +314,11 @@ const installerTests = step.if(runDebugTests)(
 const buildJob = job("build", {
   name: matrix.target,
   runsOn: matrix.os,
+  permissions: {
+    attestations: "write",
+    contents: "write",
+    id-token: "write",
+  },
   strategy: { matrix },
   env: {
     // disabled to reduce ./target size and generally it's slower enabled
@@ -421,7 +426,14 @@ ${
 `,
         draft: true,
       },
-    }),
+    },
+    {
+      name: "Generate artifact attestations",
+      uses: "actions/attest@v4",
+      with: {
+        "subject-checksums": "SHASUMS256.txt"
+      }
+    },
   ],
 });
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,10 @@ jobs:
       - build
     if: 'startsWith(github.ref, ''refs/tags/'')'
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v6
@@ -382,3 +386,7 @@ jobs:
             |dprint-loongarch64-unknown-linux-gnu.zip|${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_GNU }}|
             |dprint-loongarch64-unknown-linux-musl.zip|${{ needs.build.outputs.ZIP_CHECKSUM_LOONGARCH64_UNKNOWN_LINUX_MUSL }}|
           draft: true
+      - name: Generate artifact attestations
+        uses: actions/attest@v4
+        with:
+          subject-checksums: SHASUMS256.txt


### PR DESCRIPTION
Ref https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations

Untested, but I suppose it could work. ci.yml generation untested as well.