### PR TITLE
perf: reduce wasm plugin thread stack size to 4 MiB

### DIFF
--- a/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
@@ -131,12 +131,16 @@ impl WasmModuleCreator {
 pub const MAX_WASM_STACK_SIZE: usize = 1024 * 1024;
 
 /// Native stack size for the (tokio blocking) thread that runs a wasm plugin
-/// instance. wasmtime executes wasm on this native stack up to
-/// `MAX_WASM_STACK_SIZE`, so it must exceed that with headroom for host frames.
+/// instance. wasmtime executes wasm on this native stack, so it must exceed
+/// `MAX_WASM_STACK_SIZE` (the hard cap on wasm stack usage) with headroom for the
+/// host frames around the wasm call — which is a shallow path, so 3 MiB is ample.
 /// Applied via the tokio runtime's `thread_stack_size` since the instance loop
 /// runs on `spawn_blocking` (tokio's default blocking-thread stack is too small
-/// on some platforms, e.g. Windows).
-pub const WASM_PLUGIN_THREAD_STACK_SIZE: usize = MAX_WASM_STACK_SIZE + 16 * 1024 * 1024;
+/// on some platforms, e.g. Windows). The stack is reserved address space that the
+/// OS commits lazily as it's touched, so the unused headroom costs no physical
+/// memory; it just needs to be large enough that wasm hits its own limit (a
+/// recoverable trap) before exhausting the native stack (a crash).
+pub const WASM_PLUGIN_THREAD_STACK_SIZE: usize = MAX_WASM_STACK_SIZE + 3 * 1024 * 1024;
 
 fn new_engine() -> wasmtime::Engine {
   let mut config = Config::new();


### PR DESCRIPTION
The wasm plugin thread stack was set to 17 MiB (`MAX_WASM_STACK_SIZE` + 16 MiB). But wasm stack usage is hard-capped by `max_wasm_stack` = `MAX_WASM_STACK_SIZE` (1 MiB), so a thread larger than ~1 MiB + host headroom buys nothing — wasm can never use more than 1 MiB regardless of the native stack size. The extra 16 MiB was pure headroom.

This reduces it to **1 MiB + 3 MiB = 4 MiB**. The host call path into wasm is shallow, so 3 MiB of headroom is ample.

### Memory note
Thread stacks are reserved address space that the OS commits lazily as pages are touched (Rust uses `STACK_SIZE_PARAM_IS_A_RESERVATION` on Windows; Linux demand-pages mmap'd stacks). So this never cost physical RAM proportional to the reserve — physical use tracks the actual stack depth (≤ 1 MiB). The change shrinks the per-thread *reserve* 4× (17→4 MiB), which matters mostly for long-lived processes like the LSP that hold several plugin-instance threads.

Behavior is unchanged: `max_wasm_stack` stays 1 MiB, so the same files format (verified the deeply-nested `types/dojo/dojox.mobile.d.ts` from DefinitelyTyped still formats), and `cargo test` passes (627).