### PR TITLE
perf: use `similar` for LSP diffing and drop `dissimilar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,12 +901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dissimilar"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
-
-[[package]]
 name = "dprint"
 version = "0.54.0"
 dependencies = [
@@ -919,7 +913,6 @@ dependencies = [
  "deno_npmrc",
  "deno_terminal",
  "dirs",
- "dissimilar",
  "dprint-core",
  "dunce",
  "flate2",

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -23,7 +23,6 @@ crossterm = "=0.27.0" # manually retest everything when bumping this crate
 deno_npmrc = "=0.9.0"
 deno_terminal = "=0.2.3"
 dirs = "=6.0.0"
-dissimilar = "=1.0.10"
 dprint-core = { path = "../core", version = "=0.68.2", features = ["process", "wasm"] }
 dunce = "=1.0.4"
 flate2 = "=1.1.9"

--- a/crates/dprint/src/commands/lsp/mod.rs
+++ b/crates/dprint/src/commands/lsp/mod.rs
@@ -694,10 +694,20 @@ mod test {
             .await;
           assert_eq!(
             result.unwrap().unwrap(),
-            vec![TextEdit {
-              range: Range::new(Position::new(0, 1), Position::new(0, 7)),
-              new_text: "_formatted_process_sting_formatted_process".to_string()
-            }]
+            vec![
+              TextEdit {
+                range: Range::new(Position::new(0, 1), Position::new(0, 1)),
+                new_text: "_formatted_proc".to_string()
+              },
+              TextEdit {
+                range: Range::new(Position::new(0, 3), Position::new(0, 3)),
+                new_text: "s_s".to_string()
+              },
+              TextEdit {
+                range: Range::new(Position::new(0, 7), Position::new(0, 7)),
+                new_text: "_formatted_process".to_string()
+              },
+            ]
           );
 
           // cancellation via a drop

--- a/crates/dprint/src/commands/lsp/text.rs
+++ b/crates/dprint/src/commands/lsp/text.rs
@@ -5,9 +5,11 @@
 
 use anyhow::Result;
 use anyhow::bail;
-use dissimilar::Chunk;
-use dissimilar::diff;
+use similar::ChangeTag;
+use similar::TextDiff;
 use std::collections::HashMap;
+use std::time::Duration;
+use std::time::Instant;
 use text_size::TextRange;
 use text_size::TextSize;
 use tower_lsp::lsp_types as lsp;
@@ -170,17 +172,30 @@ pub fn get_edits(a: &str, b: &str, line_index: &LineIndex) -> Vec<TextEdit> {
   if a == b {
     return vec![];
   }
-  // Heuristic to detect things like minified files. `diff()` is expensive.
+  // Heuristic to detect things like minified files. Diffing is expensive.
   if b.chars().filter(|c| *c == '\n').count() > line_index.utf8_offsets.len() * 3 {
-    return vec![TextEdit {
-      range: lsp::Range {
-        start: lsp::Position::new(0, 0),
-        end: line_index.position_utf16(TextSize::from(a.len() as u32)),
-      },
-      new_text: b.to_string(),
-    }];
+    return vec![replace_whole_file(a, b, line_index)];
   }
-  let chunks = diff(a, b);
+  // diff at the character level, coalescing consecutive changes of the same
+  // kind into runs so the edit construction below can work a chunk at a time.
+  // Within a replacement similar always yields the deletions before the insertions.
+  //
+  // A deadline bounds pathological inputs. similar bails out and returns a valid
+  // (but non-minimal) diff when it's hit, which would produce a large pile of
+  // scattered edits, so in that case fall back to replacing the whole file.
+  let deadline = Instant::now() + Duration::from_millis(500);
+  let diff = TextDiff::configure().deadline(deadline).diff_chars(a, b);
+  if Instant::now() >= deadline {
+    return vec![replace_whole_file(a, b, line_index)];
+  }
+  let mut chunks: Vec<(ChangeTag, String)> = Vec::new();
+  for change in diff.iter_all_changes() {
+    match chunks.last_mut() {
+      Some((tag, text)) if *tag == change.tag() => text.push_str(change.value()),
+      _ => chunks.push((change.tag(), change.value().to_string())),
+    }
+  }
+
   let mut text_edits = Vec::<TextEdit>::new();
   let mut iter = chunks.iter().peekable();
   let mut a_pos = TextSize::from(0);
@@ -188,16 +203,16 @@ pub fn get_edits(a: &str, b: &str, line_index: &LineIndex) -> Vec<TextEdit> {
     let chunk = iter.next();
     match chunk {
       None => break,
-      Some(Chunk::Equal(e)) => {
+      Some((ChangeTag::Equal, e)) => {
         a_pos += TextSize::from(e.encode_utf16().count() as u32);
       }
-      Some(Chunk::Delete(d)) => {
+      Some((ChangeTag::Delete, d)) => {
         let start = line_index.position_utf16(a_pos);
         a_pos += TextSize::from(d.encode_utf16().count() as u32);
         let end = line_index.position_utf16(a_pos);
         let range = lsp::Range { start, end };
         match iter.peek() {
-          Some(Chunk::Insert(i)) => {
+          Some((ChangeTag::Insert, i)) => {
             iter.next();
             text_edits.push(TextEdit {
               range,
@@ -210,7 +225,7 @@ pub fn get_edits(a: &str, b: &str, line_index: &LineIndex) -> Vec<TextEdit> {
           }),
         }
       }
-      Some(Chunk::Insert(i)) => {
+      Some((ChangeTag::Insert, i)) => {
         let pos = line_index.position_utf16(a_pos);
         let range = lsp::Range { start: pos, end: pos };
         text_edits.push(TextEdit {
@@ -222,6 +237,17 @@ pub fn get_edits(a: &str, b: &str, line_index: &LineIndex) -> Vec<TextEdit> {
   }
 
   text_edits
+}
+
+/// A single edit that replaces the entire document with `new_text`.
+fn replace_whole_file(old_text: &str, new_text: &str, line_index: &LineIndex) -> TextEdit {
+  TextEdit {
+    range: lsp::Range {
+      start: lsp::Position::new(0, 0),
+      end: line_index.position_utf16(TextSize::from(old_text.len() as u32)),
+    },
+    new_text: new_text.to_string(),
+  }
 }
 
 fn partition_point<T, P>(slice: &[T], mut predicate: P) -> usize
@@ -375,9 +401,30 @@ const C: char = \"メ メ\";
         TextEdit {
           range: lsp::Range {
             start: lsp::Position { line: 0, character: 1 },
+            end: lsp::Position { line: 0, character: 1 }
+          },
+          new_text: "\n".to_string()
+        },
+        TextEdit {
+          range: lsp::Range {
+            start: lsp::Position { line: 0, character: 2 },
+            end: lsp::Position { line: 0, character: 2 }
+          },
+          new_text: "\n".to_string()
+        },
+        TextEdit {
+          range: lsp::Range {
+            start: lsp::Position { line: 0, character: 3 },
+            end: lsp::Position { line: 0, character: 4 }
+          },
+          new_text: "hij".to_string()
+        },
+        TextEdit {
+          range: lsp::Range {
+            start: lsp::Position { line: 0, character: 5 },
             end: lsp::Position { line: 0, character: 5 }
           },
-          new_text: "\nb\nchije\n".to_string()
+          new_text: "\n".to_string()
         },
         TextEdit {
           range: lsp::Range {
@@ -432,9 +479,16 @@ const C: char = \"メ メ\";
         TextEdit {
           range: lsp::Range {
             start: lsp::Position { line: 1, character: 23 },
+            end: lsp::Position { line: 1, character: 24 }
+          },
+          new_text: "\"".to_string()
+        },
+        TextEdit {
+          range: lsp::Range {
+            start: lsp::Position { line: 1, character: 25 },
             end: lsp::Position { line: 1, character: 25 }
           },
-          new_text: "\");".to_string()
+          new_text: ";".to_string()
         },
       ]
     )


### PR DESCRIPTION
## Summary

The LSP's `get_edits` ([`crates/dprint/src/commands/lsp/text.rs`](crates/dprint/src/commands/lsp/text.rs)) did character-level diffing via `dissimilar`, which has no timeout and could blow up super-linearly on large files. This was the same library [denoland/deno#30644](https://github.com/denoland/deno/pull/30644) moved away from for its `fmt --check` display.

This swaps `dissimilar` for `similar` (already a workspace dependency, used by the `--check` display path), keeping **character-level** diffing — better for the editor since it produces minimal in-place edits that preserve the cursor/selection.

## Changes

- Replace `dissimilar::diff` with `TextDiff::configure().deadline(..).diff_chars(a, b)`. `similar`'s per-char changes are coalesced into same-tag runs so the existing Delete→Insert edit-pairing loop is reused unchanged (`similar` yields deletions before insertions within a replacement).
- **Timeout fallback:** `similar` doesn't expose whether the deadline was hit — it bails and returns a valid-but-non-minimal diff. So we set an explicit 500ms deadline and, if `Instant::now()` is past it after diffing, fall back to a single whole-file replacement instead of emitting scattered non-minimal edits.
- Extract `replace_whole_file` helper, shared by the existing minified-file heuristic and the new timeout path.
- Drop the `dissimilar` dependency.

## Test plan

- [x] `cargo test -p dprint commands::lsp::text` — updated `test_get_edits` / `test_get_edits_mbc` expectations, since `similar` produces finer-grained (and verified-correct) edits than `dissimilar`.