### PR TITLE
feat: support `"inherit": true` in nested configuration files

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -2590,6 +2590,30 @@ mod test {
   }
 
   #[test]
+  fn should_inherit_ancestor_excludes_in_nested_config() {
+    let file_path1 = "/file.txt";
+    let file_path2 = "/sub_dir/file.txt";
+    let file_path3 = "/sub_dir/skip/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin().add_excludes("**/skip");
+      })
+      .with_local_config("/sub_dir/dprint.json", |config| {
+        config.set_inherit(true);
+      })
+      .write_file(&file_path1, "text")
+      .write_file(&file_path2, "text")
+      .write_file(&file_path3, "text")
+      .build();
+    run_test_cli(vec!["fmt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_formatted");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text_formatted");
+    // the ancestor's "**/skip" exclude is inherited and still matches in the nested scope
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text");
+  }
+
+  #[test]
   fn should_not_inherit_ancestor_plugins_without_inherit_true() {
     // inheriting is opt-in, so a nested config without `"inherit": true`
     // and without any plugins of its own should error

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -2561,6 +2561,93 @@ mod test {
   }
 
   #[test]
+  fn should_inherit_ancestor_config_in_nested_config() {
+    let file_path1 = "/file.txt";
+    let file_path2 = "/sub_dir/file.txt";
+    let file_path3 = "/sub_dir/nested/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin().add_config_section("test-plugin", r#"{ "ending": "root" }"#);
+      })
+      // inherits the ancestor's plugin, but overrides its configuration
+      .with_local_config("/sub_dir/dprint.json", |config| {
+        config.set_inherit(true).add_config_section("test-plugin", r#"{ "ending": "sub" }"#);
+      })
+      // inherits without overriding anything, so it uses the ancestor's configuration
+      .with_local_config("/sub_dir/nested/dprint.json", |config| {
+        config.set_inherit(true);
+      })
+      .write_file(&file_path1, "text")
+      .write_file(&file_path2, "text")
+      .write_file(&file_path3, "text")
+      .build();
+    run_test_cli(vec!["fmt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_root");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text_sub");
+    // the nested config inherits the merged ancestor config (sub_dir, then root)
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text_sub");
+  }
+
+  #[test]
+  fn should_not_inherit_ancestor_plugins_without_inherit_true() {
+    // inheriting is opt-in, so a nested config without `"inherit": true`
+    // and without any plugins of its own should error
+    let file_path1 = "/file.txt";
+    let file_path2 = "/sub_dir/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/sub_dir/dprint.json", |config| {
+        config.add_config_section("test-plugin", r#"{ "ending": "sub" }"#);
+      })
+      .write_file(&file_path1, "text")
+      .write_file(&file_path2, "text")
+      .build();
+    let err = run_test_cli(vec!["fmt"], &environment).err().unwrap();
+    assert_eq!(
+      err.to_string(),
+      "No formatting plugins found. Ensure at least one is specified in the 'plugins' array of the configuration file."
+    );
+    err.assert_exit_code(13);
+  }
+
+  #[test]
+  fn should_combine_nested_config_plugins_with_inherited_plugins() {
+    // a nested config that inherits gets the ancestor's plugins in addition
+    // to any plugins it specifies itself (issue #711, project-c)
+    let file_path1 = "/file.txt";
+    let file_path2 = "/sub_dir/file.txt";
+    let file_path3 = "/sub_dir/file.txt_ps";
+    let environment = TestEnvironmentBuilder::new()
+      .add_remote_wasm_plugin()
+      .add_remote_process_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      // additionally pulls in the process plugin while inheriting the wasm plugin
+      .with_local_config("/sub_dir/dprint.json", |config| {
+        config.set_inherit(true).add_remote_process_plugin();
+      })
+      .initialize()
+      .write_file(&file_path1, "text")
+      .write_file(&file_path2, "text")
+      .write_file(&file_path3, "text")
+      .build();
+    run_test_cli(vec!["fmt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    // the process plugin is only used in the nested scope, so it's extracted lazily there
+    assert_eq!(environment.take_stderr_messages(), vec!["Extracting zip for test-process-plugin"]);
+    // only the wasm plugin in the root scope
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_formatted");
+    // the nested scope inherits the wasm plugin
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text_formatted");
+    // ...and additionally has the process plugin it specified (handles .txt_ps)
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text_formatted_process");
+  }
+
+  #[test]
   fn should_not_error_nested_config_no_matching_files_in_scope_cli_args() {
     let file_path1 = "/sub_dir/file.txt";
     let file_path2 = "/sub_dir/sub_dir/file.txt";

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -19,6 +19,7 @@ use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::plugins::PluginSourceReference;
 use crate::plugins::parse_plugin_source_reference;
+use crate::utils::GlobPattern;
 use crate::utils::PathSource;
 use crate::utils::PluginKind;
 use crate::utils::ResolvedFilePathWithText;
@@ -214,18 +215,15 @@ pub async fn resolve_config_from_path_with_bytes<TEnvironment: Environment>(
 /// config have precedence over the ancestor's plugins, the ancestor's excludes
 /// are combined with the nested config's excludes, and plugin configurations are
 /// merged with the nested config winning on conflicts.
+///
+/// Note: `includes` are not inherited.
 pub fn inherit_config(mut config: ResolvedConfig, parent: &ResolvedConfig) -> Result<ResolvedConfig> {
   // plugins specified in the nested config have precedence over the ancestor's
   config.plugins.extend(parent.plugins.iter().cloned());
   config.plugins = filter_duplicate_plugin_sources(std::mem::take(&mut config.plugins));
 
-  // combine excludes (nested config's excludes have precedence)
-  if let Some(parent_excludes) = &parent.excludes {
-    match &mut config.excludes {
-      Some(excludes) => excludes.extend(parent_excludes.iter().cloned()),
-      None => config.excludes = Some(parent_excludes.clone()),
-    }
-  }
+  // combine excludes, rebasing the ancestor's patterns onto this config's directory
+  config.excludes = inherit_excludes(config.excludes, parent.excludes.as_deref(), &parent.base_path, &config.base_path);
 
   // inherit the incremental flag when not specified in the nested config
   if config.incremental.is_none() {
@@ -235,6 +233,36 @@ pub fn inherit_config(mut config: ResolvedConfig, parent: &ResolvedConfig) -> Re
   merge_config_map_into(&mut config.config_map, parent.config_map.clone())?;
 
   Ok(config)
+}
+
+/// Combines a nested config's own excludes with its ancestor's, rebasing each
+/// ancestor pattern from the ancestor's directory onto the nested config's
+/// directory. Ancestor patterns that don't reach into the nested directory are
+/// dropped.
+///
+/// The ancestor's patterns are ordered first so the nested config's own excludes
+/// can opt back out of them (ex. with a `!` pattern).
+fn inherit_excludes(
+  own: Option<Vec<String>>,
+  ancestor: Option<&[String]>,
+  ancestor_base: &CanonicalizedPathBuf,
+  new_base: &CanonicalizedPathBuf,
+) -> Option<Vec<String>> {
+  let Some(ancestor) = ancestor else {
+    return own;
+  };
+  let mut result = ancestor
+    .iter()
+    .filter_map(|pattern| {
+      GlobPattern::new(pattern.clone(), ancestor_base.clone())
+        .into_new_base(new_base.clone())
+        .map(|p| p.relative_pattern)
+    })
+    .collect::<Vec<_>>();
+  if let Some(own) = own {
+    result.extend(own);
+  }
+  if result.is_empty() { None } else { Some(result) }
 }
 
 fn resolve_extends<TEnvironment: Environment>(
@@ -1825,7 +1853,9 @@ mod tests {
       source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/dprint.json")),
       base_path: CanonicalizedPathBuf::new_for_testing("/"),
       includes: Some(vec!["**/*.txt".to_string()]),
-      excludes: Some(vec!["root-excludes".to_string()]),
+      // "**/node_modules" rebases into the nested directory, but the anchored
+      // "dist" points outside it and is dropped
+      excludes: Some(vec!["**/node_modules".to_string(), "dist".to_string()]),
       plugins: vec![
         PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
         PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/json.wasm"),
@@ -1877,9 +1907,9 @@ mod tests {
         PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/json.wasm"),
       ]
     );
-    // excludes are combined (child's first)
-    assert_eq!(result.excludes, Some(vec!["sub-excludes".to_string(), "root-excludes".to_string()]));
-    // includes are not inherited (they're relative to the ancestor's directory)
+    // ancestor excludes (rebased, droppable) come first, then the nested config's own
+    assert_eq!(result.excludes, Some(vec!["**/node_modules".to_string(), "sub-excludes".to_string()]));
+    // includes are not inherited
     assert_eq!(result.includes, None);
     // incremental is inherited when not specified
     assert_eq!(result.incremental, Some(true));
@@ -1902,6 +1932,35 @@ mod tests {
         ),
         ("lineWidth".to_string(), ConfigMapValue::from_i32(80)),
       ])
+    );
+  }
+
+  #[test]
+  fn inherit_config_should_rebase_ancestor_excludes_onto_nested_directory() {
+    fn inherited_excludes(ancestor: &[&str], ancestor_base: &str, new_base: &str) -> Option<Vec<String>> {
+      inherit_excludes(
+        None,
+        Some(&ancestor.iter().map(|s| s.to_string()).collect::<Vec<_>>()),
+        &CanonicalizedPathBuf::new_for_testing(ancestor_base),
+        &CanonicalizedPathBuf::new_for_testing(new_base),
+      )
+    }
+
+    // depth-relative patterns keep matching within the nested directory
+    assert_eq!(inherited_excludes(&["**/node_modules"], "/", "/sub"), Some(vec!["**/node_modules".to_string()]));
+    // a pattern anchored into the nested directory is rebased to be relative to it
+    assert_eq!(inherited_excludes(&["sub/dist"], "/", "/sub"), Some(vec!["dist".to_string()]));
+    // an anchored pattern that points outside the nested directory is dropped
+    assert_eq!(inherited_excludes(&["other/dist"], "/", "/sub"), None);
+    // dropping leaves the nested config's own excludes intact
+    assert_eq!(
+      inherit_excludes(
+        Some(vec!["own".to_string()]),
+        Some(&["other/dist".to_string()]),
+        &CanonicalizedPathBuf::new_for_testing("/"),
+        &CanonicalizedPathBuf::new_for_testing("/sub"),
+      ),
+      Some(vec!["own".to_string()])
     );
   }
 

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -38,6 +38,9 @@ pub struct ResolvedConfig {
   pub excludes: Option<Vec<String>>,
   pub plugins: Vec<PluginSourceReference>,
   pub incremental: Option<bool>,
+  /// Whether a nested (directory specific) configuration file should inherit
+  /// the plugins and configuration of its ancestor configuration file.
+  pub inherit: Option<bool>,
   pub config_map: ConfigMap,
 }
 
@@ -119,6 +122,7 @@ pub async fn resolve_config_from_args(args: &CliArgs, environment: &impl Environ
           excludes: None,
           includes: None,
           incremental: None,
+          inherit: None,
           plugins: Vec::new(),
         }
       } else if args.config_discovery(environment).traverse_ancestors() {
@@ -185,6 +189,7 @@ pub async fn resolve_config_from_path_with_bytes<TEnvironment: Environment>(
   let excludes = take_array_from_config_map(&mut config_map, "excludes")?;
 
   let incremental = take_bool_from_config_map(&mut config_map, "incremental")?;
+  let inherit = take_bool_from_config_map(&mut config_map, "inherit")?;
   config_map.shift_remove("projectType"); // this was an old config property that's no longer used
   let extends = take_extends(&mut config_map)?;
   let resolved_config = ResolvedConfig {
@@ -195,10 +200,41 @@ pub async fn resolve_config_from_path_with_bytes<TEnvironment: Environment>(
     excludes,
     plugins,
     incremental,
+    inherit,
   };
 
   // resolve extends
   Ok(resolve_extends(resolved_config, extends, base_source, environment.clone()).await?)
+}
+
+/// Merges the ancestor (`parent`) configuration into a nested configuration
+/// file that has specified `"inherit": true`.
+///
+/// The nested config's values take precedence. Plugins specified in the nested
+/// config have precedence over the ancestor's plugins, the ancestor's excludes
+/// are combined with the nested config's excludes, and plugin configurations are
+/// merged with the nested config winning on conflicts.
+pub fn inherit_config(mut config: ResolvedConfig, parent: &ResolvedConfig) -> Result<ResolvedConfig> {
+  // plugins specified in the nested config have precedence over the ancestor's
+  config.plugins.extend(parent.plugins.iter().cloned());
+  config.plugins = filter_duplicate_plugin_sources(std::mem::take(&mut config.plugins));
+
+  // combine excludes (nested config's excludes have precedence)
+  if let Some(parent_excludes) = &parent.excludes {
+    match &mut config.excludes {
+      Some(excludes) => excludes.extend(parent_excludes.iter().cloned()),
+      None => config.excludes = Some(parent_excludes.clone()),
+    }
+  }
+
+  // inherit the incremental flag when not specified in the nested config
+  if config.incremental.is_none() {
+    config.incremental = parent.incremental;
+  }
+
+  merge_config_map_into(&mut config.config_map, parent.config_map.clone())?;
+
+  Ok(config)
 }
 
 fn resolve_extends<TEnvironment: Environment>(
@@ -270,19 +306,32 @@ async fn handle_config_file<TEnvironment: Environment>(
   // combine plugins
   resolved_config.plugins.extend(plugins);
 
-  for (key, value) in new_config_map {
+  merge_config_map_into(&mut resolved_config.config_map, new_config_map)?;
+
+  resolve_extends(resolved_config, extends, config_path_and_text.source.parent(), environment.clone()).await
+}
+
+/// Merges the lower precedence `source` config map into the higher precedence
+/// `target` config map. Values already present in `target` win, while plugin
+/// configurations have their properties and overrides combined.
+///
+/// This is used both when resolving `extends` (the extended config is the lower
+/// precedence `source`) and when a nested config `inherit`s its ancestor (the
+/// ancestor config is the lower precedence `source`).
+fn merge_config_map_into(target: &mut ConfigMap, source: ConfigMap) -> Result<()> {
+  for (key, value) in source {
     match value {
       ConfigMapValue::KeyValue(key_value) => {
-        resolved_config.config_map.entry(key).or_insert(ConfigMapValue::KeyValue(key_value));
+        target.entry(key).or_insert(ConfigMapValue::KeyValue(key_value));
       }
       ConfigMapValue::Vec(items) => {
-        resolved_config.config_map.entry(key).or_insert(ConfigMapValue::Vec(items));
+        target.entry(key).or_insert(ConfigMapValue::Vec(items));
       }
       ConfigMapValue::PluginConfig(obj) => {
-        if let Some(resolved_config_obj) = resolved_config.config_map.get_mut(&key) {
-          if let ConfigMapValue::PluginConfig(resolved_config_obj) = resolved_config_obj {
+        if let Some(target_obj) = target.get_mut(&key) {
+          if let ConfigMapValue::PluginConfig(target_obj) = target_obj {
             // check for locked configuration
-            if obj.locked && (!resolved_config_obj.properties.is_empty() || !resolved_config_obj.overrides.is_empty()) {
+            if obj.locked && (!target_obj.properties.is_empty() || !target_obj.overrides.is_empty()) {
               bail!(
                 concat!(
                   "The configuration for \"{}\" was locked, but a parent configuration specified it. ",
@@ -294,30 +343,29 @@ async fn handle_config_file<TEnvironment: Environment>(
 
             // now the properties
             for (key, value) in obj.properties {
-              resolved_config_obj.properties.entry(key).or_insert(value);
+              target_obj.properties.entry(key).or_insert(value);
             }
 
             if !obj.overrides.is_empty() {
               let mut overrides = obj.overrides;
-              overrides.append(&mut resolved_config_obj.overrides);
-              resolved_config_obj.overrides = overrides;
+              overrides.append(&mut target_obj.overrides);
+              target_obj.overrides = overrides;
             }
 
-            // Set the associations if they aren't overwritten in the parent
-            // config. This is ok to do because process plugins and includes/excludes
-            // aren't inherited from other config.
-            if resolved_config_obj.associations.is_none() {
-              resolved_config_obj.associations = obj.associations;
+            // Set the associations if they aren't overwritten in the higher
+            // precedence config. This is ok to do because process plugins and
+            // includes/excludes aren't inherited from other config.
+            if target_obj.associations.is_none() {
+              target_obj.associations = obj.associations;
             }
           }
         } else {
-          resolved_config.config_map.insert(key, ConfigMapValue::PluginConfig(obj));
+          target.insert(key, ConfigMapValue::PluginConfig(obj));
         }
       }
     }
   }
-
-  resolve_extends(resolved_config, extends, config_path_and_text.source.parent(), environment.clone()).await
+  Ok(())
 }
 
 fn take_extends(config_map: &mut ConfigMap) -> Result<Vec<String>> {
@@ -557,6 +605,67 @@ mod tests {
     )
     .unwrap();
     resolve_config_from_args(&args, environment).await
+  }
+
+  async fn resolve_local_config(path: &str, environment: &TestEnvironment) -> ResolvedConfig {
+    let canonical = environment.canonicalize(path).unwrap();
+    let config_path = ResolvedConfigPathWithText {
+      content: environment.read_file(&canonical).unwrap(),
+      base_path: canonical.parent().unwrap(),
+      source: PathSource::new_local(canonical),
+      is_global_config: false,
+      is_first_download: false,
+    };
+    resolve_config_from_path_with_bytes(&config_path, environment).await.unwrap()
+  }
+
+  #[test]
+  fn inherit_config_should_keep_config_dir_relative_to_each_config_file() {
+    // ${configDir} is expanded when each config file is parsed (before the inherit
+    // merge), so an inherited value keeps the ancestor's directory rather than being
+    // re-based to the nested config file's directory.
+    let environment = TestEnvironmentBuilder::new()
+      .write_file(
+        "/a/dprint.json",
+        r#"{
+            "test": {
+              "fromAncestor": "${configDir}/value"
+            }
+        }"#,
+      )
+      .write_file(
+        "/a/b/dprint.json",
+        r#"{
+            "inherit": true,
+            "test": {
+              "fromNested": "${configDir}/value"
+            }
+        }"#,
+      )
+      .build();
+
+    environment.clone().run_in_runtime(async move {
+      let parent = resolve_local_config("/a/dprint.json", &environment).await;
+      let child = resolve_local_config("/a/b/dprint.json", &environment).await;
+      let result = inherit_config(child, &parent).unwrap();
+      assert_eq!(
+        result.config_map,
+        ConfigMap::from([(
+          "test".to_string(),
+          ConfigMapValue::PluginConfig(RawPluginConfig {
+            locked: false,
+            associations: None,
+            overrides: Vec::new(),
+            properties: ConfigKeyMap::from([
+              // the nested config file's ${configDir} points at its own directory...
+              ("fromNested".to_string(), ConfigKeyValue::from_str("/a/b/value")),
+              // ...while the inherited value still points at the ancestor's directory
+              ("fromAncestor".to_string(), ConfigKeyValue::from_str("/a/value")),
+            ]),
+          }),
+        )])
+      );
+    });
   }
 
   #[test]
@@ -1686,6 +1795,163 @@ mod tests {
       assert_eq!(environment.take_stdout_messages().len(), 0);
       assert_eq!(result.incremental, Some(false));
     });
+  }
+
+  #[test]
+  fn should_parse_inherit_property() {
+    let environment = TestEnvironment::new();
+    environment
+      .write_file(
+        &PathBuf::from("/test.json"),
+        r#"{
+            "inherit": true,
+            "plugins": ["./testing/asdf.wasm"],
+        }"#,
+      )
+      .unwrap();
+
+    environment.clone().run_in_runtime(async move {
+      let result = get_result("/test.json", &environment).await.unwrap();
+      assert_eq!(environment.take_stdout_messages().len(), 0);
+      assert_eq!(result.inherit, Some(true));
+      // should not leak into the config map (which would cause an unknown property diagnostic)
+      assert_eq!(result.config_map.contains_key("inherit"), false);
+    });
+  }
+
+  #[test]
+  fn inherit_config_should_merge_ancestor_config() {
+    let parent = ResolvedConfig {
+      source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/dprint.json")),
+      base_path: CanonicalizedPathBuf::new_for_testing("/"),
+      includes: Some(vec!["**/*.txt".to_string()]),
+      excludes: Some(vec!["root-excludes".to_string()]),
+      plugins: vec![
+        PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
+        PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/json.wasm"),
+      ],
+      incremental: Some(true),
+      inherit: None,
+      config_map: ConfigMap::from([
+        ("lineWidth".to_string(), ConfigMapValue::from_i32(80)),
+        (
+          "test".to_string(),
+          ConfigMapValue::PluginConfig(RawPluginConfig {
+            locked: false,
+            associations: None,
+            overrides: Vec::new(),
+            properties: ConfigKeyMap::from([
+              ("indentWidth".to_string(), ConfigKeyValue::from_i32(4)),
+              ("newLineKind".to_string(), ConfigKeyValue::from_str("crlf")),
+            ]),
+          }),
+        ),
+      ]),
+    };
+    let child = ResolvedConfig {
+      source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/sub/dprint.json")),
+      base_path: CanonicalizedPathBuf::new_for_testing("/sub"),
+      includes: None,
+      excludes: Some(vec!["sub-excludes".to_string()]),
+      // a plugin specified in the child has precedence over the ancestor's
+      plugins: vec![PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm")],
+      incremental: None,
+      inherit: Some(true),
+      config_map: ConfigMap::from([(
+        "test".to_string(),
+        ConfigMapValue::PluginConfig(RawPluginConfig {
+          locked: false,
+          associations: None,
+          overrides: Vec::new(),
+          properties: ConfigKeyMap::from([("indentWidth".to_string(), ConfigKeyValue::from_i32(2))]),
+        }),
+      )]),
+    };
+
+    let result = inherit_config(child, &parent).unwrap();
+    // child plugins first, then ancestor's, with duplicates removed
+    assert_eq!(
+      result.plugins,
+      vec![
+        PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
+        PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/json.wasm"),
+      ]
+    );
+    // excludes are combined (child's first)
+    assert_eq!(result.excludes, Some(vec!["sub-excludes".to_string(), "root-excludes".to_string()]));
+    // includes are not inherited (they're relative to the ancestor's directory)
+    assert_eq!(result.includes, None);
+    // incremental is inherited when not specified
+    assert_eq!(result.incremental, Some(true));
+    assert_eq!(
+      result.config_map,
+      ConfigMap::from([
+        (
+          "test".to_string(),
+          ConfigMapValue::PluginConfig(RawPluginConfig {
+            locked: false,
+            associations: None,
+            overrides: Vec::new(),
+            properties: ConfigKeyMap::from([
+              // child wins on conflicts...
+              ("indentWidth".to_string(), ConfigKeyValue::from_i32(2)),
+              // ...but inherits values it didn't override
+              ("newLineKind".to_string(), ConfigKeyValue::from_str("crlf")),
+            ]),
+          }),
+        ),
+        ("lineWidth".to_string(), ConfigMapValue::from_i32(80)),
+      ])
+    );
+  }
+
+  #[test]
+  fn inherit_config_should_error_overriding_locked_ancestor_config() {
+    let parent = ResolvedConfig {
+      source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/dprint.json")),
+      base_path: CanonicalizedPathBuf::new_for_testing("/"),
+      includes: None,
+      excludes: None,
+      plugins: Vec::new(),
+      incremental: None,
+      inherit: None,
+      config_map: ConfigMap::from([(
+        "test".to_string(),
+        ConfigMapValue::PluginConfig(RawPluginConfig {
+          locked: true,
+          associations: None,
+          overrides: Vec::new(),
+          properties: ConfigKeyMap::from([("indentWidth".to_string(), ConfigKeyValue::from_i32(4))]),
+        }),
+      )]),
+    };
+    let child = ResolvedConfig {
+      source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/sub/dprint.json")),
+      base_path: CanonicalizedPathBuf::new_for_testing("/sub"),
+      includes: None,
+      excludes: None,
+      plugins: Vec::new(),
+      incremental: None,
+      inherit: Some(true),
+      config_map: ConfigMap::from([(
+        "test".to_string(),
+        ConfigMapValue::PluginConfig(RawPluginConfig {
+          locked: false,
+          associations: None,
+          overrides: Vec::new(),
+          properties: ConfigKeyMap::from([("indentWidth".to_string(), ConfigKeyValue::from_i32(2))]),
+        }),
+      )]),
+    };
+
+    let err = inherit_config(child, &parent).err().unwrap();
+    assert_eq!(
+      err.to_string(),
+      concat!(
+        "The configuration for \"test\" was locked, but a parent configuration specified it. ",
+        "Locked configurations cannot have their properties overridden."
+      )
+    );
   }
 
   #[test]

--- a/crates/dprint/src/environment/test_environment_builder.rs
+++ b/crates/dprint/src/environment/test_environment_builder.rs
@@ -13,6 +13,7 @@ use crate::utils::get_sha256_checksum;
 pub struct TestConfigFileBuilder {
   environment: TestEnvironment,
   incremental: Option<bool>,
+  inherit: Option<bool>,
   includes: Option<Vec<String>>,
   excludes: Option<Vec<String>>,
   plugins: Option<Vec<String>>,
@@ -24,6 +25,7 @@ impl TestConfigFileBuilder {
     TestConfigFileBuilder {
       environment,
       incremental: None,
+      inherit: None,
       includes: None,
       excludes: None,
       plugins: None,
@@ -33,6 +35,9 @@ impl TestConfigFileBuilder {
 
   pub fn to_string(&self) -> String {
     let mut parts = Vec::new();
+    if let Some(inherit) = self.inherit.as_ref() {
+      parts.push(format!(r#""inherit": {}"#, inherit));
+    }
     for (key, value) in self.sections.iter() {
       parts.push(format!("\"{}\": {}", key, value));
     }
@@ -60,6 +65,11 @@ impl TestConfigFileBuilder {
 
   pub fn set_incremental(&mut self, value: bool) -> &mut Self {
     self.incremental = Some(value);
+    self
+  }
+
+  pub fn set_inherit(&mut self, value: bool) -> &mut Self {
+    self.inherit = Some(value);
     self
   }
 

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -35,6 +35,7 @@ use crate::configuration::ResolvedConfig;
 use crate::configuration::ResolvedConfigPathWithText;
 use crate::configuration::get_global_config;
 use crate::configuration::get_plugin_config_map;
+use crate::configuration::inherit_config;
 use crate::configuration::resolve_config_from_args;
 use crate::configuration::resolve_config_from_path_with_bytes;
 use crate::environment::CanonicalizedPathBuf;
@@ -631,6 +632,10 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
         is_first_download: false,
       };
       let mut config = resolve_config_from_path_with_bytes(&config_path, self.environment).await?;
+      // when the nested config opts into inheriting, merge in the ancestor config
+      if config.inherit == Some(true) {
+        config = inherit_config(config, parent_config)?;
+      }
       if !self.args.plugins.is_empty() {
         config.plugins.clone_from(&parent_config.plugins);
       }

--- a/website/src/assets/schemas/v0.json
+++ b/website/src/assets/schemas/v0.json
@@ -14,6 +14,11 @@
       "type": "boolean",
       "default": true
     },
+    "inherit": {
+      "description": "For a nested (directory specific) configuration file, whether to inherit the plugins and configuration of the ancestor configuration file. Has no effect on a root configuration file.",
+      "type": "boolean",
+      "default": false
+    },
     "extends": {
       "description": "Configurations to extend.",
       "anyOf": [{

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -387,7 +387,7 @@ When inheriting:
 - Plugins specified in the nested configuration file have precedence over the ancestor's plugins. Any plugins not specified are inherited from the ancestor.
 - Plugin configuration is merged with the nested configuration file winning on conflicts.
 - The ancestor's `excludes` are combined with the nested configuration file's `excludes`.
-- The ancestor's `includes` are _not_ inherited as they're relative to the ancestor's directory.
+- The ancestor's `includes` are _not_ inherited.
 
 Inheriting is opt-in (rather than opt-out) so that adding a configuration file higher up in the directory structure does not unexpectedly start affecting a nested configuration file.
 

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -349,6 +349,48 @@ Referencing multiple configuration files is also supported. These should be orde
 
 Note: The `includes` property of extended _remote_ configuration is ignored for security reasons out of an abundance of caution (to disallow the dprint cli pulling in sensitive files) and additionally non-Wasm plugins are ignored in remote configuration because they don't run sandboxed.
 
+## Directory Specific Configuration
+
+Useful for monorepos, you may place additional configuration files in descendant directories. When dprint searches for files to format, it stops descending into a directory once it discovers a configuration file there and uses that configuration file for the files in that subtree instead (see [changing config discovery](/cli#changing-config-discovery)).
+
+By default a nested configuration file is completely independent—it does not pick up the plugins or configuration of the ancestor configuration file:
+
+<!-- dprint-ignore -->
+
+```json
+// ./sub-project/dprint.json
+{
+  // only TOML files in ./sub-project will be formatted
+  "plugins": [
+    "https://plugins.dprint.dev/toml-x.x.x.wasm"
+  ]
+}
+```
+
+To instead inherit the plugins and configuration of the ancestor configuration file, specify `"inherit": true`:
+
+<!-- dprint-ignore -->
+
+```json
+// ./sub-project/dprint.json
+{
+  "inherit": true,
+  "typescript": {
+    // inherits the ancestor's TypeScript config, but overrides the indent width
+    "indentWidth": 2
+  }
+}
+```
+
+When inheriting:
+
+- Plugins specified in the nested configuration file have precedence over the ancestor's plugins. Any plugins not specified are inherited from the ancestor.
+- Plugin configuration is merged with the nested configuration file winning on conflicts.
+- The ancestor's `excludes` are combined with the nested configuration file's `excludes`.
+- The ancestor's `includes` are _not_ inherited as they're relative to the ancestor's directory.
+
+Inheriting is opt-in (rather than opt-out) so that adding a configuration file higher up in the directory structure does not unexpectedly start affecting a nested configuration file.
+
 ## Incremental
 
 By default, dprint will only format files that have changed since the last time you formatted the code in order to drastically improve performance.


### PR DESCRIPTION
Nested (directory specific) configuration files can now opt into
inheriting the plugins and configuration of their nearest ancestor
configuration file by specifying `"inherit": true`.

When inheriting:
- plugins in the nested config take precedence; others are inherited
- plugin configuration is merged, nested config winning on conflicts
- the ancestor's excludes are combined with the nested config's excludes
- incremental is inherited when not specified
- includes are not inherited (relative to the ancestor's directory)

Inheriting is opt-in so adding a config higher up doesn't unexpectedly
affect nested configs.

Closes #711