### PR TITLE
perf: read directories on multiple threads when globbing

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -606,6 +606,9 @@ OPTIONS:
 ENVIRONMENT VARIABLES:
   DPRINT_MAX_THREADS   Limit the number of threads dprint uses for
                        formatting (ex. DPRINT_MAX_THREADS=4).
+  DPRINT_GLOB_READ_THREADS
+                       Number of threads used to read directories while
+                       discovering files (ex. DPRINT_GLOB_READ_THREADS=8).
   DPRINT_CACHE_DIR     Directory to store the dprint cache. Note that this
                        directory may be periodically deleted by the CLI.
   DPRINT_CONFIG_DIR    Global config directory to store a global dprint.json file.

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -5,6 +5,7 @@ use std::ffi::OsString;
 use std::io;
 use std::io::Read;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -282,7 +283,13 @@ pub trait Environment:
   fn cpu_arch(&self) -> String;
   /// Gets the operating system.
   fn os(&self) -> String;
-  fn max_threads(&self) -> usize;
+  fn available_parallelism(&self) -> Option<NonZeroUsize>;
+  fn max_threads(&self) -> usize {
+    resolve_max_threads(
+      self.env_var("DPRINT_MAX_THREADS").as_deref().and_then(|s| s.to_str()),
+      self.available_parallelism(),
+    )
+  }
   /// Gets the CLI version
   fn cli_version(&self) -> String;
   fn get_time_secs(&self) -> u64;
@@ -312,4 +319,36 @@ pub trait Environment:
   fn ensure_system_path(&self, directory_path: &str) -> io::Result<()>;
   #[cfg(windows)]
   fn remove_system_path(&self, directory_path: &str) -> io::Result<()>;
+}
+
+fn resolve_max_threads(env_var: Option<&str>, available_parallelism: Option<NonZeroUsize>) -> usize {
+  fn maybe_specified_threads(env_var: Option<&str>) -> Option<usize> {
+    let value = env_var?.parse::<usize>().ok()?;
+    if value > 0 { Some(value) } else { None }
+  }
+
+  let maybe_actual_count = available_parallelism.map(|p| p.get());
+  match maybe_specified_threads(env_var) {
+    Some(specified_count) => match maybe_actual_count {
+      Some(actual_count) if specified_count > actual_count => actual_count,
+      _ => specified_count,
+    },
+    _ => maybe_actual_count.unwrap_or(4),
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn should_resolve_num_threads() {
+    assert_eq!(resolve_max_threads(None, None), 4);
+    assert_eq!(resolve_max_threads(None, NonZeroUsize::new(1)), 1);
+    assert_eq!(resolve_max_threads(None, NonZeroUsize::new(4)), 4);
+    assert_eq!(resolve_max_threads(Some("2"), NonZeroUsize::new(4)), 2);
+    assert_eq!(resolve_max_threads(Some("0"), NonZeroUsize::new(4)), 4);
+    assert_eq!(resolve_max_threads(Some("5"), NonZeroUsize::new(4)), 4);
+    assert_eq!(resolve_max_threads(Some("4"), NonZeroUsize::new(4)), 4);
+  }
 }

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -518,9 +518,8 @@ impl Environment for RealEnvironment {
     }
   }
 
-  fn max_threads(&self) -> usize {
-    #[allow(clippy::disallowed_methods)]
-    resolve_max_threads(std::env::var("DPRINT_MAX_THREADS").ok(), std::thread::available_parallelism().ok())
+  fn available_parallelism(&self) -> Option<NonZeroUsize> {
+    std::thread::available_parallelism().ok()
   }
 
   fn cli_version(&self) -> String {
@@ -682,22 +681,6 @@ impl Environment for RealEnvironment {
   }
 }
 
-fn resolve_max_threads(env_var: Option<String>, available_parallelism: Option<NonZeroUsize>) -> usize {
-  fn maybe_specified_threads(env_var: Option<String>) -> Option<usize> {
-    let value = env_var?.parse::<usize>().ok()?;
-    if value > 0 { Some(value) } else { None }
-  }
-
-  let maybe_actual_count = available_parallelism.map(|p| p.get());
-  match maybe_specified_threads(env_var) {
-    Some(specified_count) => match maybe_actual_count {
-      Some(actual_count) if specified_count > actual_count => actual_count,
-      _ => specified_count,
-    },
-    _ => maybe_actual_count.unwrap_or(4),
-  }
-}
-
 fn canonicalize_path(path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf> {
   // use this to avoid //?//C:/etc... like paths on windows (UNC)
   match dunce::canonicalize(path.as_ref()) {
@@ -766,16 +749,5 @@ mod test {
       result.unwrap().to_string(),
       "The DPRINT_CACHE_DIR environment variable must specify an absolute path."
     );
-  }
-
-  #[test]
-  fn should_resolve_num_threads() {
-    assert_eq!(resolve_max_threads(None, None), 4);
-    assert_eq!(resolve_max_threads(None, NonZeroUsize::new(1)), 1);
-    assert_eq!(resolve_max_threads(None, NonZeroUsize::new(4)), 4);
-    assert_eq!(resolve_max_threads(Some("2".to_string()), NonZeroUsize::new(4)), 2);
-    assert_eq!(resolve_max_threads(Some("0".to_string()), NonZeroUsize::new(4)), 4);
-    assert_eq!(resolve_max_threads(Some("5".to_string()), NonZeroUsize::new(4)), 4);
-    assert_eq!(resolve_max_threads(Some("4".to_string()), NonZeroUsize::new(4)), 4);
   }
 }

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -12,6 +12,7 @@ use std::future::Future;
 use std::io;
 use std::io::Read;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -716,8 +717,8 @@ impl Environment for TestEnvironment {
     self.os.lock().clone()
   }
 
-  fn max_threads(&self) -> usize {
-    *self.max_threads_count.lock()
+  fn available_parallelism(&self) -> Option<NonZeroUsize> {
+    NonZeroUsize::new(*self.max_threads_count.lock())
   }
 
   fn cli_version(&self) -> String {

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -362,6 +362,9 @@ OPTIONS:
 ENVIRONMENT VARIABLES:
   DPRINT_MAX_THREADS   Limit the number of threads dprint uses for
                        formatting (ex. DPRINT_MAX_THREADS=4).
+  DPRINT_GLOB_READ_THREADS
+                       Number of threads used to read directories while
+                       discovering files (ex. DPRINT_GLOB_READ_THREADS=8).
   DPRINT_CACHE_DIR     Directory to store the dprint cache. Note that this
                        directory may be periodically deleted by the CLI.
   DPRINT_CONFIG_DIR    Global config directory to store a global dprint.json file.

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use parking_lot::Condvar;
 use parking_lot::Mutex;
+use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -82,18 +83,27 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
 
   // This is a performance improvement to attempt to reduce the time of globbing down
   // to the speed of `fs::read_dir` calls. Essentially, run all the `fs::read_dir` calls
-  // on a new thread and do the glob matching on the other thread.
-  let read_dir_runner = ReadDirRunner::new(
+  // on separate threads and do the glob matching on the current thread.
+  //
+  // Reading directories is I/O bound, so spreading the reads across several threads
+  // saturates the disk far better than a single reader can. See issue #1001.
+  let read_dir_thread_count = resolve_read_dir_thread_count(environment);
+  log_debug!(environment, "Reading directories on {} thread(s)", read_dir_thread_count);
+  let read_dir_runner = Arc::new(ReadDirRunner::new(
     environment.clone(),
     shared_state.clone(),
     ReadDirRunnerOptions {
       start_dir: opts.start_dir,
       config_discovery: opts.config_discovery,
+      thread_count: read_dir_thread_count,
     },
-  );
-  dprint_core::async_runtime::spawn_blocking(move || read_dir_runner.run());
+  ));
+  for _ in 0..read_dir_thread_count {
+    let read_dir_runner = read_dir_runner.clone();
+    dprint_core::async_runtime::spawn_blocking(move || read_dir_runner.run());
+  }
 
-  // run the glob matching on the current thread (the two threads will communicate with each other)
+  // run the glob matching on the current thread (it communicates with the reader threads)
   let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
   let results = glob_matching_processor.run()?;
 
@@ -101,6 +111,23 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
   log_debug!(environment, "Finished globbing in {}ms", start_instant.elapsed().as_millis());
 
   Ok(results)
+}
+
+/// Resolves how many threads to use for reading directories.
+///
+/// Reading is I/O bound, so using a handful of threads helps saturate the disk,
+/// but there are diminishing returns (and eventually regressions) past a small
+/// number — see the measurements in issue #1001. The default is capped well
+/// below the CPU count for this reason, and can be overridden for experimentation
+/// via the `DPRINT_GLOB_READ_THREADS` environment variable.
+fn resolve_read_dir_thread_count(environment: &impl Environment) -> usize {
+  if let Some(count) = environment
+    .env_var("DPRINT_GLOB_READ_THREADS")
+    .and_then(|v| v.to_str().and_then(|v| v.parse::<usize>().ok()))
+  {
+    return count.max(1);
+  }
+  environment.max_threads().clamp(1, 8)
 }
 
 struct DirEntries {
@@ -145,6 +172,7 @@ const PUSH_DIR_ENTRIES_BATCH_COUNT: usize = 500;
 struct ReadDirRunnerOptions {
   start_dir: PathBuf,
   config_discovery: ConfigDiscovery,
+  thread_count: usize,
 }
 
 struct ReadDirRunner<TEnvironment: Environment> {
@@ -163,106 +191,152 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
   }
 
   pub fn run(&self) {
-    while let Some(pending_dirs) = self.get_next_pending_dirs() {
+    while let Some(pending_dirs) = self.acquire_dirs() {
       let mut pending_count = 0;
       let mut all_entries = Vec::new();
-      for current_dir in pending_dirs.into_iter().flatten() {
-        let info_result = self.environment.dir_info(&current_dir);
-        let entries = match info_result {
-          Ok(entries) => {
-            if entries.is_empty() {
-              continue;
-            }
-            let maybe_config_file = if self.options.config_discovery.traverse_descendants() && current_dir != self.options.start_dir {
-              entries
-                .iter()
-                .filter_map(|e| match e {
-                  DirEntry::Directory(_) => None,
-                  DirEntry::File { name, path } => {
-                    if matches!(name.to_str(), Some(".dprint.json" | "dprint.json" | ".dprint.jsonc" | "dprint.jsonc")) {
-                      Some(path)
-                    } else {
-                      None
-                    }
-                  }
-                })
-                .next()
-            } else {
-              None
-            };
-            if let Some(config_file) = maybe_config_file {
-              vec![DirOrConfigEntry::Config(config_file.clone())]
-            } else {
-              entries
-                .into_iter()
-                .map(|e| match e {
-                  DirEntry::Directory(path) => DirOrConfigEntry::Dir(path),
-                  DirEntry::File { path, .. } => DirOrConfigEntry::File(path),
-                })
-                .collect::<Vec<_>>()
+      for current_dir in pending_dirs {
+        match self.read_dir_entries(&current_dir) {
+          Ok(Some(entries)) => {
+            pending_count += entries.len();
+            all_entries.push(DirEntries { path: current_dir, entries });
+            // it is much faster to batch these than to hit the lock every time
+            if pending_count > PUSH_DIR_ENTRIES_BATCH_COUNT {
+              self.push_entries(std::mem::take(&mut all_entries));
+              pending_count = 0;
             }
           }
+          Ok(None) => continue,
           Err(err) => {
-            let ignore_error = is_system_volume_error(&current_dir, &err);
-            if ignore_error {
-              continue;
-            }
-            if err.kind() == std::io::ErrorKind::PermissionDenied {
-              log_warn!(self.environment, "WARNING: Ignoring directory. Permission denied: {}", current_dir.display());
-              continue;
-            } else {
-              self.set_glob_error(anyhow!("Error reading dir '{}': {:#}", current_dir.display(), err));
-              return;
-            }
+            self.finish_with_error(err, all_entries);
+            return;
           }
-        };
-        pending_count += entries.len();
-        all_entries.push(DirEntries { path: current_dir, entries });
-        // it is much faster to batch these than to hit the lock every time
-        if pending_count > PUSH_DIR_ENTRIES_BATCH_COUNT {
-          self.push_entries(std::mem::take(&mut all_entries));
-          pending_count = 0;
         }
       }
-      if !all_entries.is_empty() {
-        self.push_entries(all_entries);
-      }
+      self.finish_reading(all_entries);
     }
   }
 
-  fn get_next_pending_dirs(&self) -> Option<Vec<Vec<PathBuf>>> {
+  /// Reads a single directory, returning its entries to be matched.
+  ///
+  /// `Ok(None)` means the directory contributed nothing and should be skipped
+  /// (it was empty or couldn't be read for a non-fatal reason).
+  fn read_dir_entries(&self, current_dir: &Path) -> Result<Option<Vec<DirOrConfigEntry>>> {
+    let entries = match self.environment.dir_info(current_dir) {
+      Ok(entries) => entries,
+      Err(err) => {
+        if is_system_volume_error(current_dir, &err) {
+          return Ok(None);
+        }
+        if err.kind() == std::io::ErrorKind::PermissionDenied {
+          log_warn!(self.environment, "WARNING: Ignoring directory. Permission denied: {}", current_dir.display());
+          return Ok(None);
+        }
+        return Err(anyhow!("Error reading dir '{}': {:#}", current_dir.display(), err));
+      }
+    };
+    if entries.is_empty() {
+      return Ok(None);
+    }
+    let maybe_config_file = if self.options.config_discovery.traverse_descendants() && current_dir != self.options.start_dir {
+      entries
+        .iter()
+        .filter_map(|e| match e {
+          DirEntry::Directory(_) => None,
+          DirEntry::File { name, path } => {
+            if matches!(name.to_str(), Some(".dprint.json" | "dprint.json" | ".dprint.jsonc" | "dprint.jsonc")) {
+              Some(path)
+            } else {
+              None
+            }
+          }
+        })
+        .next()
+    } else {
+      None
+    };
+    if let Some(config_file) = maybe_config_file {
+      Ok(Some(vec![DirOrConfigEntry::Config(config_file.clone())]))
+    } else {
+      Ok(Some(
+        entries
+          .into_iter()
+          .map(|e| match e {
+            DirEntry::Directory(path) => DirOrConfigEntry::Dir(path),
+            DirEntry::File { path, .. } => DirOrConfigEntry::File(path),
+          })
+          .collect::<Vec<_>>(),
+      ))
+    }
+  }
+
+  /// Waits for directories to read, returning a chunk of them or `None` once the
+  /// walk is finished (or aborted via an error on another thread).
+  fn acquire_dirs(&self) -> Option<Vec<PathBuf>> {
     let (lock, cvar) = &self.shared_state.inner;
     let mut state = lock.lock();
     loop {
-      if !state.pending_dirs.is_empty() {
-        state.read_dir_thread_state = ReadDirThreadState::Processing;
-        cvar.notify_one();
-        return Some(std::mem::take(&mut state.pending_dirs));
-      }
-      state.read_dir_thread_state = ReadDirThreadState::Waiting;
-      cvar.notify_one();
-      if matches!(state.processing_thread_state, ProcessingThreadState::Waiting) && state.pending_entries.is_empty() {
+      if state.shutdown {
         return None;
-      } else {
-        // wait to be notified by the other thread
-        cvar.wait(&mut state);
       }
+      if !state.pending_dirs.is_empty() {
+        let take = read_dir_chunk_size(state.pending_dirs.len(), self.options.thread_count);
+        let chunk = state.pending_dirs.drain(..take).collect::<Vec<_>>();
+        state.reading_count += 1;
+        return Some(chunk);
+      }
+      // nothing to read right now; wait for the matching thread to feed more
+      // directories or to signal that the walk is complete
+      cvar.wait(&mut state);
     }
   }
 
-  fn set_glob_error(&self, error: Error) {
-    let (lock, cvar) = &self.shared_state.inner;
-    let mut state = lock.lock();
-    state.read_dir_thread_state = ReadDirThreadState::Error(error);
-    cvar.notify_one();
-  }
-
   fn push_entries(&self, entries: Vec<DirEntries>) {
+    if entries.is_empty() {
+      return;
+    }
     let (lock, cvar) = &self.shared_state.inner;
     let mut state = lock.lock();
     state.pending_entries.push(entries);
-    cvar.notify_one();
+    cvar.notify_all();
   }
+
+  /// Pushes any remaining entries and marks this reader as no longer reading.
+  fn finish_reading(&self, entries: Vec<DirEntries>) {
+    let (lock, cvar) = &self.shared_state.inner;
+    let mut state = lock.lock();
+    if !entries.is_empty() {
+      state.pending_entries.push(entries);
+    }
+    state.reading_count -= 1;
+    cvar.notify_all();
+  }
+
+  fn finish_with_error(&self, error: Error, entries: Vec<DirEntries>) {
+    let (lock, cvar) = &self.shared_state.inner;
+    let mut state = lock.lock();
+    // keep any entries read before the error so a partial result isn't silently dropped
+    if !entries.is_empty() {
+      state.pending_entries.push(entries);
+    }
+    if state.error.is_none() {
+      state.error = Some(error);
+    }
+    state.shutdown = true;
+    state.reading_count -= 1;
+    cvar.notify_all();
+  }
+}
+
+/// Maximum number of directories a reader grabs per lock acquisition. Kept small
+/// so work stays balanced across readers and the matching thread is fed steadily,
+/// while still amortizing the lock over several directories.
+const READ_DIR_CHUNK_SIZE: usize = 8;
+
+/// Hands out a share of the pending directories to a reader, while keeping the
+/// chunk small enough that the matching thread stays fed and the readers stay
+/// balanced across a wide directory level.
+fn read_dir_chunk_size(pending_len: usize, thread_count: usize) -> usize {
+  (pending_len / thread_count.max(1)).clamp(1, READ_DIR_CHUNK_SIZE)
 }
 
 fn is_system_volume_error(dir_path: &Path, err: &std::io::Error) -> bool {
@@ -351,61 +425,49 @@ impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
   }
 
   fn push_pending_dirs(&self, pending_dirs: Vec<PathBuf>) {
+    if pending_dirs.is_empty() {
+      return; // nothing new to read; don't bother waking the readers
+    }
     let (lock, cvar) = &self.shared_state.inner;
     let mut state = lock.lock();
-    state.pending_dirs.push(pending_dirs);
-    cvar.notify_one();
+    state.pending_dirs.extend(pending_dirs);
+    cvar.notify_all();
   }
 
   fn get_next_entries(&self) -> Result<Option<Vec<Vec<DirEntries>>>> {
     let (lock, cvar) = &self.shared_state.inner;
     let mut state = lock.lock();
     loop {
+      if let Some(err) = state.error.take() {
+        return Err(err);
+      }
       if !state.pending_entries.is_empty() {
-        state.processing_thread_state = ProcessingThreadState::Processing;
         return Ok(Some(std::mem::take(&mut state.pending_entries)));
       }
-      if !matches!(state.processing_thread_state, ProcessingThreadState::Waiting) {
-        state.processing_thread_state = ProcessingThreadState::Waiting;
-        cvar.notify_one();
+      // when no reader is currently reading and there's nothing left to read,
+      // the walk is complete: tell the readers to stop and finish up
+      if state.reading_count == 0 && state.pending_dirs.is_empty() {
+        state.shutdown = true;
+        cvar.notify_all();
+        return Ok(None);
       }
-      match &state.read_dir_thread_state {
-        ReadDirThreadState::Waiting => {
-          if state.pending_dirs.is_empty() {
-            return Ok(None);
-          } else {
-            // wait to be notified by the other thread
-            cvar.wait(&mut state);
-          }
-        }
-        ReadDirThreadState::Error(err) => {
-          return Err(anyhow!("{:#}", err));
-        }
-        ReadDirThreadState::Processing => {
-          // wait to be notified by the other thread
-          cvar.wait(&mut state);
-        }
-      }
+      // wait to be notified by a reader thread
+      cvar.wait(&mut state);
     }
   }
 }
 
-enum ReadDirThreadState {
-  Processing,
-  Waiting,
-  Error(Error),
-}
-
-enum ProcessingThreadState {
-  Processing,
-  Waiting,
-}
-
 struct SharedStateInternal {
-  pending_dirs: Vec<Vec<PathBuf>>,
+  /// Directories waiting to be read by the reader threads.
+  pending_dirs: VecDeque<PathBuf>,
+  /// Batches of read directory entries waiting to be matched.
   pending_entries: Vec<Vec<DirEntries>>,
-  read_dir_thread_state: ReadDirThreadState,
-  processing_thread_state: ProcessingThreadState,
+  /// Number of reader threads currently reading directories.
+  reading_count: usize,
+  /// The first error encountered by a reader thread, if any.
+  error: Option<Error>,
+  /// Set once the walk is complete (or aborted) so reader threads stop.
+  shutdown: bool,
 }
 
 struct SharedState {
@@ -417,10 +479,11 @@ impl SharedState {
     SharedState {
       inner: (
         Mutex::new(SharedStateInternal {
-          processing_thread_state: ProcessingThreadState::Waiting,
-          read_dir_thread_state: ReadDirThreadState::Processing,
-          pending_dirs: vec![vec![initial_dir]],
+          pending_dirs: VecDeque::from([initial_dir]),
           pending_entries: Vec::new(),
+          reading_count: 0,
+          error: None,
+          shutdown: false,
         }),
         Condvar::new(),
       ),

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -113,13 +113,19 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
   Ok(results)
 }
 
+/// Default number of threads used for reading directories.
+///
+/// Reading is I/O bound rather than CPU bound, so this is a small fixed value
+/// instead of a function of the CPU count: a handful of threads saturate the
+/// disk even on a machine with few cores, while going much higher regresses
+/// (see the measurements in issue #1001). It's deliberately independent of
+/// `DPRINT_MAX_THREADS`, which limits the CPU threads used for formatting.
+const DEFAULT_READ_DIR_THREAD_COUNT: usize = 8;
+
 /// Resolves how many threads to use for reading directories.
 ///
-/// Reading is I/O bound, so using a handful of threads helps saturate the disk,
-/// but there are diminishing returns (and eventually regressions) past a small
-/// number — see the measurements in issue #1001. The default is capped well
-/// below the CPU count for this reason, and can be overridden for experimentation
-/// via the `DPRINT_GLOB_READ_THREADS` environment variable.
+/// Defaults to [`DEFAULT_READ_DIR_THREAD_COUNT`] and can be overridden via the
+/// `DPRINT_GLOB_READ_THREADS` environment variable.
 fn resolve_read_dir_thread_count(environment: &impl Environment) -> usize {
   if let Some(count) = environment
     .env_var("DPRINT_GLOB_READ_THREADS")
@@ -127,7 +133,7 @@ fn resolve_read_dir_thread_count(environment: &impl Environment) -> usize {
   {
     return count.max(1);
   }
-  environment.max_threads().clamp(1, 8)
+  DEFAULT_READ_DIR_THREAD_COUNT
 }
 
 struct DirEntries {

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -207,7 +207,7 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
           }
           Ok(None) => continue,
           Err(err) => {
-            self.finish_with_error(err, all_entries);
+            self.finish_with_error(err);
             return;
           }
         }
@@ -307,22 +307,21 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     if !entries.is_empty() {
       state.pending_entries.push(entries);
     }
-    state.reading_count -= 1;
+    state.finish_reading();
     cvar.notify_all();
   }
 
-  fn finish_with_error(&self, error: Error, entries: Vec<DirEntries>) {
+  /// Aborts the whole walk: records the error (first one wins) and marks this
+  /// reader as no longer reading. Any entries this reader had already read are
+  /// dropped — the matching thread surfaces the error rather than a partial result.
+  fn finish_with_error(&self, error: Error) {
     let (lock, cvar) = &self.shared_state.inner;
     let mut state = lock.lock();
-    // keep any entries read before the error so a partial result isn't silently dropped
-    if !entries.is_empty() {
-      state.pending_entries.push(entries);
-    }
     if state.error.is_none() {
       state.error = Some(error);
     }
     state.shutdown = true;
-    state.reading_count -= 1;
+    state.finish_reading();
     cvar.notify_all();
   }
 }
@@ -334,7 +333,9 @@ const READ_DIR_CHUNK_SIZE: usize = 8;
 
 /// Hands out a share of the pending directories to a reader, while keeping the
 /// chunk small enough that the matching thread stays fed and the readers stay
-/// balanced across a wide directory level.
+/// balanced across a wide directory level. Note that a single very large
+/// directory is still read by one thread (a `read_dir` isn't splittable), so
+/// this balances across directories, not within one.
 fn read_dir_chunk_size(pending_len: usize, thread_count: usize) -> usize {
   (pending_len / thread_count.max(1)).clamp(1, READ_DIR_CHUNK_SIZE)
 }
@@ -470,6 +471,16 @@ struct SharedStateInternal {
   shutdown: bool,
 }
 
+impl SharedStateInternal {
+  /// Records that a reader has stopped reading the chunk it acquired. Every
+  /// acquired chunk decrements exactly once, so this should never underflow;
+  /// guard it anyway because an underflow would silently hang the walk (the
+  /// `reading_count == 0` termination check could never become true).
+  fn finish_reading(&mut self) {
+    self.reading_count = self.reading_count.checked_sub(1).expect("reading_count underflow");
+  }
+}
+
 struct SharedState {
   inner: (Mutex<SharedStateInternal>, Condvar),
 }
@@ -549,6 +560,57 @@ mod test {
     result.sort();
     expected_matches.sort();
     assert_eq!(result, expected_matches);
+  }
+
+  #[tokio::test]
+  async fn should_match_same_files_regardless_of_read_thread_count() {
+    // build a wide + deep tree (with a gitignore at the root) so the work is
+    // split across many readers and fed back in several waves, then assert the
+    // matched set is identical whether globbing with a single reader or a pool
+    // of readers. only ordering and speed should differ — if reordered
+    // traversal ever changed which files matched (e.g. a gitignore resolution
+    // order dependency) this would catch it.
+    let mut builder = TestEnvironmentBuilder::new();
+    builder.write_file("/.git/HEAD", "");
+    builder.write_file("/.gitignore", "ignored\n");
+    for i in 0..200 {
+      builder.write_file(format!("/dir{}/a.txt", i), "");
+      builder.write_file(format!("/dir{}/nested/deep/b.txt", i), "");
+      // excluded by the root .gitignore
+      builder.write_file(format!("/dir{}/ignored/c.txt", i), "");
+    }
+    let environment = builder.build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let run = |read_threads: &str| {
+      environment.set_env_var("DPRINT_GLOB_READ_THREADS", Some(read_threads));
+      let result = glob(
+        &environment,
+        GlobOptions {
+          start_dir: PathBuf::from("/"),
+          config_discovery: ConfigDiscovery::Default,
+          file_patterns: GlobPatterns {
+            arg_includes: None,
+            config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
+            arg_excludes: None,
+            config_excludes: Vec::new(),
+          },
+          pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+          no_gitignore: false,
+        },
+      )
+      .unwrap();
+      let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+      result.sort();
+      result
+    };
+
+    let serial = run("1");
+    let parallel = run("16");
+    assert_eq!(serial, parallel);
+    // sanity: matched a.txt and nested/deep/b.txt for each dir, and the
+    // gitignored files were excluded
+    assert_eq!(serial.len(), 400);
+    assert!(serial.iter().all(|p| !p.contains("ignored")));
   }
 
   #[tokio::test]

--- a/website/src/setup.md
+++ b/website/src/setup.md
@@ -85,4 +85,6 @@ This is very unsafe to do and not recommended. A warning will be displayed on fi
 
 By default, dprint only runs for a short period of time and so it will try to take advantage of as many CPU cores as it can. This might be an issue in some scenarios, and so you can limit the amount of parallelism by setting the `DPRINT_MAX_THREADS` environment variable in version 0.32 and up (ex. `DPRINT_MAX_THREADS=4`).
 
+Separately, dprint reads directories on several threads when discovering files in order to better saturate the disk. This is I/O bound, so the number of read threads is independent of `DPRINT_MAX_THREADS`. You can override it with the `DPRINT_GLOB_READ_THREADS` environment variable (ex. `DPRINT_GLOB_READ_THREADS=8`), though the default is suitable for most setups.
+
 Next step: [Configuration](/config)


### PR DESCRIPTION
Globbing previously used a single thread for all `fs::read_dir` calls, which can't saturate a modern SSD on large directory trees. Spread the reads across a pool of reader threads that pull directories off a shared queue, while the matching thread still drives descent so gitignore and config-file discovery behave exactly as before.

The thread count defaults to 8 and can be overridden via `DPRINT_GLOB_READ_THREADS`.

On a full walk of DefinitelyTyped (~241k dirs) this is ~2.8x faster with a cold cache.

Closes  #1001