### PR TITLE
fix(install.sh): use correct riscv64 build name, add loongarch64 support, append .exe to path for Windows and resolve relative DPRINT_INSTALL path

### DIFF
--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -36,18 +36,20 @@ else
 	dprint_uri="https://github.com/dprint/dprint/releases/download/${1}/dprint-${target}.zip"
 fi
 
-dprint_install="$(realpath "${DPRINT_INSTALL:-$HOME/.dprint}")"
+dprint_install="${DPRINT_INSTALL:-$HOME/.dprint}"
 bin_dir="$dprint_install/bin"
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
+fi
+dprint_install="$(realpath "$dprint_install")"
+bin_dir="$dprint_install/bin"
+
 exe="$bin_dir/dprint"
 zip="$exe.zip"
 
 # append .exe for Windows
 if [ "$target" = "x86_64-pc-windows-msvc" ]; then
 	exe="$exe.exe"
-fi
-
-if [ ! -d "$bin_dir" ]; then
-	mkdir -p "$bin_dir"
 fi
 
 # download

--- a/website/src/assets/install.sh
+++ b/website/src/assets/install.sh
@@ -15,28 +15,19 @@ else
 	case $(uname -sm) in
 		"Darwin x86_64") target="x86_64-apple-darwin" ;;
 		"Darwin arm64") target="aarch64-apple-darwin" ;;
-		"Linux aarch64")
-			is_musl=$(ldd /bin/sh | grep 'musl' || true)
-			if [ -z "$is_musl" ]; then
-				target="aarch64-unknown-linux-gnu"
-			else
-				target="aarch64-unknown-linux-musl"
-			fi ;;
-		"Linux riscv64")
-			is_musl=$(ldd /bin/sh | grep 'musl' || true)
-			if [ -z "$is_musl" ]; then
-				target="riscv64-unknown-linux-gnu"
-			else
-				target="riscv64-unknown-linux-musl"
-			fi ;;
-		*)
-			is_musl=$(ldd /bin/sh | grep 'musl' || true)
-			if [ -z "$is_musl" ]; then
-				target="x86_64-unknown-linux-gnu"
-			else
-				target="x86_64-unknown-linux-musl"
-			fi ;;
+		"Linux aarch64") target="aarch64-unknown-linux" ;;
+		"Linux loongarch64") target="loongarch64-unknown-linux" ;;
+		"Linux riscv64") target="riscv64gc-unknown-linux-gnu" ;; # riscv64 build only has a GNU libc variant.
+		*) target="x86_64-unknown-linux" ;;
 	esac
+fi
+if [ "${target%-linux}" != "$target" ]; then # check "-linux" suffix
+	is_musl=$(ldd /bin/sh | grep 'musl' || true)
+	if [ -z "$is_musl" ]; then
+		target="$target-gnu"
+	else
+		target="$target-musl"
+	fi
 fi
 
 if [ $# -eq 0 ]; then
@@ -45,25 +36,31 @@ else
 	dprint_uri="https://github.com/dprint/dprint/releases/download/${1}/dprint-${target}.zip"
 fi
 
-dprint_install="${DPRINT_INSTALL:-$HOME/.dprint}"
+dprint_install="$(realpath "${DPRINT_INSTALL:-$HOME/.dprint}")"
 bin_dir="$dprint_install/bin"
 exe="$bin_dir/dprint"
+zip="$exe.zip"
+
+# append .exe for Windows
+if [ "$target" = "x86_64-pc-windows-msvc" ]; then
+	exe="$exe.exe"
+fi
 
 if [ ! -d "$bin_dir" ]; then
 	mkdir -p "$bin_dir"
 fi
 
 # download
-curl --fail --location --progress-bar --output "$exe.zip" "$dprint_uri"
+curl --fail --location --progress-bar --output "$zip" "$dprint_uri"
 
 # stop any running dprint editor services
 pkill -9 "dprint" || true
 
 # install
 cd "$bin_dir"
-unzip -o "$exe.zip"
+unzip -o "$zip"
 chmod +x "$exe"
-rm "$exe.zip"
+rm "$zip"
 
 echo "dprint was installed successfully to $exe"
 if command -v dprint >/dev/null; then


### PR DESCRIPTION
Made a few fixes to the `https://dprint.dev/install.sh` script, namely:
- **Use `riscv64gc` build name instead of the old `riscv64`.**
  This seems to have changed somewhere along the way and gone unnoticed until now. The releases only contain a `dprint-riscv64gc-unknown-linux-gnu.zip` file nowadays and the script would fail on `riscv64` systems.
- **Add support for `loongarch64` architecture.**
  According to my research, `uname -sm` prints `Linux loongarch64` for `loongarch64` systems, and since there is a build file for this architecture I figure we should use it.
- **Append `.exe` file extension to executable on Windows.**
  Previously, the script would fail if it detected Windows because the `dprint-x86_64-pc-windows-msvc.zip` file only has a `dprint.exe` file in it, not a `dprint` file like the other release files.
- **Resolve relative `DPRINT_INSTALL` paths.**
  For example if running with `DPRINT_INSTALL=./.dprint curl -fsSL https://dprint.dev/install.sh | sh` the script would fail while unzipping.

And I also took the time to deduplicate the GNU/musl libc detection.

Hope it's okay I packed multiple fixes into a single PR.
Let me know what you think! :shipit: