### PR TITLE
feat: add --file flag to resolved-config to filter plugins by file

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -79,7 +79,7 @@ impl CliArgs {
     // these output json or other text that's read by stdout
     matches!(
       self.sub_command,
-      SubCommand::StdInFmt(..) | SubCommand::EditorInfo | SubCommand::OutputResolvedConfig | SubCommand::IncrementalState | SubCommand::Completions(..)
+      SubCommand::StdInFmt(..) | SubCommand::EditorInfo | SubCommand::OutputResolvedConfig(..) | SubCommand::IncrementalState | SubCommand::Completions(..)
     )
   }
 
@@ -117,7 +117,7 @@ pub enum SubCommand {
   Config(ConfigSubCommand),
   ClearCache,
   OutputFilePaths(OutputFilePathsSubCommand),
-  OutputResolvedConfig,
+  OutputResolvedConfig(OutputResolvedConfigSubCommand),
   IncrementalState,
   OutputFormatTimes(OutputFormatTimesSubCommand),
   Version,
@@ -151,7 +151,7 @@ impl SubCommand {
       SubCommand::OutputFormatTimes(a) => Some(&a.patterns),
       SubCommand::Config(_)
       | SubCommand::ClearCache
-      | SubCommand::OutputResolvedConfig
+      | SubCommand::OutputResolvedConfig(_)
       | SubCommand::IncrementalState
       | SubCommand::Version
       | SubCommand::License
@@ -214,6 +214,12 @@ pub enum ConfigSubCommand {
 #[derive(Debug, PartialEq, Eq)]
 pub struct OutputFilePathsSubCommand {
   pub patterns: FilePatternArgs,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct OutputResolvedConfigSubCommand {
+  /// When set, limits the output to only the plugins that would format this file.
+  pub file_path: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -401,7 +407,9 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
     ("file-paths", matches) => SubCommand::OutputFilePaths(OutputFilePathsSubCommand {
       patterns: parse_file_patterns(matches, &std_in_reader)?,
     }),
-    ("resolved-config", _) => SubCommand::OutputResolvedConfig,
+    ("resolved-config", matches) => SubCommand::OutputResolvedConfig(OutputResolvedConfigSubCommand {
+      file_path: matches.get_one::<String>("file").map(String::from),
+    }),
     ("incremental-state", _) => SubCommand::IncrementalState,
     ("format-times", matches) => SubCommand::OutputFormatTimes(OutputFormatTimesSubCommand {
       patterns: parse_file_patterns(matches, &std_in_reader)?,
@@ -778,6 +786,14 @@ EXAMPLES:
       Command::new("resolved-config")
         .alias("output-resolved-config")
         .about("Prints the resolved configuration for the plugins based on the args and configuration.")
+        .arg(
+          Arg::new("file")
+            .long("file")
+            .value_name("file")
+            .help("Limit the output to only the plugins that would format this file.")
+            .num_args(1)
+            .required(false)
+        )
     )
     .subcommand(
       Command::new("incremental-state")
@@ -997,10 +1013,26 @@ mod test {
     }
     assert!(matches!(sub_command(vec!["file-paths"]), SubCommand::OutputFilePaths(_)));
     assert!(matches!(sub_command(vec!["output-file-paths"]), SubCommand::OutputFilePaths(_)));
-    assert!(matches!(sub_command(vec!["resolved-config"]), SubCommand::OutputResolvedConfig));
-    assert!(matches!(sub_command(vec!["output-resolved-config"]), SubCommand::OutputResolvedConfig));
+    assert!(matches!(sub_command(vec!["resolved-config"]), SubCommand::OutputResolvedConfig(_)));
+    assert!(matches!(sub_command(vec!["output-resolved-config"]), SubCommand::OutputResolvedConfig(_)));
     assert!(matches!(sub_command(vec!["format-times"]), SubCommand::OutputFormatTimes(_)));
     assert!(matches!(sub_command(vec!["output-format-times"]), SubCommand::OutputFormatTimes(_)));
+  }
+
+  #[test]
+  fn resolved_config_file_path_arg() {
+    fn file_path(args: Vec<&str>) -> Option<String> {
+      match test_args(args).unwrap().sub_command {
+        SubCommand::OutputResolvedConfig(cmd) => cmd.file_path,
+        _ => unreachable!(),
+      }
+    }
+    assert_eq!(file_path(vec!["resolved-config"]), None);
+    assert_eq!(file_path(vec!["resolved-config", "--file", "src/main.py"]), Some("src/main.py".to_string()));
+    assert_eq!(
+      file_path(vec!["output-resolved-config", "--file", "src/main.py"]),
+      Some("src/main.py".to_string())
+    );
   }
 
   #[test]

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -16,6 +16,7 @@ use url::Url;
 
 use crate::arg_parser::CliArgs;
 use crate::arg_parser::FilePatternArgs;
+use crate::arg_parser::OutputResolvedConfigSubCommand;
 use crate::configuration::get_init_config_file_text;
 use crate::configuration::*;
 use crate::environment::CanonicalizedPathBuf;
@@ -1065,6 +1066,7 @@ async fn get_plugins_to_update<TEnvironment: Environment>(
 }
 
 pub async fn output_resolved_config<TEnvironment: Environment>(
+  cmd: &OutputResolvedConfigSubCommand,
   args: &CliArgs,
   environment: &TEnvironment,
   plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
@@ -1073,8 +1075,26 @@ pub async fn output_resolved_config<TEnvironment: Environment>(
   let plugins_scope = resolve_plugins_scope(config, environment, plugin_resolver).await?;
   plugins_scope.ensure_no_global_config_diagnostics()?;
 
+  // when a file path is provided, limit the output to only the plugins that
+  // would format that file (resolving associations, file names, and extensions
+  // the same way `dprint fmt` does). this helps debug why a plugin isn't
+  // running on a file (ex. a missing `associations` entry — see issue #794).
+  let included_plugin_names = cmd.file_path.as_ref().map(|file_path| {
+    let file_path = environment.cwd().join(file_path);
+    plugins_scope
+      .plugin_name_maps
+      .get_plugin_names_from_file_path(&file_path)
+      .into_iter()
+      .collect::<HashSet<_>>()
+  });
+
   let mut plugin_jsons = Vec::new();
   for plugin in plugins_scope.plugins.values() {
+    if let Some(included_plugin_names) = &included_plugin_names
+      && !included_plugin_names.contains(plugin.name())
+    {
+      continue;
+    }
     let config_key = &plugin.info().config_key;
 
     // output its diagnostics
@@ -2450,6 +2470,80 @@ mod test {
         "  },\n",
         "  \"testProcessPlugin\": {\n",
         "    \"ending\": \"formatted_process\",\n",
+        "    \"lineWidth\": 120\n",
+        "  }\n",
+        "}",
+      )]
+    );
+  }
+
+  #[test]
+  fn should_output_resolved_config_for_file_path() {
+    // the wasm plugin formats `.txt`, the process plugin formats `.txt_ps` —
+    // passing a file path limits the output to the plugin that handles it
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin().build();
+    run_test_cli(vec!["resolved-config", "--file", "file.txt"], &environment).unwrap();
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![concat!(
+        "{\n",
+        "  \"test-plugin\": {\n",
+        "    \"ending\": \"formatted\",\n",
+        "    \"lineWidth\": 120\n",
+        "  }\n",
+        "}",
+      )]
+    );
+
+    run_test_cli(vec!["resolved-config", "--file", "file.txt_ps"], &environment).unwrap();
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![concat!(
+        "{\n",
+        "  \"testProcessPlugin\": {\n",
+        "    \"ending\": \"formatted_process\",\n",
+        "    \"lineWidth\": 120\n",
+        "  }\n",
+        "}",
+      )]
+    );
+  }
+
+  #[test]
+  fn should_output_empty_resolved_config_for_unhandled_file_path() {
+    // a file no plugin handles outputs an empty object rather than every plugin
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin().build();
+    run_test_cli(vec!["resolved-config", "--file", "file.unknown_ext"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec!["{}"]);
+  }
+
+  #[test]
+  fn should_output_resolved_config_for_file_path_with_associations() {
+    // an `associations` entry that doesn't include a file's extension means the
+    // plugin won't format it — the file-path filter reflects that (issue #794)
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_remote_wasm_plugin().add_config_section(
+          "test-plugin",
+          r#"{
+            "associations": ["**/*.special"]
+          }"#,
+        );
+      })
+      .build();
+
+    // the plugin is now associated only with `.special`, so a `.txt` file is unhandled
+    run_test_cli(vec!["resolved-config", "--file", "file.txt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec!["{}"]);
+
+    // but a `.special` file is handled by the plugin
+    run_test_cli(vec!["resolved-config", "--file", "file.special"], &environment).unwrap();
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![concat!(
+        "{\n",
+        "  \"test-plugin\": {\n",
+        "    \"ending\": \"formatted\",\n",
         "    \"lineWidth\": 120\n",
         "  }\n",
         "}",

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -160,7 +160,7 @@ pub async fn run_cli<TEnvironment: Environment>(args: &CliArgs, environment: &TE
     },
     SubCommand::Version => commands::output_version(environment),
     SubCommand::StdInFmt(cmd) => commands::stdin_fmt(cmd, args, environment, plugin_resolver).await,
-    SubCommand::OutputResolvedConfig => commands::output_resolved_config(args, environment, plugin_resolver).await,
+    SubCommand::OutputResolvedConfig(cmd) => commands::output_resolved_config(cmd, args, environment, plugin_resolver).await,
     SubCommand::IncrementalState => commands::incremental_state(args, environment, plugin_resolver).await,
     SubCommand::OutputFilePaths(cmd) => commands::output_file_paths(cmd, args, environment, plugin_resolver).await,
     SubCommand::OutputFormatTimes(cmd) => commands::output_format_times(cmd, args, environment, plugin_resolver).await,

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -266,6 +266,12 @@ Example output (JSON):
 }
 ```
 
+Optionally use the `--file` flag to limit the output to only the plugins that would format that file. This is useful for verifying which plugins are actually associated with a file:
+
+```sh
+dprint resolved-config --file path/to/file.py
+```
+
 ### Outputting format times
 
 It can be useful to know what files take a long time to format as you may consider skipping them. To see this information, use the following command:


### PR DESCRIPTION
`dprint resolved-config --file <path>` limits the output to only the plugins that would format that file (resolving associations, file names, and extensions the same way `dprint fmt` does).

Closes #794