### PR TITLE
feat: support reading a list of files to format from stdin

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
 use clap::ArgMatches;
@@ -456,7 +455,7 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
   let mut file_patterns = maybe_values_to_vec(matches.get_many("files"));
 
   if matches.get_flag("stdin-files") {
-    file_patterns.extend(read_stdin_file_paths(std_in_reader)?);
+    file_patterns.extend(std_in_reader.read_non_empty_lines()?);
   }
 
   if !plugins.is_empty() && file_patterns.is_empty() {
@@ -472,13 +471,6 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
     exclude_patterns: maybe_values_to_vec(matches.get_many("excludes")),
     exclude_pattern_overrides: matches.get_many("excludes-override").map(values_to_vec),
   })
-}
-
-/// Reads a newline-separated list of file paths from stdin. Blank lines are ignored.
-fn read_stdin_file_paths<TStdInReader: StdInReader>(std_in_reader: &TStdInReader) -> Result<Vec<String>> {
-  let bytes = std_in_reader.read()?;
-  let text = String::from_utf8(bytes).context("Failed reading file paths from stdin as UTF-8.")?;
-  Ok(text.lines().filter(|line| !line.is_empty()).map(String::from).collect())
 }
 
 fn parse_incremental(matches: &ArgMatches) -> Option<bool> {

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
 use clap::ArgMatches;
@@ -333,13 +334,13 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         SubCommand::StdInFmt(StdInFmtSubCommand {
           file_name_or_path,
           file_bytes: std_in_reader.read()?,
-          patterns: parse_file_patterns(matches)?,
+          patterns: parse_file_patterns(matches, &std_in_reader)?,
         })
       } else {
         let enable_stable_format = !matches.get_flag("skip-stable-format");
         SubCommand::Fmt(FmtSubCommand {
           diff: matches.get_flag("diff"),
-          patterns: parse_file_patterns(matches)?,
+          patterns: parse_file_patterns(matches, &std_in_reader)?,
           incremental: if enable_stable_format { parse_incremental(matches) } else { Some(false) },
           enable_stable_format,
           allow_no_files: if matches.get_flag("staged") {
@@ -363,7 +364,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
       };
 
       SubCommand::Check(CheckSubCommand {
-        patterns: parse_file_patterns(matches)?,
+        patterns: parse_file_patterns(matches, &std_in_reader)?,
         incremental: parse_incremental(matches),
         only_staged: matches.get_flag("staged"),
         list_different: matches.get_flag("list-different"),
@@ -399,12 +400,12 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
     }),
     ("clear-cache", _) => SubCommand::ClearCache,
     ("file-paths", matches) => SubCommand::OutputFilePaths(OutputFilePathsSubCommand {
-      patterns: parse_file_patterns(matches)?,
+      patterns: parse_file_patterns(matches, &std_in_reader)?,
     }),
     ("resolved-config", _) => SubCommand::OutputResolvedConfig,
     ("incremental-state", _) => SubCommand::IncrementalState,
     ("format-times", matches) => SubCommand::OutputFormatTimes(OutputFormatTimesSubCommand {
-      patterns: parse_file_patterns(matches)?,
+      patterns: parse_file_patterns(matches, &std_in_reader)?,
       allow_no_files: matches.get_flag("allow-no-files"),
     }),
     ("version", _) => SubCommand::Version,
@@ -450,9 +451,13 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
   })
 }
 
-fn parse_file_patterns(matches: &ArgMatches) -> Result<FilePatternArgs> {
+fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_reader: &TStdInReader) -> Result<FilePatternArgs> {
   let plugins = maybe_values_to_vec(matches.get_many("plugins"));
-  let file_patterns = maybe_values_to_vec(matches.get_many("files"));
+  let mut file_patterns = maybe_values_to_vec(matches.get_many("files"));
+
+  if matches.get_flag("stdin-files") {
+    file_patterns.extend(read_stdin_file_paths(std_in_reader)?);
+  }
 
   if !plugins.is_empty() && file_patterns.is_empty() {
     validate_plugin_args_when_no_files(&plugins)?;
@@ -467,6 +472,13 @@ fn parse_file_patterns(matches: &ArgMatches) -> Result<FilePatternArgs> {
     exclude_patterns: maybe_values_to_vec(matches.get_many("excludes")),
     exclude_pattern_overrides: matches.get_many("excludes-override").map(values_to_vec),
   })
+}
+
+/// Reads a newline-separated list of file paths from stdin. Blank lines are ignored.
+fn read_stdin_file_paths<TStdInReader: StdInReader>(std_in_reader: &TStdInReader) -> Result<Vec<String>> {
+  let bytes = std_in_reader.read()?;
+  let text = String::from_utf8(bytes).context("Failed reading file paths from stdin as UTF-8.")?;
+  Ok(text.lines().filter(|line| !line.is_empty()).map(String::from).collect())
 }
 
 fn parse_incremental(matches: &ArgMatches) -> Option<bool> {
@@ -658,6 +670,7 @@ EXAMPLES:
             .long("stdin")
             .value_name("extension/file-name/file-path")
             .help("Format stdin and output the result to stdout. Provide an absolute file path to apply the inclusion and exclusion rules or an extension or file name to always format the text.")
+            .conflicts_with("stdin-files")
             .required(false)
             .num_args(1)
         )
@@ -897,6 +910,15 @@ impl ClapExtensions for clap::Command {
           .num_args(1..),
       )
       .arg(
+        Arg::new("stdin-files")
+          .long("stdin-files")
+          .help("Read a newline-separated list of file paths to format from stdin instead of from the command line arguments.")
+          .conflicts_with("files")
+          .conflicts_with("staged")
+          .num_args(0)
+          .required(false),
+      )
+      .arg(
         Arg::new("includes-override")
           .long("includes-override")
           .value_name("patterns")
@@ -1058,6 +1080,31 @@ mod test {
     let fmt_cmd = parse_fmt_sub_command(vec!["fmt", "--skip-stable-format", "--incremental=true"]).unwrap();
     assert_eq!(fmt_cmd.enable_stable_format, false);
     assert_eq!(fmt_cmd.incremental, Some(false));
+  }
+
+  #[test]
+  fn stdin_files_arg() {
+    let stdin_reader = TestStdInReader::from("/file1.txt\n\n/sub dir/file 2.txt\n");
+    let args = parse_args(vec!["".to_string(), "fmt".to_string(), "--stdin-files".to_string()], stdin_reader).unwrap();
+    match args.sub_command {
+      SubCommand::Fmt(cmd) => {
+        // blank lines are skipped and paths with spaces are preserved
+        assert_eq!(cmd.patterns.include_patterns, vec!["/file1.txt".to_string(), "/sub dir/file 2.txt".to_string()]);
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  #[test]
+  fn stdin_files_conflicts_with_file_patterns() {
+    let stdin_reader = TestStdInReader::from("/file1.txt\n");
+    let err = parse_args(
+      vec!["".to_string(), "fmt".to_string(), "--stdin-files".to_string(), "other.txt".to_string()],
+      stdin_reader,
+    )
+    .err()
+    .unwrap();
+    assert!(err.to_string().contains("cannot be used with"));
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -373,6 +373,40 @@ mod test {
   }
 
   #[test]
+  fn should_format_files_from_stdin_files() {
+    let file_path1 = "/file.txt";
+    let file_path2 = "/sub dir/file with space.txt";
+    let file_path3 = "/not-included.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(&file_path1, "text")
+      .write_file(&file_path2, "text2")
+      .write_file(&file_path3, "text3")
+      .build();
+    // include a blank line and a path containing spaces to ensure both are handled
+    let test_std_in = TestStdInReader::from(format!("{}\n\n{}\n", file_path1, file_path2));
+    run_test_cli_with_stdin(vec!["fmt", "--stdin-files"], &environment, test_std_in).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_formatted");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text2_formatted");
+    // wasn't in the list, so it's left untouched
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text3");
+  }
+
+  #[test]
+  fn should_check_files_from_stdin_files() {
+    let file_path1 = "/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(&file_path1, "text")
+      .build();
+    let test_std_in = TestStdInReader::from(format!("{}\n", file_path1));
+    let error_message = run_test_cli_with_stdin(vec!["check", "--stdin-files", "--list-different"], &environment, test_std_in)
+      .err()
+      .unwrap();
+    error_message.assert_exit_code(20);
+    assert_eq!(environment.take_stdout_messages(), vec![file_path1.to_string()]);
+  }
+
+  #[test]
   fn should_format_only_staged_files() {
     let file_path1 = "/file.txt";
     let file_path2 = "/file.txt_ps";

--- a/crates/dprint/src/utils/stdin_reader.rs
+++ b/crates/dprint/src/utils/stdin_reader.rs
@@ -1,4 +1,6 @@
+use anyhow::Context;
 use anyhow::Result;
+use std::io::BufRead;
 use std::io::Read;
 use std::io::{self};
 
@@ -7,6 +9,10 @@ pub use tests::TestStdInReader;
 
 pub trait StdInReader: Clone + Send + Sync {
   fn read(&self) -> Result<Vec<u8>>;
+
+  /// Reads stdin line by line, skipping blank lines, without buffering the
+  /// entire input into a single string. Useful for large lists of file paths.
+  fn read_non_empty_lines(&self) -> Result<Vec<String>>;
 }
 
 #[derive(Default, Clone, Copy)]
@@ -17,6 +23,17 @@ impl StdInReader for RealStdInReader {
     let mut text = Vec::new();
     io::stdin().read_to_end(&mut text)?;
     Ok(text)
+  }
+
+  fn read_non_empty_lines(&self) -> Result<Vec<String>> {
+    let mut lines = Vec::new();
+    for line in io::stdin().lock().lines() {
+      let line = line.context("Failed reading line from stdin.")?;
+      if !line.is_empty() {
+        lines.push(line);
+      }
+    }
+    Ok(lines)
   }
 }
 
@@ -43,6 +60,12 @@ mod tests {
     fn read(&self) -> Result<Vec<u8>> {
       let text = self.text.lock();
       Ok(text.as_ref().expect("Expected to have stdin text set.").clone())
+    }
+
+    fn read_non_empty_lines(&self) -> Result<Vec<String>> {
+      let bytes = self.read()?;
+      let text = String::from_utf8(bytes).context("Failed reading stdin as UTF-8.")?;
+      Ok(text.lines().filter(|line| !line.is_empty()).map(String::from).collect())
     }
   }
 }

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -68,6 +68,20 @@ Use `dprint fmt --stdin <file-path/file-name/extension>` and provide the input f
 
 Provide a full file path to format with inclusion/exclusion rules of your dprint configuration file or provide only a file name or extension to always format the file.
 
+### Formatting a list of files from Standard Input
+
+Requires dprint >= 0.55.0
+
+Use the `--stdin-files` flag to read a newline-separated list of file paths to format from stdin instead of passing them as command line arguments. This is useful when piping the output of another tool into dprint:
+
+```sh
+generate_files | dprint fmt --stdin-files
+```
+
+Unlike piping through `xargs`, this handles file paths containing spaces since the only delimiter is the newline (blank lines are ignored). It also avoids the command line length limits that apply when passing many paths as arguments.
+
+The paths are resolved against the inclusion/exclusion rules of your dprint configuration file, the same way file patterns passed on the command line are. This flag is also available for the `check`, `file-paths`, and `format-times` subcommands.
+
 ## Checking What Files Aren't Formatted
 
 Instead of formatting files, you can get a report of any files that aren't formatted by running:


### PR DESCRIPTION
Adds a `--stdin-files` flag to the `fmt`, `check`, `file-paths`, and `format-times` subcommands that reads a newline-separated list of file paths from stdin instead of from the command line arguments.

Closes #745