### PR TITLE
feat: add `--dirty flag` to format git working directory changes

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -174,6 +174,7 @@ pub struct CheckSubCommand {
   pub list_different: bool,
   pub allow_no_files: bool,
   pub only_staged: bool,
+  pub only_dirty: bool,
   pub fail_fast: bool,
 }
 
@@ -186,6 +187,7 @@ pub struct FmtSubCommand {
   pub allow_no_files: bool,
   pub fail_on_change: bool,
   pub only_staged: bool,
+  pub only_dirty: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -258,6 +260,7 @@ pub struct FilePatternArgs {
   pub allow_node_modules: bool,
   pub no_gitignore: bool,
   pub only_staged: bool,
+  pub only_dirty: bool,
 }
 
 #[derive(Debug, Error)]
@@ -348,13 +351,14 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
           patterns: parse_file_patterns(matches, &std_in_reader)?,
           incremental: if enable_stable_format { parse_incremental(matches) } else { Some(false) },
           enable_stable_format,
-          allow_no_files: if matches.get_flag("staged") {
+          allow_no_files: if matches.get_flag("staged") || matches.get_flag("dirty") {
             true
           } else {
             matches.get_flag("allow-no-files")
           },
           fail_on_change: matches.get_flag("fail-on-change"),
           only_staged: matches.get_flag("staged"),
+          only_dirty: matches.get_flag("dirty"),
         })
       }
     }
@@ -372,6 +376,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         patterns: parse_file_patterns(matches, &std_in_reader)?,
         incremental: parse_incremental(matches),
         only_staged: matches.get_flag("staged"),
+        only_dirty: matches.get_flag("dirty"),
         list_different: matches.get_flag("list-different"),
         allow_no_files: matches.get_flag("allow-no-files"),
         fail_fast,
@@ -472,6 +477,7 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
 
   Ok(FilePatternArgs {
     only_staged: matches.get_flag("staged"),
+    only_dirty: matches.get_flag("dirty"),
     allow_node_modules: matches.get_flag("allow-node-modules"),
     no_gitignore: matches.get_flag("no-gitignore"),
     include_patterns: file_patterns,
@@ -688,6 +694,7 @@ EXAMPLES:
             .required(false)
         )
         .add_only_staged_arg()
+        .add_only_dirty_arg()
         .add_allow_no_files_arg()
         .arg(
           Arg::new("skip-stable-format")
@@ -711,6 +718,7 @@ EXAMPLES:
         .add_incremental_arg()
         .add_allow_no_files_arg()
         .add_only_staged_arg()
+        .add_only_dirty_arg()
         .arg(
           Arg::new("list-different")
             .long("list-different")
@@ -784,6 +792,7 @@ EXAMPLES:
         .about("Prints the resolved file paths for the plugins based on the args and configuration.")
         .add_resolve_file_path_args()
         .add_only_staged_arg()
+        .add_only_dirty_arg()
     )
     .subcommand(
       Command::new("resolved-config")
@@ -809,6 +818,7 @@ EXAMPLES:
         .add_resolve_file_path_args()
         .add_allow_no_files_arg()
         .add_only_staged_arg()
+        .add_only_dirty_arg()
     )
     .subcommand(
       Command::new("clear-cache")
@@ -912,6 +922,7 @@ trait ClapExtensions {
   fn add_incremental_arg(self) -> Self;
   fn add_allow_no_files_arg(self) -> Self;
   fn add_only_staged_arg(self) -> Self;
+  fn add_only_dirty_arg(self) -> Self;
 }
 
 impl ClapExtensions for clap::Command {
@@ -929,6 +940,7 @@ impl ClapExtensions for clap::Command {
           .help("Read a newline-separated list of file paths to format from stdin instead of from the command line arguments.")
           .conflicts_with("files")
           .conflicts_with("staged")
+          .conflicts_with("dirty")
           .num_args(0)
           .required(false),
       )
@@ -996,6 +1008,18 @@ impl ClapExtensions for clap::Command {
       Arg::new("staged")
         .long("staged")
         .help("Format only the staged files.")
+        .num_args(0)
+        .required(false),
+    )
+  }
+
+  fn add_only_dirty_arg(self) -> Self {
+    use clap::Arg;
+    self.arg(
+      Arg::new("dirty")
+        .long("dirty")
+        .help("Format only the files with uncommitted changes in the git working directory (staged, unstaged, and untracked).")
+        .conflicts_with("staged")
         .num_args(0)
         .required(false),
     )
@@ -1146,9 +1170,26 @@ mod test {
   }
 
   #[test]
+  fn dirty_arg() {
+    let fmt_cmd = parse_fmt_sub_command(vec!["fmt"]).unwrap();
+    assert_eq!(fmt_cmd.only_dirty, false);
+    let fmt_cmd = parse_fmt_sub_command(vec!["fmt", "--dirty"]).unwrap();
+    assert_eq!(fmt_cmd.only_dirty, true);
+  }
+
+  #[test]
+  fn staged_and_dirty_conflict() {
+    let err = parse_fmt_sub_command(vec!["fmt", "--staged", "--dirty"]).err().unwrap();
+    assert!(err.to_string().contains("cannot be used with"));
+  }
+
+  #[test]
   fn no_files_arg() {
     let fmt_cmd = parse_fmt_sub_command(vec!["fmt", "--staged"]).unwrap();
     assert_eq!(fmt_cmd.only_staged, true);
+    assert_eq!(fmt_cmd.allow_no_files, true);
+    let fmt_cmd = parse_fmt_sub_command(vec!["fmt", "--dirty"]).unwrap();
+    assert_eq!(fmt_cmd.only_dirty, true);
     assert_eq!(fmt_cmd.allow_no_files, true);
   }
 

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -613,6 +613,7 @@ pub async fn update_plugins_config_file<TEnvironment: Environment>(
     allow_node_modules: false,
     no_gitignore: false,
     only_staged: false,
+    only_dirty: false,
   };
   let config_discovery = args.config_discovery(environment);
   let scopes = resolve_plugins_scope_and_paths(

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -424,6 +424,44 @@ mod test {
   }
 
   #[test]
+  fn should_format_only_dirty_files() {
+    let file_path1 = "/file.txt";
+    let file_path2 = "/file.txt_ps";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin()
+      .write_file(&file_path1, "text_1")
+      .write_file(&file_path2, "text_2")
+      .add_dirty_file(file_path1)
+      .build();
+
+    environment.set_max_threads(1);
+    run_test_cli(vec!["fmt", "--dirty"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_1_formatted");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text_2");
+  }
+
+  #[test]
+  fn should_format_only_dirty_files_while_respecting_includes() {
+    let file_path1 = "/file.txt";
+    let file_path2 = "/file.txt_ps";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin()
+      .with_local_config("./dprint.json", |c| {
+        c.add_includes("**/*.txt_ps").add_remote_wasm_plugin().add_remote_process_plugin();
+      })
+      .write_file(&file_path1, "text_1")
+      .write_file(&file_path2, "text_2")
+      .add_dirty_file(file_path1)
+      .add_dirty_file(file_path2)
+      .build();
+
+    environment.set_max_threads(1);
+    run_test_cli(vec!["fmt", "--dirty"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_1");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text_2_formatted_process");
+  }
+
+  #[test]
   fn should_format_only_staged_files_while_respecting_includes() {
     let file_path1 = "/file.txt";
     let file_path2 = "/file.txt_ps";

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -206,6 +206,9 @@ pub trait Environment:
   fn env_var(&self, name: &str) -> Option<OsString>;
 
   fn get_staged_files(&self) -> Result<Vec<PathBuf>>;
+  /// Resolves the files that have uncommitted changes in the git working
+  /// directory: staged, unstaged, and untracked (but not gitignored) files.
+  fn get_dirty_files(&self) -> Result<Vec<PathBuf>>;
   /// Resolves the path to git's global excludes file (the `core.excludesFile`
   /// config value, falling back to `$XDG_CONFIG_HOME/git/ignore`). Used only when
   /// global gitignore support is opted into via `DPRINT_GLOBAL_GITIGNORE`. The

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -361,7 +361,7 @@ impl Environment for RealEnvironment {
     let dir_path = dir_path.as_ref();
     let mut system = self.system.lock();
     system.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-    let mut killed = 0;
+    let mut killed_pids = Vec::new();
     for process in system.processes().values() {
       let Some(exe) = process.exe() else {
         continue;
@@ -369,14 +369,28 @@ impl Environment for RealEnvironment {
       if exe.starts_with(dir_path) {
         log_debug!(self, "Killing process {} using executable: {}", process.pid(), exe.display());
         if process.kill() {
-          killed += 1;
+          killed_pids.push(process.pid());
         }
-        // wait for the process to actually exit so its executable is no longer
-        // locked before we attempt to delete it again
-        process.wait();
       }
     }
-    killed
+
+    // wait for the killed processes to actually exit so their executables are no
+    // longer locked before the caller tries to delete them again. poll with a
+    // timeout rather than `Process::wait`, which blocks indefinitely (e.g. on a
+    // process we couldn't kill, or a zombie its real parent hasn't reaped yet).
+    if !killed_pids.is_empty() {
+      let mut remaining_polls = 100; // ~2s at 20ms per poll
+      while remaining_polls > 0 {
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&killed_pids), true);
+        if killed_pids.iter().all(|pid| system.process(*pid).is_none()) {
+          break;
+        }
+        remaining_polls -= 1;
+        std::thread::sleep(std::time::Duration::from_millis(20));
+      }
+    }
+
+    killed_pids.len()
   }
 
   fn dir_info(&self, dir_path: impl AsRef<Path>) -> io::Result<Vec<DirEntry>> {

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
@@ -297,6 +298,35 @@ impl Environment for RealEnvironment {
       .output()?;
 
     Ok(String::from_utf8_lossy(&output.stdout).lines().map(PathBuf::from).collect())
+  }
+
+  fn get_dirty_files(&self) -> Result<Vec<PathBuf>> {
+    // collect every file with uncommitted changes in the working directory:
+    // unstaged tracked changes, staged tracked changes, and untracked files
+    // that aren't gitignored. each is gathered the same way `get_staged_files`
+    // gathers staged files so the behaviour (e.g. renamed files yielding their
+    // new path, deletions being skipped) stays consistent.
+    fn git_lines(args: &[&str]) -> Result<Vec<PathBuf>> {
+      let output = Command::new("git").args(args).output()?;
+      Ok(String::from_utf8_lossy(&output.stdout).lines().map(PathBuf::from).collect())
+    }
+
+    let mut files = Vec::new();
+    let mut seen = HashSet::new();
+    let groups = [
+      // unstaged tracked changes
+      git_lines(&["diff", "--name-only", "--relative", "--diff-filter=ACMR"])?,
+      // staged tracked changes
+      git_lines(&["diff", "--name-only", "--relative", "--staged", "--diff-filter=ACMR"])?,
+      // untracked files that aren't gitignored
+      git_lines(&["ls-files", "--others", "--exclude-standard"])?,
+    ];
+    for file in groups.into_iter().flatten() {
+      if seen.insert(file.clone()) {
+        files.push(file);
+      }
+    }
+    Ok(files)
   }
 
   fn global_gitignore_path(&self) -> Option<PathBuf> {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -135,6 +135,7 @@ pub struct TestEnvironment {
   log_level: Arc<Mutex<LogLevel>>,
   sys: Arc<InMemorySys>,
   staged_files: Arc<Mutex<Vec<PathBuf>>>,
+  dirty_files: Arc<Mutex<Vec<PathBuf>>>,
   global_gitignore_path: Arc<Mutex<Option<PathBuf>>>,
   stdout_messages: Arc<Mutex<Vec<String>>>,
   stderr_messages: Arc<Mutex<Vec<String>>>,
@@ -176,6 +177,7 @@ impl TestEnvironment {
       log_level: Arc::new(Mutex::new(LogLevel::Info)),
       sys: Default::default(),
       staged_files: Default::default(),
+      dirty_files: Default::default(),
       global_gitignore_path: Default::default(),
       stdout_messages: Default::default(),
       stderr_messages: Default::default(),
@@ -302,6 +304,9 @@ impl TestEnvironment {
 
   pub fn set_staged_file(&self, file: impl AsRef<Path>) {
     self.staged_files.lock().push(file.as_ref().to_path_buf())
+  }
+  pub fn set_dirty_file(&self, file: impl AsRef<Path>) {
+    self.dirty_files.lock().push(file.as_ref().to_path_buf())
   }
   pub fn set_global_gitignore_path(&self, path: impl AsRef<Path>) {
     *self.global_gitignore_path.lock() = Some(path.as_ref().to_path_buf());
@@ -511,6 +516,10 @@ impl Environment for TestEnvironment {
 
   fn get_staged_files(&self) -> Result<Vec<PathBuf>> {
     Ok(self.staged_files.lock().clone())
+  }
+
+  fn get_dirty_files(&self) -> Result<Vec<PathBuf>> {
+    Ok(self.dirty_files.lock().clone())
   }
 
   fn global_gitignore_path(&self) -> Option<PathBuf> {

--- a/crates/dprint/src/environment/test_environment_builder.rs
+++ b/crates/dprint/src/environment/test_environment_builder.rs
@@ -349,6 +349,11 @@ impl TestEnvironmentBuilder {
     self
   }
 
+  pub fn add_dirty_file(&mut self, file_path: impl AsRef<Path>) -> &mut Self {
+    self.environment.set_dirty_file(file_path);
+    self
+  }
+
   pub fn add_remote_file(&mut self, path: &str, text: &str) -> &mut Self {
     self.environment.add_remote_file_bytes(path, text.to_string().into_bytes());
     self

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -101,6 +101,12 @@ pub async fn get_and_resolve_file_paths<'a>(
       staged_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
       cwd.clone(),
     ));
+  } else if args.only_dirty {
+    let dirty_files = environment.get_dirty_files().context("Failed running git status.")?;
+    file_patterns.arg_includes = Some(GlobPattern::new_vec(
+      dirty_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
+      cwd.clone(),
+    ));
   }
 
   if file_patterns.config_includes.is_none() {

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -54,6 +54,20 @@ dprint fmt --staged
 
 Note: This requires that [git](https://git-scm.com/) is installed and that you use git for source control.
 
+### Formatting only git working directory files
+
+Requires dprint >= 0.55.0
+
+To format only the files with uncommitted changes in the git working directory—staged, unstaged, and untracked (but not gitignored) files—use the `--dirty` flag:
+
+```sh
+dprint fmt --dirty
+```
+
+This is useful in editors such as the JetBrains IDEs where the staging area isn't surfaced and you want to format everything you've touched but not yet committed.
+
+Note: This requires that [git](https://git-scm.com/) is installed and that you use git for source control.
+
 ### Ignoring .gitignore
 
 By default, dprint respects `.gitignore` files (as well as a repository's `.git/info/exclude` file) and excludes any gitignored files from formatting. To disable this behaviour, use the `--no-gitignore` flag:


### PR DESCRIPTION
Formats files with uncommitted changes in the git working directory (staged, unstaged, and untracked files that aren't gitignored). This helps in editors such as the JetBrains IDEs where the staging area isn't surfaced and you want to format everything you've touched but not yet committed.

Closes https://github.com/dprint/dprint/issues/890