### PR TITLE
fix: read `.git/info/exclude` when respecting gitignore

### DIFF
--- a/crates/dprint/src/configuration/deserialize_config.rs
+++ b/crates/dprint/src/configuration/deserialize_config.rs
@@ -35,7 +35,7 @@ pub fn deserialize_config(config_file_text: &str) -> Result<ConfigMap> {
             "Expected property '{}' with value '{}' to be convertible to a signed integer. {}",
             property_name,
             value,
-            err.to_string()
+            err
           )
         }
       }),

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -343,7 +343,7 @@ struct ConfigPathContext<'a> {
 fn get_config_map_from_path(path: ConfigPathContext) -> Result<ConfigMap> {
   let mut result = match deserialize_config(path.current.content) {
     Ok(map) => map,
-    Err(e) => bail!("Error deserializing. {}", e.to_string()),
+    Err(e) => bail!("Error deserializing. {}", e),
   };
   template_expand(path, &mut result)?;
 

--- a/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
+++ b/crates/dprint/src/plugins/implementations/process/setup_process_plugin.rs
@@ -265,7 +265,7 @@ pub fn parse_process_plugin_file(bytes: &[u8]) -> Result<ProcessPluginFile> {
     Ok(plugin_file) => plugin_file,
     Err(err) => bail!(
       "Error deserializing plugin file: {}\n\nThis might mean you're using an old version of dprint.",
-      err.to_string()
+      err
     ),
   };
 

--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -34,6 +34,15 @@ impl DirGitIgnores {
   }
 }
 
+/// Whether `.gitignore` and `.git` are present in a directory the caller has
+/// already listed. Providing this lets resolution skip file system calls for
+/// files it can already tell are absent.
+#[derive(Clone, Copy)]
+pub struct DirEntriesHint {
+  pub has_gitignore: bool,
+  pub has_git: bool,
+}
+
 /// Resolves gitignores in a directory tree taking into account
 /// ancestor gitignores that may be found in a directory.
 pub struct GitIgnoreTree<TEnvironment> {
@@ -55,8 +64,10 @@ impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
     }
   }
 
-  pub fn get_resolved_git_ignore_for_dir_children(&mut self, dir_path: &Path) -> Option<Rc<DirGitIgnores>> {
-    self.get_resolved_git_ignore_inner(dir_path, None)
+  /// Resolves the gitignore for the children of a directory the caller has
+  /// already listed, passing a hint so resolution can avoid redundant reads.
+  pub fn get_resolved_git_ignore_for_dir_children(&mut self, dir_path: &Path, hint: DirEntriesHint) -> Option<Rc<DirGitIgnores>> {
+    self.get_resolved_git_ignore_inner(dir_path, Some(hint))
   }
 
   pub fn get_resolved_git_ignore_for_file(&mut self, file_path: &Path) -> Option<Rc<DirGitIgnores>> {
@@ -64,49 +75,83 @@ impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
     self.get_resolved_git_ignore_inner(dir_path, None)
   }
 
-  fn get_resolved_git_ignore_inner(&mut self, dir_path: &Path, maybe_parent: Option<&Path>) -> Option<Rc<DirGitIgnores>> {
+  fn get_resolved_git_ignore_inner(&mut self, dir_path: &Path, hint: Option<DirEntriesHint>) -> Option<Rc<DirGitIgnores>> {
     let maybe_resolved = self.ignores.get(dir_path).cloned();
     if let Some(resolved) = maybe_resolved {
       resolved
     } else {
-      let resolved = self.resolve_gitignore_in_dir(dir_path, maybe_parent);
+      let resolved = self.resolve_gitignore_in_dir(dir_path, hint);
       self.ignores.insert(dir_path.to_owned(), resolved.clone());
       resolved
     }
   }
 
-  fn resolve_gitignore_in_dir(&mut self, dir_path: &Path, maybe_parent: Option<&Path>) -> Option<Rc<DirGitIgnores>> {
-    if let Some(parent) = maybe_parent {
-      // stop searching if the parent dir had a .git directory in it
-      if self.environment.path_exists(parent.join(".git")) {
-        return None;
-      }
-    }
-
-    let parent = dir_path.parent().and_then(|parent| self.get_resolved_git_ignore_inner(parent, Some(dir_path)));
-    let current = self.environment.read_file(dir_path.join(".gitignore")).ok().and_then(|text| {
-      let mut builder = ignore::gitignore::GitignoreBuilder::new(dir_path);
-      for line in text.lines() {
-        builder.add_line(None, line).ok()?;
-      }
-      // override the gitignore contents to include these paths
-      for path in &self.include_paths {
-        if let Ok(suffix) = path.strip_prefix(dir_path) {
-          let suffix = suffix.to_string_lossy().replace('\\', "/");
-          let _ignore = builder.add_line(None, &format!("!/{}", suffix));
-          if !suffix.ends_with('/') {
-            let _ignore = builder.add_line(None, &format!("!/{}/", suffix));
-          }
-        }
-      }
-      let gitignore = builder.build().ok()?;
-      Some(Rc::new(gitignore))
-    });
+  fn resolve_gitignore_in_dir(&mut self, dir_path: &Path, hint: Option<DirEntriesHint>) -> Option<Rc<DirGitIgnores>> {
+    // a directory containing `.git` is the root of a repository, so don't
+    // search for gitignores above it
+    let is_repo_root = match hint {
+      Some(hint) => hint.has_git,
+      None => self.environment.path_exists(dir_path.join(".git")),
+    };
+    let parent = if is_repo_root {
+      None
+    } else {
+      // ancestors aren't part of the caller's listing, so resolve them without a hint
+      dir_path.parent().and_then(|parent| self.get_resolved_git_ignore_inner(parent, None))
+    };
+    let current = self.resolve_current_gitignore(dir_path, is_repo_root, hint);
     if parent.is_none() && current.is_none() {
       None
     } else {
       Some(Rc::new(DirGitIgnores { current, parent }))
     }
+  }
+
+  fn resolve_current_gitignore(&self, dir_path: &Path, is_repo_root: bool, hint: Option<DirEntriesHint>) -> Option<Rc<ignore::gitignore::Gitignore>> {
+    // skip the read when the caller's listing already shows there's no `.gitignore`
+    let maybe_has_gitignore = hint.map(|h| h.has_gitignore).unwrap_or(true);
+    let gitignore_text = if maybe_has_gitignore {
+      self.environment.read_file(dir_path.join(".gitignore")).ok()
+    } else {
+      None
+    };
+    // git also reads `.git/info/exclude` at the repository root, treating it
+    // like an uncommitted `.gitignore` there (https://git-scm.com/docs/gitignore).
+    // Only the repo root can have this file, so avoid the read everywhere else.
+    let exclude_text = if is_repo_root {
+      self.environment.read_file(dir_path.join(".git").join("info").join("exclude")).ok()
+    } else {
+      None
+    };
+    if gitignore_text.is_none() && exclude_text.is_none() {
+      return None;
+    }
+
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(dir_path);
+    // add `.git/info/exclude` first so that the closer `.gitignore` patterns
+    // take precedence (the last matching pattern wins)
+    if let Some(text) = &exclude_text {
+      for line in text.lines() {
+        builder.add_line(None, line).ok()?;
+      }
+    }
+    if let Some(text) = &gitignore_text {
+      for line in text.lines() {
+        builder.add_line(None, line).ok()?;
+      }
+    }
+    // override the gitignore contents to include these paths
+    for path in &self.include_paths {
+      if let Ok(suffix) = path.strip_prefix(dir_path) {
+        let suffix = suffix.to_string_lossy().replace('\\', "/");
+        let _ignore = builder.add_line(None, &format!("!/{}", suffix));
+        if !suffix.ends_with('/') {
+          let _ignore = builder.add_line(None, &format!("!/{}/", suffix));
+        }
+      }
+    }
+    let gitignore = builder.build().ok()?;
+    Some(Rc::new(gitignore))
   }
 }
 
@@ -141,5 +186,37 @@ mod test {
     run_test("/sub_dir/sub_dir/ignore.txt", true);
     run_test("/sub_dir/ignore.txt", false);
     run_test("/ignore.txt", false);
+  }
+
+  #[test]
+  fn honors_git_info_exclude() {
+    let env = TestEnvironment::new();
+    env.write_file("/.gitignore", "from_gitignore.txt").unwrap();
+    env.mk_dir_all("/.git/info").unwrap();
+    env.write_file("/.git/info/exclude", "from_exclude.txt\n!unexclude.txt").unwrap();
+    env.mk_dir_all("/sub_dir").unwrap();
+    let mut ignore_tree = GitIgnoreTree::new(env, Vec::new());
+    let mut run_test = |path: &str, expected: bool| {
+      let path = PathBuf::from(path);
+      let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
+      assert_eq!(gitignore.is_ignored(&path, /* is_dir */ false), expected, "Path: {}", path.display());
+    };
+    run_test("/from_gitignore.txt", true);
+    run_test("/from_exclude.txt", true);
+    // patterns in `.git/info/exclude` apply to descendant directories too
+    run_test("/sub_dir/from_exclude.txt", true);
+    run_test("/other.txt", false);
+  }
+
+  #[test]
+  fn git_info_exclude_without_gitignore() {
+    // a repo with only `.git/info/exclude` and no `.gitignore` should still be honored
+    let env = TestEnvironment::new();
+    env.mk_dir_all("/.git/info").unwrap();
+    env.write_file("/.git/info/exclude", "ignored.txt").unwrap();
+    let mut ignore_tree = GitIgnoreTree::new(env, Vec::new());
+    let path = PathBuf::from("/ignored.txt");
+    let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
+    assert!(gitignore.is_ignored(&path, /* is_dir */ false));
   }
 }

--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -189,7 +189,7 @@ mod test {
   }
 
   #[test]
-  fn honors_git_info_exclude() {
+  fn honours_git_info_exclude() {
     let env = TestEnvironment::new();
     env.write_file("/.gitignore", "from_gitignore.txt").unwrap();
     env.mk_dir_all("/.git/info").unwrap();
@@ -210,7 +210,7 @@ mod test {
 
   #[test]
   fn git_info_exclude_without_gitignore() {
-    // a repo with only `.git/info/exclude` and no `.gitignore` should still be honored
+    // a repo with only `.git/info/exclude` and no `.gitignore` should still be honoured
     let env = TestEnvironment::new();
     env.mk_dir_all("/.git/info").unwrap();
     env.write_file("/.git/info/exclude", "ignored.txt").unwrap();

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -11,6 +11,7 @@ use crate::arg_parser::ConfigDiscovery;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::DirEntry;
 use crate::environment::Environment;
+use crate::utils::gitignore::DirEntriesHint;
 use crate::utils::gitignore::GitIgnoreTree;
 
 use super::ExcludeMatchDetail;
@@ -104,6 +105,31 @@ enum DirOrConfigEntry {
   File(PathBuf),
   // todo: get rid of this from here probably
   Config(PathBuf),
+}
+
+/// Derives a gitignore resolution hint from an already-read directory listing.
+fn dir_entries_hint(entries: &[DirOrConfigEntry]) -> DirEntriesHint {
+  let mut hint = DirEntriesHint {
+    has_git: false,
+    has_gitignore: false,
+  };
+  for entry in entries {
+    match entry {
+      DirOrConfigEntry::Dir(path) | DirOrConfigEntry::File(path) => {
+        match path.file_name().and_then(|f| f.to_str()) {
+          // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
+          Some(".gitignore") => hint.has_gitignore = true,
+          Some(".git") => hint.has_git = true,
+          _ => continue,
+        }
+      }
+      DirOrConfigEntry::Config(_) => continue,
+    }
+    if hint.has_gitignore && hint.has_git {
+      break; // nothing left to learn
+    }
+  }
+  hint
 }
 
 const PUSH_DIR_ENTRIES_BATCH_COUNT: usize = 500;
@@ -264,10 +290,12 @@ impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
         Err(err) => return Err(err), // error
         Ok(Some(entries)) => {
           for dir in entries.into_iter().flatten() {
+            // reuse the directory listing we already have to avoid extra file system calls
+            let dir_hint = dir_entries_hint(&dir.entries);
             let gitignore = self
               .git_ignore_tree
               .as_mut()
-              .and_then(|t| t.get_resolved_git_ignore_for_dir_children(&dir.path));
+              .and_then(|t| t.get_resolved_git_ignore_for_dir_children(&dir.path, dir_hint));
             for entry in dir.entries {
               match entry {
                 DirOrConfigEntry::Dir(path) => {
@@ -450,6 +478,38 @@ mod test {
     result.sort();
     expected_matches.sort();
     assert_eq!(result, expected_matches);
+  }
+
+  #[tokio::test]
+  async fn should_respect_git_info_exclude() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/.git/info/exclude", "excluded.txt")
+      .write_file("/included.txt", "")
+      .write_file("/excluded.txt", "")
+      .write_file("/sub/included.txt", "")
+      .write_file("/sub/excluded.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+
+    let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    assert_eq!(result, vec!["/included.txt", "/sub/included.txt"]);
   }
 
   #[tokio::test]

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -56,7 +56,7 @@ Note: This requires that [git](https://git-scm.com/) is installed and that you u
 
 ### Ignoring .gitignore
 
-By default, dprint respects `.gitignore` files and excludes any gitignored files from formatting. To disable this behaviour, use the `--no-gitignore` flag:
+By default, dprint respects `.gitignore` files (as well as a repository's `.git/info/exclude` file) and excludes any gitignored files from formatting. To disable this behaviour, use the `--no-gitignore` flag:
 
 ```sh
 dprint fmt --no-gitignore


### PR DESCRIPTION
Also reduces some syscalls.

Closes https://github.com/dprint/dprint/issues/1012