### PR TITLE
feat: opt-in support for git's global excludes file via DPRINT_GLOBAL_GITIGNORE

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -622,6 +622,9 @@ ENVIRONMENT VARIABLES:
                        to ignore all certificates or a comma separated list of specific
                        hosts to ignore (ex. dprint.dev,localhost,[::],127.0.0.1)
   DPRINT_EDITOR        Editor used for editing config files.
+  DPRINT_GLOBAL_GITIGNORE
+                       Set to "1" to also respect git's global excludes file
+                       (core.excludesFile). Disabled by default.
   HTTPS_PROXY          Proxy to use when downloading plugins or configuration
                        files (also supports HTTP_PROXY and NO_PROXY).
   NO_COLOR             Disables coloured output.

--- a/crates/dprint/src/commands/general.rs
+++ b/crates/dprint/src/commands/general.rs
@@ -695,6 +695,41 @@ mod test {
   }
 
   #[test]
+  fn global_gitignore_env_var() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_includes("**/*.txt");
+      })
+      // a `.git` dir makes the root a repository, where the global excludes apply
+      .write_file("/.git/HEAD", "")
+      .write_file("/global_ignore", "ignored.txt")
+      .write_file("/file.txt", "")
+      .write_file("/ignored.txt", "")
+      .write_file("/sub/ignored.txt", "")
+      .build();
+    environment.set_global_gitignore_path("/global_ignore");
+
+    // without the env var, the global excludes file is ignored
+    run_test_cli(vec!["output-file-paths"], &environment).unwrap();
+    let mut logged_messages = environment.take_stdout_messages();
+    logged_messages.sort();
+    assert_eq!(logged_messages, vec!["/file.txt", "/ignored.txt", "/sub/ignored.txt"]);
+
+    // with the env var, the global excludes apply to the repo and its descendants
+    environment.set_env_var("DPRINT_GLOBAL_GITIGNORE", Some("1"));
+    run_test_cli(vec!["output-file-paths"], &environment).unwrap();
+    let mut logged_messages = environment.take_stdout_messages();
+    logged_messages.sort();
+    assert_eq!(logged_messages, vec!["/file.txt"]);
+
+    // `--no-gitignore` disables it even when the env var is set
+    run_test_cli(vec!["output-file-paths", "--no-gitignore"], &environment).unwrap();
+    let mut logged_messages = environment.take_stdout_messages();
+    logged_messages.sort();
+    assert_eq!(logged_messages, vec!["/file.txt", "/ignored.txt", "/sub/ignored.txt"]);
+  }
+
+  #[test]
   fn should_clear_cache_directory() {
     let environment = TestEnvironment::new();
     environment.mk_dir_all("/cache").unwrap();

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -205,6 +205,12 @@ pub trait Environment:
   fn env_var(&self, name: &str) -> Option<OsString>;
 
   fn get_staged_files(&self) -> Result<Vec<PathBuf>>;
+  /// Resolves the path to git's global excludes file (the `core.excludesFile`
+  /// config value, falling back to `$XDG_CONFIG_HOME/git/ignore`). Used only when
+  /// global gitignore support is opted into via `DPRINT_GLOBAL_GITIGNORE`. The
+  /// path is not guaranteed to exist; the caller handles a missing file when
+  /// reading it. Returns `None` only when no path can be resolved at all.
+  fn global_gitignore_path(&self) -> Option<PathBuf>;
   fn read_file(&self, file_path: impl AsRef<Path>) -> io::Result<String>;
   fn maybe_read_file(&self, file_path: impl AsRef<Path>) -> io::Result<Option<String>> {
     match self.read_file(file_path) {

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -104,6 +104,18 @@ impl RealEnvironment {
     Ok(environment)
   }
 
+  /// Expands a leading `~` to the user's home directory, mirroring how git
+  /// expands `core.excludesFile`.
+  fn expand_user_path(&self, value: &str) -> Option<PathBuf> {
+    if value == "~" {
+      Some(self.get_home_dir()?.into_path_buf())
+    } else if let Some(rest) = value.strip_prefix("~/") {
+      Some(self.get_home_dir()?.join(rest))
+    } else {
+      Some(PathBuf::from(value))
+    }
+  }
+
   #[cfg(test)]
   pub fn run_test_with_real_env(run_with_env: impl Fn(RealEnvironment) -> dprint_core::async_runtime::LocalBoxFuture<'static, ()>) {
     let rt = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
@@ -253,6 +265,31 @@ impl Environment for RealEnvironment {
       .output()?;
 
     Ok(String::from_utf8_lossy(&output.stdout).lines().map(PathBuf::from).collect())
+  }
+
+  fn global_gitignore_path(&self) -> Option<PathBuf> {
+    // prefer the path configured via `git config core.excludesFile`
+    let configured = Command::new("git")
+      .arg("config")
+      .arg("--get")
+      .arg("core.excludesFile")
+      .output()
+      .ok()
+      .filter(|output| output.status.success())
+      .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+      .filter(|value| !value.is_empty());
+
+    match configured {
+      Some(value) => self.expand_user_path(&value),
+      None => {
+        // git's default location when `core.excludesFile` is unset
+        let base = match std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+          Some(xdg) => PathBuf::from(xdg),
+          None => self.get_home_dir()?.join(".config"),
+        };
+        Some(base.join("git").join("ignore"))
+      }
+    }
   }
 
   fn write_file_bytes(&self, file_path: impl AsRef<Path>, bytes: &[u8]) -> io::Result<()> {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -134,6 +134,7 @@ pub struct TestEnvironment {
   log_level: Arc<Mutex<LogLevel>>,
   sys: Arc<InMemorySys>,
   staged_files: Arc<Mutex<Vec<PathBuf>>>,
+  global_gitignore_path: Arc<Mutex<Option<PathBuf>>>,
   stdout_messages: Arc<Mutex<Vec<String>>>,
   stderr_messages: Arc<Mutex<Vec<String>>>,
   remote_files: Arc<Mutex<HashMap<String, Result<Vec<u8>>>>>,
@@ -174,6 +175,7 @@ impl TestEnvironment {
       log_level: Arc::new(Mutex::new(LogLevel::Info)),
       sys: Default::default(),
       staged_files: Default::default(),
+      global_gitignore_path: Default::default(),
       stdout_messages: Default::default(),
       stderr_messages: Default::default(),
       remote_files: Default::default(),
@@ -299,6 +301,9 @@ impl TestEnvironment {
 
   pub fn set_staged_file(&self, file: impl AsRef<Path>) {
     self.staged_files.lock().push(file.as_ref().to_path_buf())
+  }
+  pub fn set_global_gitignore_path(&self, path: impl AsRef<Path>) {
+    *self.global_gitignore_path.lock() = Some(path.as_ref().to_path_buf());
   }
   pub fn set_dir_info_error(&self, err: io::Error) {
     *self.dir_info_error.lock() = Some(err);
@@ -505,6 +510,10 @@ impl Environment for TestEnvironment {
 
   fn get_staged_files(&self) -> Result<Vec<PathBuf>> {
     Ok(self.staged_files.lock().clone())
+  }
+
+  fn global_gitignore_path(&self) -> Option<PathBuf> {
+    self.global_gitignore_path.lock().clone()
   }
 
   fn read_file(&self, file_path: impl AsRef<Path>) -> io::Result<String> {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -9,7 +9,6 @@ use crate::environment::Environment;
 use crate::utils::ExcludeMatchDetail;
 use crate::utils::GitIgnoreTree;
 use crate::utils::GitIgnoreTreeOptions;
-use crate::utils::resolve_global_gitignore_lines;
 use crate::utils::GlobMatcher;
 use crate::utils::GlobMatcherOptions;
 use crate::utils::GlobMatchesDetail;
@@ -17,6 +16,7 @@ use crate::utils::GlobPattern;
 use crate::utils::GlobPatterns;
 use crate::utils::is_absolute_pattern;
 use crate::utils::is_negated_glob;
+use crate::utils::resolve_global_gitignore_lines;
 
 pub struct FileMatcher<TEnvironment: Environment> {
   glob_matcher: GlobMatcher,

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -8,6 +8,8 @@ use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::utils::ExcludeMatchDetail;
 use crate::utils::GitIgnoreTree;
+use crate::utils::GitIgnoreTreeOptions;
+use crate::utils::resolve_global_gitignore_lines;
 use crate::utils::GlobMatcher;
 use crate::utils::GlobMatcherOptions;
 use crate::utils::GlobMatchesDetail;
@@ -27,10 +29,14 @@ impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
     let gitignores = if args.no_gitignore {
       None
     } else {
+      let global_gitignore_lines = resolve_global_gitignore_lines(&environment);
       Some(GitIgnoreTree::new(
         environment,
-        // explicitly specified paths should override what's in the gitignore
-        patterns.include_paths(),
+        GitIgnoreTreeOptions {
+          // explicitly specified paths should override what's in the gitignore
+          include_paths: patterns.include_paths(),
+          global_gitignore_lines,
+        },
       ))
     };
     let glob_matcher = GlobMatcher::new(
@@ -312,7 +318,7 @@ mod test {
     .unwrap();
     let mut file_matcher = FileMatcher {
       glob_matcher,
-      gitignores: Some(GitIgnoreTree::new(environment, vec![])),
+      gitignores: Some(GitIgnoreTree::new(environment, GitIgnoreTreeOptions::default())),
     };
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/match.ts", true);
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/other/match.ts", true);
@@ -343,7 +349,7 @@ mod test {
     .unwrap();
     let mut file_matcher = FileMatcher {
       glob_matcher,
-      gitignores: Some(GitIgnoreTree::new(environment, vec![])),
+      gitignores: Some(GitIgnoreTree::new(environment, GitIgnoreTreeOptions::default())),
     };
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/sub-dir/dir/match.ts", true);
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/sub-dir/dir/other/match.ts", true);

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -378,6 +378,9 @@ ENVIRONMENT VARIABLES:
                        to ignore all certificates or a comma separated list of specific
                        hosts to ignore (ex. dprint.dev,localhost,[::],127.0.0.1)
   DPRINT_EDITOR        Editor used for editing config files.
+  DPRINT_GLOBAL_GITIGNORE
+                       Set to "1" to also respect git's global excludes file
+                       (core.excludesFile). Disabled by default.
   HTTPS_PROXY          Proxy to use when downloading plugins or configuration
                        files (also supports HTTP_PROXY and NO_PROXY).
   NO_COLOR             Disables coloured output.

--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -34,6 +34,37 @@ impl DirGitIgnores {
   }
 }
 
+/// Resolves the lines of git's global excludes file when global gitignore
+/// support is opted into via the `DPRINT_GLOBAL_GITIGNORE` environment variable.
+/// Returns an empty list when disabled or when no global excludes file exists.
+pub fn resolve_global_gitignore_lines(environment: &impl Environment) -> Vec<String> {
+  if !global_gitignore_enabled(environment) {
+    return Vec::new();
+  }
+  let Some(path) = environment.global_gitignore_path() else {
+    return Vec::new();
+  };
+  match environment.maybe_read_file(&path) {
+    Ok(Some(text)) => text.lines().map(|line| line.to_string()).collect(),
+    Ok(None) => Vec::new(), // no global excludes file present
+    Err(err) => {
+      log_debug!(environment, "Failed reading global gitignore '{}': {:#}", path.display(), err);
+      Vec::new()
+    }
+  }
+}
+
+fn global_gitignore_enabled(environment: &impl Environment) -> bool {
+  match environment.env_var("DPRINT_GLOBAL_GITIGNORE") {
+    Some(value) => {
+      let value = value.to_string_lossy();
+      let value = value.trim();
+      value == "1" || value.eq_ignore_ascii_case("true")
+    }
+    None => false,
+  }
+}
+
 /// Whether `.gitignore` and `.git` are present in a directory the caller has
 /// already listed. Providing this lets resolution skip file system calls for
 /// files it can already tell are absent.
@@ -43,24 +74,29 @@ pub struct DirEntriesHint {
   pub has_git: bool,
 }
 
+#[derive(Default)]
+pub struct GitIgnoreTreeOptions {
+  /// Paths that should override what's in the gitignore.
+  pub include_paths: Vec<PathBuf>,
+  /// Lines from git's global excludes file, applied at the repository root with
+  /// the lowest precedence. Empty unless global gitignore support is opted into.
+  pub global_gitignore_lines: Vec<String>,
+}
+
 /// Resolves gitignores in a directory tree taking into account
 /// ancestor gitignores that may be found in a directory.
 pub struct GitIgnoreTree<TEnvironment> {
   environment: TEnvironment,
   ignores: HashMap<PathBuf, Option<Rc<DirGitIgnores>>>,
-  include_paths: Vec<PathBuf>,
+  options: GitIgnoreTreeOptions,
 }
 
 impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
-  pub fn new(
-    environment: TEnvironment,
-    // paths that should override what's in the gitignore
-    include_paths: Vec<PathBuf>,
-  ) -> Self {
+  pub fn new(environment: TEnvironment, options: GitIgnoreTreeOptions) -> Self {
     Self {
       environment,
       ignores: Default::default(),
-      include_paths,
+      options,
     }
   }
 
@@ -123,13 +159,19 @@ impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
     } else {
       None
     };
-    if gitignore_text.is_none() && exclude_text.is_none() {
+    // git's global excludes file applies repository-wide, so resolve it at the
+    // repo root where it becomes the parent of every descendant directory
+    let global_lines: &[String] = if is_repo_root { self.options.global_gitignore_lines.as_slice() } else { &[] };
+    if gitignore_text.is_none() && exclude_text.is_none() && global_lines.is_empty() {
       return None;
     }
 
     let mut builder = ignore::gitignore::GitignoreBuilder::new(dir_path);
-    // add `.git/info/exclude` first so that the closer `.gitignore` patterns
-    // take precedence (the last matching pattern wins)
+    // git's precedence is global excludes < `.git/info/exclude` < `.gitignore`,
+    // and the last matching pattern wins, so add them in that order
+    for line in global_lines {
+      builder.add_line(None, line).ok()?;
+    }
     if let Some(text) = &exclude_text {
       for line in text.lines() {
         builder.add_line(None, line).ok()?;
@@ -141,7 +183,7 @@ impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
       }
     }
     // override the gitignore contents to include these paths
-    for path in &self.include_paths {
+    for path in &self.options.include_paths {
       if let Ok(suffix) = path.strip_prefix(dir_path) {
         let suffix = suffix.to_string_lossy().replace('\\', "/");
         let _ignore = builder.add_line(None, &format!("!/{}", suffix));
@@ -168,7 +210,7 @@ mod test {
     env.mk_dir_all("/sub_dir/sub_dir").unwrap();
     env.write_file("/sub_dir/.gitignore", "data.txt").unwrap();
     env.write_file("/sub_dir/sub_dir/.gitignore", "!file.txt\nignore.txt").unwrap();
-    let mut ignore_tree = GitIgnoreTree::new(env, Vec::new());
+    let mut ignore_tree = GitIgnoreTree::new(env, GitIgnoreTreeOptions::default());
     let mut run_test = |path: &str, expected: bool| {
       let path = PathBuf::from(path);
       let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
@@ -195,7 +237,7 @@ mod test {
     env.mk_dir_all("/.git/info").unwrap();
     env.write_file("/.git/info/exclude", "from_exclude.txt\n!unexclude.txt").unwrap();
     env.mk_dir_all("/sub_dir").unwrap();
-    let mut ignore_tree = GitIgnoreTree::new(env, Vec::new());
+    let mut ignore_tree = GitIgnoreTree::new(env, GitIgnoreTreeOptions::default());
     let mut run_test = |path: &str, expected: bool| {
       let path = PathBuf::from(path);
       let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
@@ -209,12 +251,42 @@ mod test {
   }
 
   #[test]
+  fn global_gitignore_is_lowest_precedence() {
+    let env = TestEnvironment::new();
+    // a `.git` dir makes `/` the repo root, where the global excludes apply
+    env.mk_dir_all("/.git").unwrap();
+    env.write_file("/.git/HEAD", "").unwrap();
+    env.write_file("/.gitignore", "from_gitignore.txt\n!from_global.txt").unwrap();
+    env.mk_dir_all("/sub").unwrap();
+    let global_gitignore_lines = vec!["from_global.txt".to_string(), "*.log".to_string()];
+    let mut ignore_tree = GitIgnoreTree::new(
+      env,
+      GitIgnoreTreeOptions {
+        global_gitignore_lines,
+        ..Default::default()
+      },
+    );
+    let mut run_test = |path: &str, expected: bool| {
+      let path = PathBuf::from(path);
+      let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
+      assert_eq!(gitignore.is_ignored(&path, /* is_dir */ false), expected, "Path: {}", path.display());
+    };
+    // ignored by the global excludes file
+    run_test("/from_global.txt", false); // re-included by the closer `.gitignore`
+    run_test("/debug.log", true); // global pattern, applies to descendants too
+    run_test("/sub/debug.log", true);
+    // ignored by the repo `.gitignore`
+    run_test("/from_gitignore.txt", true);
+    run_test("/other.txt", false);
+  }
+
+  #[test]
   fn git_info_exclude_without_gitignore() {
     // a repo with only `.git/info/exclude` and no `.gitignore` should still be honoured
     let env = TestEnvironment::new();
     env.mk_dir_all("/.git/info").unwrap();
     env.write_file("/.git/info/exclude", "ignored.txt").unwrap();
-    let mut ignore_tree = GitIgnoreTree::new(env, Vec::new());
+    let mut ignore_tree = GitIgnoreTree::new(env, GitIgnoreTreeOptions::default());
     let path = PathBuf::from("/ignored.txt");
     let gitignore = ignore_tree.get_resolved_git_ignore_for_file(&path).unwrap();
     assert!(gitignore.is_ignored(&path, /* is_dir */ false));

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -13,6 +13,8 @@ use crate::environment::DirEntry;
 use crate::environment::Environment;
 use crate::utils::gitignore::DirEntriesHint;
 use crate::utils::gitignore::GitIgnoreTree;
+use crate::utils::gitignore::GitIgnoreTreeOptions;
+use crate::utils::gitignore::resolve_global_gitignore_lines;
 
 use super::ExcludeMatchDetail;
 use super::GlobMatcher;
@@ -59,7 +61,13 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
   let git_ignore_tree = if opts.no_gitignore {
     None
   } else {
-    Some(GitIgnoreTree::new(environment.clone(), opts.file_patterns.include_paths()))
+    Some(GitIgnoreTree::new(
+      environment.clone(),
+      GitIgnoreTreeOptions {
+        include_paths: opts.file_patterns.include_paths(),
+        global_gitignore_lines: resolve_global_gitignore_lines(environment),
+      },
+    ))
   };
   let glob_matcher = GlobMatcher::new(
     opts.file_patterns,
@@ -510,6 +518,110 @@ mod test {
     let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
     result.sort();
     assert_eq!(result, vec!["/included.txt", "/sub/included.txt"]);
+  }
+
+  #[tokio::test]
+  async fn should_respect_global_gitignore_when_opted_in() {
+    let environment = TestEnvironmentBuilder::new()
+      // a `.git` dir makes `/` the repository root, where the global excludes apply
+      .write_file("/.git/HEAD", "")
+      .write_file("/global_ignore", "globally_excluded.txt")
+      .write_file("/included.txt", "")
+      .write_file("/globally_excluded.txt", "")
+      .write_file("/sub/included.txt", "")
+      .write_file("/sub/globally_excluded.txt", "")
+      .build();
+    environment.set_env_var("DPRINT_GLOBAL_GITIGNORE", Some("1"));
+    environment.set_global_gitignore_path("/global_ignore");
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+
+    let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    // the global excludes apply at the repo root and to its descendants
+    assert_eq!(result, vec!["/included.txt", "/sub/included.txt"]);
+  }
+
+  #[tokio::test]
+  async fn should_ignore_global_gitignore_when_not_opted_in() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/.git/HEAD", "")
+      .write_file("/global_ignore", "globally_excluded.txt")
+      .write_file("/included.txt", "")
+      .write_file("/globally_excluded.txt", "")
+      .build();
+    // note: env var not set, so the global excludes file is ignored
+    environment.set_global_gitignore_path("/global_ignore");
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+
+    let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    assert_eq!(result, vec!["/globally_excluded.txt", "/included.txt"]);
+  }
+
+  #[tokio::test]
+  async fn no_gitignore_should_override_global_gitignore() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/.git/HEAD", "")
+      .write_file("/global_ignore", "globally_excluded.txt")
+      .write_file("/included.txt", "")
+      .write_file("/globally_excluded.txt", "")
+      .build();
+    environment.set_env_var("DPRINT_GLOBAL_GITIGNORE", Some("1"));
+    environment.set_global_gitignore_path("/global_ignore");
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        // `--no-gitignore` disables all gitignore handling, including the global file
+        no_gitignore: true,
+      },
+    )
+    .unwrap();
+
+    let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    assert_eq!(result, vec!["/globally_excluded.txt", "/included.txt"]);
   }
 
   #[tokio::test]

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -62,6 +62,18 @@ By default, dprint respects `.gitignore` files (as well as a repository's `.git/
 dprint fmt --no-gitignore
 ```
 
+### Respecting a global .gitignore
+
+By default, dprint does not respect git's global excludes file (`core.excludesFile`, defaulting to `$XDG_CONFIG_HOME/git/ignore`). This is opt-in because it's specific to your machine and won't exist on other machines or CI, so enabling it could cause formatting results to differ between environments.
+
+To opt in, set the `DPRINT_GLOBAL_GITIGNORE` environment variable to `1`:
+
+```sh
+DPRINT_GLOBAL_GITIGNORE=1 dprint fmt
+```
+
+The global excludes file has the lowest precedence, so a repository's `.gitignore` or `.git/info/exclude` can re-include files it ignores. Using `--no-gitignore` disables it along with all other gitignore handling.
+
 ### Formatting Standard Input
 
 Use `dprint fmt --stdin <file-path/file-name/extension>` and provide the input file text to stdin. The output will be directed by the CLI to stdout.


### PR DESCRIPTION
Setting `DPRINT_GLOBAL_GITIGNORE=1` makes dprint also respect git's global excludes file (core.excludesFile, defaulting to `$XDG_CONFIG_HOME/git/ignore`). It's opt-in because the file is machine-specific and won't exist on CI, so respecting it by default could make formatting results differ between environments.

The global excludes apply at the repository root with the lowest precedence (global < .git/info/exclude < .gitignore), so a repo's own gitignore can re-include files. `--no-gitignore` disables it along with all other gitignore handling.

Closes https://github.com/dprint/dprint/issues/855