### PR TITLE
docs: add shfmt (Shell) plugin to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Repos:
 - [markup_fmt](https://github.com/g-plane/markup_fmt) - HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, Vento, Mustache and XML formatter.
 - [pretty_graphql](https://github.com/g-plane/pretty_graphql) - GraphQL formatter.
 - [pretty_yaml](https://github.com/g-plane/pretty_yaml) - YAML formatter.
+- [dprint-plugin-shfmt](https://github.com/hrko/dprint-plugin-shfmt) - shfmt (Shell) wrapper plugin.
 
 ## Notes
 

--- a/website/playground/src/plugins/getPluginUrls.ts
+++ b/website/playground/src/plugins/getPluginUrls.ts
@@ -20,6 +20,7 @@ export async function getPluginUrls(signal: AbortSignal): Promise<string[]> {
   const markupFmtPlugin = json.latest.find((p: any) => p.configKey === "markup")!;
   const prettyYamlPlugin = json.latest.find((p: any) => p.configKey === "yaml")!;
   const prettyGraphqlPlugin = json.latest.find((p: any) => p.configKey === "graphql")!;
+  const shfmtPlugin = json.latest.find((p: any) => p.configKey === "shfmt")!;
 
   return [
     typescriptPlugin.url,
@@ -35,6 +36,7 @@ export async function getPluginUrls(signal: AbortSignal): Promise<string[]> {
     markupFmtPlugin.url,
     prettyYamlPlugin.url,
     prettyGraphqlPlugin.url,
+    shfmtPlugin.url,
   ];
 }
 
@@ -57,6 +59,7 @@ export function getPluginShortNameFromPluginUrl(url: string) {
     case "markup_fmt":
     case "pretty_yaml":
     case "pretty_graphql":
+    case "shfmt":
       return name;
     default:
       return undefined;
@@ -88,6 +91,8 @@ export function getLanguageFromPluginUrl(url: string) {
       return "html";
     case "pretty_yaml":
       return "yaml";
+    case "shfmt":
+      return "shell";
     default:
       return undefined;
   }

--- a/website/playground/src/utils/UrlSharer.ts
+++ b/website/playground/src/utils/UrlSharer.ts
@@ -15,6 +15,7 @@ export const knownPlugins = new Set([
   "markup_fmt",
   "pretty_yaml",
   "pretty_graphql",
+  "shfmt",
 ]);
 
 export class UrlSaver {

--- a/website/src/_includes/partials/doc-menu.njk
+++ b/website/src/_includes/partials/doc-menu.njk
@@ -28,5 +28,6 @@
   <li><a href="/plugins/ruff">Ruff (Python)</a></li>
   <li><a href="/plugins/jupyter">Jupyter</a></li>
   <li><a href="/plugins/exec">Exec (Many CLIs)</a></li>
+  <li><a href="/plugins/shfmt">shfmt (Shell)</a></li>
   <li><a href="/plugin-dev">Creating a Plugin</a></li>
 </ul>

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -69,6 +69,7 @@ layout: layouts/base.njk
               <li><a href="/plugins/mago">Mago (PHP)</a></li>
               <li><a href="/plugins/ruff">Ruff (Python)</a></li>
               <li><a href="/plugins/jupyter">Jupyter</a></li>
+              <li><a href="/plugins/shfmt">shfmt (Shell)</a></li>
             </ul>
           </div>
         </div>

--- a/website/src/plugins.md
+++ b/website/src/plugins.md
@@ -31,6 +31,7 @@ The setup for both is the same except process plugins require a checksum to be s
 - [Mago](/plugins/mago) (PHP)
 - [Ruff](/plugins/ruff) (Python)
 - [Jupyter](/plugins/jupyter)
+- [shfmt](/plugins/shfmt) (Shell)
 
 ## Process Plugins
 

--- a/website/src/plugins/shfmt.md
+++ b/website/src/plugins/shfmt.md
@@ -1,0 +1,51 @@
+---
+title: shfmt Plugin
+description: Documentation on the shfmt code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/shfmt">shfmt</a></li>
+  </ul>
+</nav>
+
+# shfmt Plugin
+
+Adapter plugin that formats shell script code via [shfmt](https://github.com/mvdan/sh).
+
+Formats .sh, .bash, .zsh, .mksh, and .bats files.
+
+## Install and Setup
+
+In your project's directory with a dprint.json file, run:
+
+```shellsession
+dprint config add hrko/shfmt
+```
+
+This will update your config file to have an entry for the plugin. Then optionally specify a `"shfmt"` property to add configuration:
+
+```json
+{
+  "shfmt": {
+    // shfmt's config goes here
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/hrko/shfmt-vx.x.x.wasm"
+  ]
+}
+```
+
+## Configuration
+
+See [Configuration](/plugins/shfmt/config)
+
+## Playground
+
+See [Playground](https://dprint.dev/playground#plugin/shfmt)
+
+## Source
+
+See https://github.com/hrko/dprint-plugin-shfmt

--- a/website/src/plugins/shfmt/config.md
+++ b/website/src/plugins/shfmt/config.md
@@ -1,0 +1,19 @@
+---
+title: Configuration - shfmt
+description: Documentation on the configuration file for the shfmt code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/shfmt">shfmt</a></li>
+    <li><a href="/plugins/shfmt/config">Configuration</a></li>
+  </ul>
+</nav>
+
+# shfmt - Configuration
+
+<div class="plugin-config-table" data-url="https://plugins.dprint.dev/hrko/shfmt/latest/schema.json">
+  Loading...
+</div>


### PR DESCRIPTION
## Summary

- add `dprint-plugin-shfmt` to the repository list in `README.md`
- add `shfmt` integration to website playground plugin resolution
- add `shfmt` to website plugin lists/navigation
- add new plugin docs pages:
  - `/plugins/shfmt`
  - `/plugins/shfmt/config`

## Plugin Details

- plugin repository: https://github.com/hrko/dprint-plugin-shfmt
- install command: `dprint config add hrko/shfmt`
- supported extensions: `.sh`, `.bash`, `.zsh`, `.mksh`, `.bats`
- wasm url format: `https://plugins.dprint.dev/hrko/shfmt-vx.x.x.wasm`
- schema url: `https://plugins.dprint.dev/hrko/shfmt/latest/schema.json`

## Verification

- ran `deno task serve` and confirmed `shfmt` is included in:
  - website menus
  - plugin index pages
