### PR TITLE
feat(npm): detect plugin kind on `dprint add` when no path is given

### DIFF
--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -26,7 +26,9 @@ use crate::plugins::InfoFilePluginInfo;
 use crate::plugins::PluginResolver;
 use crate::plugins::PluginSourceReference;
 use crate::plugins::PluginWrapper;
+use crate::plugins::detect_npm_plugin_kind_in_node_modules;
 use crate::plugins::fetch_npm_latest_info;
+use crate::plugins::fetch_npm_versioned_tarball_info;
 use crate::plugins::read_info_file;
 use crate::plugins::read_update_url;
 use crate::resolution::GetPluginResult;
@@ -35,6 +37,7 @@ use crate::resolution::resolve_plugins_scope;
 use crate::resolution::resolve_plugins_scope_and_paths;
 use crate::utils::CachedDownloader;
 use crate::utils::PathSource;
+use crate::utils::PluginKind;
 use crate::utils::pretty_print_json_text;
 
 pub struct InitConfigFileOptions<'a> {
@@ -359,14 +362,25 @@ struct ResolveNpmPluginOptions<'a> {
 /// into the config's `plugins` array, plus the devDependencies entry to
 /// queue when `--package-json` was set.
 ///
-/// - `npm:foo@1.2.3[...]` (already versioned) → pass through verbatim.
-/// - `npm:foo` with `--no-version` or `--package-json` → keep unversioned.
-///   With `--package-json`, also return a `devDependencies` entry for the
-///   nearest `package.json` (caret range pinning the resolved latest).
+/// When the user didn't write an explicit plugin path, dprint inspects the
+/// package to detect whether it's a wasm (`plugin.wasm`) or process
+/// (`plugin.json`) plugin and writes the matching form — for the pinned forms
+/// it downloads the tarball; for the unversioned forms it reads `node_modules`.
+///
+/// - `npm:foo@1.2.3/plugin.json[@sha]` (explicit path) → pass through verbatim.
+/// - `npm:foo@1.2.3` (versioned, no path) → download that version's tarball to
+///   detect the kind and pin the matching form (with checksum for process).
+/// - `npm:foo` with `--no-version` or `--package-json` → keep unversioned. With
+///   `--package-json`, also return a `devDependencies` entry for the nearest
+///   `package.json` (caret range pinning the resolved latest) and detect the
+///   kind from that tarball; with bare `--no-version` the registry isn't
+///   touched, so the kind is read from `node_modules` if installed.
 /// - `npm:foo` (unversioned) and the package is in a nearby `package.json`'s
-///   `devDependencies` → keep unversioned (defer to npm/node_modules).
-/// - `npm:foo` (unversioned) otherwise → resolve `dist-tags.latest` and write
-///   the pinned form, with checksum for non-wasm plugins.
+///   `devDependencies` → keep unversioned (defer to npm/node_modules), reading
+///   the kind from `node_modules` if installed.
+/// - `npm:foo` (unversioned) otherwise → resolve `dist-tags.latest`, download
+///   the tarball to detect the kind, and write the pinned form (with checksum
+///   for process plugins).
 async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environment: &impl Environment) -> Result<ResolvedNpmPluginAdd> {
   let ResolveNpmPluginOptions {
     text,
@@ -375,10 +389,14 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     update_package_json,
   } = options;
   let parsed = crate::utils::parse_npm_specifier(text)?;
-  // top-level plugin reference: enforce the same .wasm/.json constraint that
-  // parse_plugin_source_reference applies, since `dprint add` writes the
-  // result straight into the plugins array.
-  crate::utils::validate_plugin_extension(&parsed.specifier, text)?;
+  // when the user wrote an explicit plugin path, enforce the same .wasm/.json
+  // constraint parse_plugin_source_reference applies, since `dprint add` writes
+  // the result straight into the plugins array. When the path was defaulted we
+  // detect the real kind below, so there's nothing to validate yet.
+  let explicit_path = parsed.path_was_explicit;
+  if explicit_path {
+    crate::utils::validate_plugin_extension(&parsed.specifier, text)?;
+  }
 
   // a config path with no parent shouldn't happen — `resolve_config_from_args`
   // hands us a canonicalized file path. Treat it as a hard bug rather than a
@@ -387,19 +405,36 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     .parent()
     .ok_or_else(|| anyhow!("Config path {} has no parent directory.", config_path.display()))?;
   let start_dir_ref: &Path = start_dir.as_ref();
+  let name = parsed.specifier.name.clone();
 
-  if parsed.specifier.version.is_some() {
+  if let Some(version) = parsed.specifier.version.clone() {
     if no_version {
       bail!("--no-version cannot be combined with a versioned specifier: {}", text);
     }
+    if explicit_path {
+      // the user fully specified name, version, and plugin file — pass through.
+      return Ok(ResolvedNpmPluginAdd {
+        url: text.to_string(),
+        package_name: name,
+        package_json_addition: None,
+      });
+    }
+    // no path given: inspect the package to learn whether it's a wasm or
+    // process plugin, then write the matching plugin file (with a checksum for
+    // process plugins).
+    let info = fetch_npm_versioned_tarball_info(&name, &version, Some(start_dir_ref), environment).await?;
     return Ok(ResolvedNpmPluginAdd {
-      url: text.to_string(),
-      package_name: parsed.specifier.name.clone(),
+      url: build_npm_add_url(&name, Some(&version), info.plugin_kind, &info.tarball_sha256),
+      package_name: name,
       package_json_addition: None,
     });
   }
 
   if no_version {
+    // when we hit the registry for the caret range we also detect the kind
+    // from that tarball — `--package-json` is usually run before the package
+    // is installed, so node_modules detection alone wouldn't find it.
+    let mut detected_kind = None;
     let package_json_addition = if update_package_json {
       // Look up the latest version so we can write a caret range. If the
       // registry is unreachable we still write the unversioned spec to
@@ -410,31 +445,29 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
           specifier: &parsed.specifier,
           start_dir: Some(start_dir_ref),
           want_tarball_sha: false,
+          detect_plugin_kind: !explicit_path,
         },
         environment,
       )
       .await
-      .with_context(|| format!("Resolving latest version for package.json entry of {}", parsed.specifier.name))?;
-      Some((parsed.specifier.name.clone(), format!("^{}", info.version)))
+      .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?;
+      detected_kind = info.detected_plugin_kind;
+      Some((name.clone(), format!("^{}", info.version)))
     } else {
       None
     };
     return Ok(ResolvedNpmPluginAdd {
-      url: parsed.specifier.display(),
-      package_name: parsed.specifier.name.clone(),
+      url: unversioned_npm_add_url(&parsed, explicit_path, detected_kind, start_dir_ref, environment),
+      package_name: name,
       package_json_addition,
     });
   }
 
-  if is_in_package_json_deps(&parsed.specifier.name, start_dir_ref, environment) {
-    log_stderr_info!(
-      environment,
-      "Found {} in package.json — adding unversioned npm specifier.",
-      parsed.specifier.name
-    );
+  if is_in_package_json_deps(&name, start_dir_ref, environment) {
+    log_stderr_info!(environment, "Found {} in package.json — adding unversioned npm specifier.", name);
     return Ok(ResolvedNpmPluginAdd {
-      url: parsed.specifier.display(),
-      package_name: parsed.specifier.name.clone(),
+      url: unversioned_npm_add_url(&parsed, explicit_path, None, start_dir_ref, environment),
+      package_name: name,
       package_json_addition: None,
     });
   }
@@ -444,25 +477,85 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
       specifier: &parsed.specifier,
       start_dir: Some(start_dir_ref),
       want_tarball_sha: false,
+      detect_plugin_kind: !explicit_path,
     },
     environment,
   )
   .await?;
-  let pinned = crate::utils::NpmSpecifier {
-    name: parsed.specifier.name,
-    version: Some(info.version),
-    path: parsed.specifier.path,
-  };
-  let display = pinned.display();
-  let url = match info.tarball_sha256 {
-    Some(checksum) => format!("{}@{}", display, checksum),
-    None => display,
+
+  let url = if explicit_path {
+    // the user named the plugin file; pin the version and add a checksum for
+    // non-wasm plugins (fetch_npm_latest_info computed it for us).
+    let pinned = crate::utils::NpmSpecifier {
+      name: name.clone(),
+      version: Some(info.version),
+      path: parsed.specifier.path.clone(),
+    };
+    let display = pinned.display();
+    match info.tarball_sha256 {
+      Some(checksum) => format!("{}@{}", display, checksum),
+      None => display,
+    }
+  } else {
+    let kind = info.detected_plugin_kind.expect("detect_plugin_kind was requested");
+    // detection downloads the tarball, so the checksum is always computed too.
+    let checksum = info.tarball_sha256.expect("tarball checksum computed alongside detection");
+    build_npm_add_url(&name, Some(&info.version), kind, &checksum)
   };
   Ok(ResolvedNpmPluginAdd {
     url,
-    package_name: pinned.name,
+    package_name: name,
     package_json_addition: None,
   })
+}
+
+/// Builds the plugins-array entry for an npm plugin whose kind was detected by
+/// inspecting the package: `npm:name[@version]` for wasm plugins, and
+/// `npm:name[@version]/plugin.json@<sha256>` for process plugins (which always
+/// require a checksum).
+fn build_npm_add_url(name: &str, version: Option<&str>, kind: PluginKind, tarball_sha256: &str) -> String {
+  let path = match kind {
+    PluginKind::Wasm => "plugin.wasm",
+    PluginKind::Process => "plugin.json",
+  };
+  let specifier = crate::utils::NpmSpecifier {
+    name: name.to_string(),
+    version: version.map(|v| v.to_string()),
+    path: path.to_string(),
+  };
+  let display = specifier.display();
+  match kind {
+    PluginKind::Wasm => display,
+    PluginKind::Process => format!("{}@{}", display, tarball_sha256),
+  }
+}
+
+/// Picks the unversioned specifier string to write for an npm plugin we aren't
+/// pinning (deferring to node_modules / package.json). When the user didn't
+/// give a path, use `detected_kind` if the caller already learned it from the
+/// registry tarball, else fall back to inspecting `node_modules`, so a process
+/// plugin gets `/plugin.json`; otherwise keep the bare form.
+fn unversioned_npm_add_url(
+  parsed: &crate::utils::ParsedNpmSpecifier,
+  explicit_path: bool,
+  detected_kind: Option<PluginKind>,
+  start_dir: &Path,
+  environment: &impl Environment,
+) -> String {
+  if explicit_path {
+    return parsed.specifier.display();
+  }
+  let kind = detected_kind.or_else(|| detect_npm_plugin_kind_in_node_modules(&parsed.specifier.name, start_dir, environment));
+  let path = match kind {
+    Some(PluginKind::Process) => "plugin.json".to_string(),
+    _ => parsed.specifier.path.clone(),
+  };
+  crate::utils::NpmSpecifier {
+    name: parsed.specifier.name.clone(),
+    version: None,
+    path,
+  }
+  .display()
 }
 
 /// Writes new `devDependencies` entries into the nearest `package.json`
@@ -974,6 +1067,7 @@ async fn get_plugins_to_update<TEnvironment: Environment>(
         specifier: &npm_source.specifier,
         start_dir,
         want_tarball_sha: plugin_reference.checksum.is_some(),
+        detect_plugin_kind: false,
       };
       match fetch_npm_latest_info(args, environment).await {
         Ok(info) => {
@@ -2850,14 +2944,40 @@ mod test {
   }
 
   #[tokio::test]
-  async fn npm_add_pinned_passes_through() {
+  async fn npm_add_pinned_wasm_keeps_bare_form() {
+    // a pinned version without a path inspects that version's tarball to learn
+    // the kind; a wasm package keeps the bare `name@version` form.
+    use crate::test_helpers::create_test_npm_tarball;
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "0.95.15" },
+      "versions": { "0.95.15": { "dist": { "tarball": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.95.15.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/@dprint/typescript", packument.to_string().into_bytes());
+    environment.add_remote_file_bytes(
+      "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.95.15.tgz",
+      create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+    );
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:@dprint/typescript@0.95.15", &config_path, false, false, &environment)
       .await
       .unwrap();
     assert_eq!(result.url, "npm:@dprint/typescript@0.95.15");
+    assert!(result.package_json_addition.is_none());
+  }
+
+  #[tokio::test]
+  async fn npm_add_pinned_with_explicit_path_passes_through() {
+    // an explicit plugin file is taken at face value and passed through
+    // verbatim without touching the registry.
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:@dprint/typescript@0.95.15/plugin.wasm", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, "npm:@dprint/typescript@0.95.15/plugin.wasm");
     assert!(result.package_json_addition.is_none());
   }
 
@@ -2916,6 +3036,7 @@ mod test {
 
   #[tokio::test]
   async fn npm_add_resolves_latest_without_devdep() {
+    use crate::test_helpers::create_test_npm_tarball;
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
     let packument = serde_json::json!({
@@ -2923,6 +3044,9 @@ mod test {
       "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    // detection downloads the tarball to learn the plugin kind — ship a wasm one
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
       .await
@@ -2947,6 +3071,103 @@ mod test {
       .await
       .unwrap();
     assert_eq!(result.url, format!("npm:foo@2.0.0/plugin.json@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_autodetects_process_plugin_without_path() {
+    // `dprint add npm:foo` (no path) should inspect the package, discover it
+    // ships a plugin.json, and write the pinned process form with a checksum.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "2.0.0" },
+      "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-2.0.0.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@2.0.0/plugin.json@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_autodetects_wasm_plugin_without_path() {
+    // `dprint add npm:foo` for a wasm package keeps the bare pinned form
+    // (no checksum), even though we now download the tarball to detect.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "2.0.0" },
+      "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-2.0.0.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, "npm:foo@2.0.0");
+  }
+
+  #[tokio::test]
+  async fn npm_add_autodetects_process_plugin_for_versioned_without_path() {
+    // a pinned version without a path still inspects that version's tarball
+    // rather than passing through verbatim as wasm.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "9.9.9" },
+      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo@1.2.3", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@1.2.3/plugin.json@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_defers_to_devdep_detects_process_path_from_node_modules() {
+    // when deferring to an unversioned spec, detect from node_modules so a
+    // process plugin still gets `/plugin.json`.
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    environment.write_file("/package.json", r#"{"devDependencies": {"foo": "^1.0.0"}}"#).unwrap();
+    environment.mk_dir_all("/node_modules/foo").unwrap();
+    environment.write_file("/node_modules/foo/plugin.json", "{}").unwrap();
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, "npm:foo/plugin.json");
+    let _ = environment.take_stderr_messages();
+  }
+
+  #[tokio::test]
+  async fn npm_add_no_version_detects_process_path_from_node_modules() {
+    // --no-version writes the unversioned form but should still pick up
+    // `/plugin.json` for a process plugin installed in node_modules.
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    environment.mk_dir_all("/node_modules/foo").unwrap();
+    environment.write_file("/node_modules/foo/plugin.json", "{}").unwrap();
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, true, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, "npm:foo/plugin.json");
   }
 
   #[tokio::test]
@@ -2983,6 +3204,7 @@ mod test {
     // --package-json pulls dist-tags.latest, writes the unversioned spec
     // to dprint.json, and returns a caret-pinned devDependency entry the
     // caller queues for the package.json update.
+    use crate::test_helpers::create_test_npm_tarball;
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
     let packument = serde_json::json!({
@@ -2990,6 +3212,10 @@ mod test {
       "versions": { "0.99.0": { "dist": { "tarball": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.99.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/@dprint/typescript", packument.to_string().into_bytes());
+    environment.add_remote_file_bytes(
+      "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.99.0.tgz",
+      create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+    );
 
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:@dprint/typescript", &config_path, true, true, &environment)
@@ -2997,6 +3223,31 @@ mod test {
       .unwrap();
     assert_eq!(result.url, "npm:@dprint/typescript");
     assert_eq!(result.package_json_addition, Some(("@dprint/typescript".to_string(), "^0.99.0".to_string())),);
+  }
+
+  #[tokio::test]
+  async fn npm_add_package_json_detects_process_path_from_tarball() {
+    // --package-json is usually run before the package is installed, so detect
+    // the kind from the registry tarball and write `/plugin.json` even though
+    // node_modules has nothing yet. No checksum is written: the unversioned
+    // form resolves from node_modules, which doesn't require one.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.0.0" },
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    environment.add_remote_file_bytes(
+      "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+      create_test_npm_tarball(&[("package/plugin.json", b"{}")]),
+    );
+
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, true, true, &environment).await.unwrap();
+    assert_eq!(result.url, "npm:foo/plugin.json");
+    assert_eq!(result.package_json_addition, Some(("foo".to_string(), "^1.0.0".to_string())));
   }
 
   #[tokio::test]
@@ -3078,14 +3329,24 @@ mod test {
   #[test]
   fn config_add_npm_replaces_existing_entry_for_same_package() {
     // re-adding a package that's already present should replace the existing
-    // entry (any version) rather than append a duplicate. A versioned
-    // specifier passes through without touching the registry, so no mock is
-    // needed here.
+    // entry (any version) rather than append a duplicate. A versioned add
+    // without a path inspects the package to detect its kind, so mock the
+    // registry with a wasm tarball.
+    use crate::test_helpers::create_test_npm_tarball;
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "2.0.0" },
+      "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/test-plugin/-/test-plugin-2.0.0.tgz" } } }
+    });
     let environment = TestEnvironmentBuilder::new()
       .with_local_config("/dprint.json", |c| {
         c.add_plugin("npm:test-plugin@1.0.0");
         c.add_plugin("npm:other@1.0.0");
       })
+      .add_remote_file_bytes("https://registry.npmjs.org/test-plugin", packument.to_string().into_bytes())
+      .add_remote_file_bytes(
+        "https://registry.npmjs.org/test-plugin/-/test-plugin-2.0.0.tgz",
+        create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+      )
       .build();
 
     run_test_cli(vec!["config", "add", "npm:test-plugin@2.0.0"], &environment).unwrap();

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -28,6 +28,7 @@ use crate::plugins::PluginSourceReference;
 use crate::plugins::PluginWrapper;
 use crate::plugins::detect_npm_plugin_kind_in_node_modules;
 use crate::plugins::fetch_npm_latest_info;
+use crate::plugins::fetch_npm_latest_tarball_info;
 use crate::plugins::fetch_npm_versioned_tarball_info;
 use crate::plugins::read_info_file;
 use crate::plugins::read_update_url;
@@ -407,7 +408,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
   let start_dir_ref: &Path = start_dir.as_ref();
   let name = parsed.specifier.name.clone();
 
-  if let Some(version) = parsed.specifier.version.clone() {
+  if let Some(version) = &parsed.specifier.version {
     if no_version {
       bail!("--no-version cannot be combined with a versioned specifier: {}", text);
     }
@@ -422,37 +423,45 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     // no path given: inspect the package to learn whether it's a wasm or
     // process plugin, then write the matching plugin file (with a checksum for
     // process plugins).
-    let info = fetch_npm_versioned_tarball_info(&name, &version, Some(start_dir_ref), environment).await?;
+    let info = fetch_npm_versioned_tarball_info(&name, version, Some(start_dir_ref), environment).await?;
     return Ok(ResolvedNpmPluginAdd {
-      url: build_npm_add_url(&name, Some(&version), info.plugin_kind, &info.tarball_sha256),
+      url: build_npm_add_url(&name, Some(version), info.plugin_kind, &info.tarball_sha256),
       package_name: name,
       package_json_addition: None,
     });
   }
 
   if no_version {
-    // when we hit the registry for the caret range we also detect the kind
-    // from that tarball — `--package-json` is usually run before the package
-    // is installed, so node_modules detection alone wouldn't find it.
+    // Look up the latest version so we can write a caret range. If the
+    // registry is unreachable we still write the unversioned spec to
+    // dprint.json but bail on the package.json update so the user notices
+    // (rather than ending up with an out-of-sync state). When the path was
+    // defaulted we also detect the kind from that tarball — `--package-json`
+    // is usually run before the package is installed, so node_modules
+    // detection alone wouldn't find it.
     let mut detected_kind = None;
     let package_json_addition = if update_package_json {
-      // Look up the latest version so we can write a caret range. If the
-      // registry is unreachable we still write the unversioned spec to
-      // dprint.json but bail on the package.json update so the user
-      // notices (rather than ending up with an out-of-sync state).
-      let info = fetch_npm_latest_info(
-        FetchNpmLatestInfo {
-          specifier: &parsed.specifier,
-          start_dir: Some(start_dir_ref),
-          want_tarball_sha: false,
-          detect_plugin_kind: !explicit_path,
-        },
-        environment,
-      )
-      .await
-      .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?;
-      detected_kind = info.detected_plugin_kind;
-      Some((name.clone(), format!("^{}", info.version)))
+      let version = if explicit_path {
+        // an explicit path already tells us the kind; only the version is needed.
+        fetch_npm_latest_info(
+          FetchNpmLatestInfo {
+            specifier: &parsed.specifier,
+            start_dir: Some(start_dir_ref),
+            want_tarball_sha: false,
+          },
+          environment,
+        )
+        .await
+        .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?
+        .version
+      } else {
+        let info = fetch_npm_latest_tarball_info(&name, Some(start_dir_ref), environment)
+          .await
+          .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?;
+        detected_kind = Some(info.plugin_kind);
+        info.version
+      };
+      Some((name.clone(), format!("^{}", version)))
     } else {
       None
     };
@@ -472,38 +481,40 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     });
   }
 
-  let info = fetch_npm_latest_info(
-    FetchNpmLatestInfo {
-      specifier: &parsed.specifier,
-      start_dir: Some(start_dir_ref),
-      want_tarball_sha: false,
-      detect_plugin_kind: !explicit_path,
-    },
-    environment,
-  )
-  .await?;
-
-  let url = if explicit_path {
-    // the user named the plugin file; pin the version and add a checksum for
-    // non-wasm plugins (fetch_npm_latest_info computed it for us).
+  if explicit_path {
+    // the user named the plugin file; pin the latest version and add a checksum
+    // for non-wasm plugins (fetch_npm_latest_info computes it when needed).
+    let info = fetch_npm_latest_info(
+      FetchNpmLatestInfo {
+        specifier: &parsed.specifier,
+        start_dir: Some(start_dir_ref),
+        want_tarball_sha: false,
+      },
+      environment,
+    )
+    .await?;
     let pinned = crate::utils::NpmSpecifier {
-      name: name.clone(),
+      name,
       version: Some(info.version),
-      path: parsed.specifier.path.clone(),
+      path: parsed.specifier.path,
     };
     let display = pinned.display();
-    match info.tarball_sha256 {
+    let url = match info.tarball_sha256 {
       Some(checksum) => format!("{}@{}", display, checksum),
       None => display,
-    }
-  } else {
-    let kind = info.detected_plugin_kind.expect("detect_plugin_kind was requested");
-    // detection downloads the tarball, so the checksum is always computed too.
-    let checksum = info.tarball_sha256.expect("tarball checksum computed alongside detection");
-    build_npm_add_url(&name, Some(&info.version), kind, &checksum)
-  };
+    };
+    return Ok(ResolvedNpmPluginAdd {
+      url,
+      package_name: pinned.name,
+      package_json_addition: None,
+    });
+  }
+
+  // no path given: resolve the latest version and inspect its tarball to learn
+  // the plugin kind (and checksum, required for process plugins).
+  let info = fetch_npm_latest_tarball_info(&name, Some(start_dir_ref), environment).await?;
   Ok(ResolvedNpmPluginAdd {
-    url,
+    url: build_npm_add_url(&name, Some(&info.version), info.plugin_kind, &info.tarball_sha256),
     package_name: name,
     package_json_addition: None,
   })
@@ -1067,7 +1078,6 @@ async fn get_plugins_to_update<TEnvironment: Environment>(
         specifier: &npm_source.specifier,
         start_dir,
         want_tarball_sha: plugin_reference.checksum.is_some(),
-        detect_plugin_kind: false,
       };
       match fetch_npm_latest_info(args, environment).await {
         Ok(info) => {

--- a/crates/dprint/src/plugins/mod.rs
+++ b/crates/dprint/src/plugins/mod.rs
@@ -23,4 +23,5 @@ pub use name_resolution::PluginNameResolutionMaps;
 pub use npm_resolution::FetchNpmLatestInfo;
 pub use npm_resolution::detect_npm_plugin_kind_in_node_modules;
 pub use npm_resolution::fetch_npm_latest_info;
+pub use npm_resolution::fetch_npm_latest_tarball_info;
 pub use npm_resolution::fetch_npm_versioned_tarball_info;

--- a/crates/dprint/src/plugins/mod.rs
+++ b/crates/dprint/src/plugins/mod.rs
@@ -21,4 +21,6 @@ pub use implementations::WASM_PLUGIN_THREAD_STACK_SIZE;
 pub use implementations::compile_wasm;
 pub use name_resolution::PluginNameResolutionMaps;
 pub use npm_resolution::FetchNpmLatestInfo;
+pub use npm_resolution::detect_npm_plugin_kind_in_node_modules;
 pub use npm_resolution::fetch_npm_latest_info;
+pub use npm_resolution::fetch_npm_versioned_tarball_info;

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -61,9 +61,6 @@ pub struct NpmLatestInfo {
   /// on the request, or whenever the plugin is non-wasm (where a checksum is
   /// always required in the dprint.json specifier).
   pub tarball_sha256: Option<String>,
-  /// The plugin kind discovered by inspecting the tarball's contents.
-  /// Populated only when `detect_plugin_kind` was set on the request.
-  pub detected_plugin_kind: Option<PluginKind>,
 }
 
 /// Inputs to [`fetch_npm_latest_info`].
@@ -77,17 +74,19 @@ pub struct FetchNpmLatestInfo<'a> {
   /// pins to the new tarball rather than carrying the stale hash. Non-wasm
   /// plugins always compute the checksum regardless.
   pub want_tarball_sha: bool,
-  /// Download the tarball and inspect it to determine whether the package
-  /// ships a `plugin.wasm` or `plugin.json`, returning the result in
-  /// `detected_plugin_kind`. Used by `dprint add` when the user gave an npm
-  /// specifier without a path. Implies downloading the tarball, so the
-  /// checksum is computed too.
-  pub detect_plugin_kind: bool,
 }
 
 /// The plugin kind and tarball checksum for a specific `name@version`,
 /// discovered by downloading and inspecting the package tarball.
 pub struct NpmTarballInfo {
+  pub plugin_kind: PluginKind,
+  pub tarball_sha256: String,
+}
+
+/// Like [`NpmTarballInfo`], but for the latest published version — carries the
+/// resolved version alongside the inspected kind and checksum.
+pub struct NpmLatestTarballInfo {
+  pub version: String,
   pub plugin_kind: PluginKind,
   pub tarball_sha256: String,
 }
@@ -99,27 +98,13 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
     specifier,
     start_dir,
     want_tarball_sha,
-    detect_plugin_kind,
   } = args;
   let registry = resolve_registry_for_package(&specifier.name, start_dir, environment);
-  let packument_url_str = get_packument_url(&registry.url, &specifier.name);
-  let packument_url = url::Url::parse(&packument_url_str).with_context(|| format!("Failed to parse npm packument URL: {}", packument_url_str))?;
-  let (_, packument_file) = environment
-    .download_file_err_404(&packument_url, registry.auth_header.as_deref())
-    .await
-    .with_context(|| format!("Failed to fetch npm packument for {}", specifier.name))?;
-  let packument: serde_json::Value =
-    serde_json::from_slice(&packument_file.content).with_context(|| format!("Failed to parse npm packument for {}", specifier.name))?;
+  let (packument, packument_url) = fetch_packument(&specifier.name, &registry, environment).await?;
+  let latest_version = latest_version_from_packument(&packument, &specifier.name)?;
 
-  let latest_version = packument
-    .get("dist-tags")
-    .and_then(|d| d.get("latest"))
-    .and_then(|v| v.as_str())
-    .ok_or_else(|| anyhow::anyhow!("Missing dist-tags.latest for {}", specifier.name))?
-    .to_string();
-
-  let need_tarball = want_tarball_sha || detect_plugin_kind || specifier.plugin_kind() != PluginKind::Wasm;
-  let (tarball_sha256, detected_plugin_kind) = if need_tarball {
+  let need_tarball_sha = want_tarball_sha || specifier.plugin_kind() != PluginKind::Wasm;
+  let tarball_sha256 = if need_tarball_sha {
     let tarball_url_str = get_tarball_url_from_packument(&packument, &latest_version, &specifier.name)?;
     let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
     let tarball_auth = same_origin_auth(&packument_url, &tarball_url, registry.auth_header.as_deref());
@@ -127,20 +112,30 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
       .download_file_err_404(&tarball_url, tarball_auth)
       .await
       .with_context(|| format!("Failed to download npm tarball for {}@{}", specifier.name, latest_version))?;
-    let detected = if detect_plugin_kind {
-      Some(detect_plugin_kind_from_tarball(&tarball_file.content).with_context(|| format!("Detecting plugin kind for {}@{}", specifier.name, latest_version))?)
-    } else {
-      None
-    };
-    (Some(get_sha256_checksum(&tarball_file.content)), detected)
+    Some(get_sha256_checksum(&tarball_file.content))
   } else {
-    (None, None)
+    None
   };
 
   Ok(NpmLatestInfo {
     version: latest_version,
     tarball_sha256,
-    detected_plugin_kind,
+  })
+}
+
+/// Resolves the latest version, then downloads its tarball to determine whether
+/// the package ships a `plugin.wasm` or `plugin.json` and to compute the
+/// checksum. Used by `dprint add` when the user gave an unversioned npm
+/// specifier without a plugin path.
+pub async fn fetch_npm_latest_tarball_info(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmLatestTarballInfo> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
+  let version = latest_version_from_packument(&packument, name)?;
+  let info = inspect_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
+  Ok(NpmLatestTarballInfo {
+    version,
+    plugin_kind: info.plugin_kind,
+    tarball_sha256: info.tarball_sha256,
   })
 }
 
@@ -150,12 +145,8 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
 /// doesn't give a plugin path.
 pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballInfo> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
-  let tarball_bytes = download_npm_tarball_bytes(name, version, &registry, environment).await?;
-  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_bytes).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
-  Ok(NpmTarballInfo {
-    plugin_kind,
-    tarball_sha256: get_sha256_checksum(&tarball_bytes),
-  })
+  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
+  inspect_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await
 }
 
 /// Inspects whether an npm package installed in `node_modules` (walking up from
@@ -174,27 +165,53 @@ pub fn detect_npm_plugin_kind_in_node_modules(package_name: &str, start_dir: &Pa
   }
 }
 
-/// Downloads the tarball bytes for `name@version` from `registry` without
-/// verifying a checksum — the caller computes one. Fetches the packument to
-/// find the version's tarball URL, sending registry auth only when the tarball
-/// shares the registry's origin.
-async fn download_npm_tarball_bytes(name: &str, version: &str, registry: &NpmRegistryResolution, environment: &impl Environment) -> Result<Vec<u8>> {
+/// Fetches and parses a package's packument, returning it alongside the URL it
+/// was fetched from (needed for the same-origin check when downloading the
+/// tarball).
+async fn fetch_packument(name: &str, registry: &NpmRegistryResolution, environment: &impl Environment) -> Result<(serde_json::Value, url::Url)> {
   let packument_url_str = get_packument_url(&registry.url, name);
   let packument_url = url::Url::parse(&packument_url_str).with_context(|| format!("Failed to parse npm packument URL: {}", packument_url_str))?;
   let (_, packument_file) = environment
     .download_file_err_404(&packument_url, registry.auth_header.as_deref())
     .await
     .with_context(|| format!("Failed to fetch npm packument for {}", name))?;
-  let packument: serde_json::Value = serde_json::from_slice(&packument_file.content).with_context(|| format!("Failed to parse npm packument for {}", name))?;
+  let packument = serde_json::from_slice(&packument_file.content).with_context(|| format!("Failed to parse npm packument for {}", name))?;
+  Ok((packument, packument_url))
+}
 
-  let tarball_url_str = get_tarball_url_from_packument(&packument, version, name)?;
+/// Reads `dist-tags.latest` from a packument.
+fn latest_version_from_packument(packument: &serde_json::Value, name: &str) -> Result<String> {
+  packument
+    .get("dist-tags")
+    .and_then(|d| d.get("latest"))
+    .and_then(|v| v.as_str())
+    .map(|s| s.to_string())
+    .ok_or_else(|| anyhow::anyhow!("Missing dist-tags.latest for {}", name))
+}
+
+/// Downloads `name@version`'s tarball (auth sent only when it shares the
+/// registry's origin) and inspects it to determine the plugin kind and
+/// checksum.
+async fn inspect_npm_tarball(
+  name: &str,
+  version: &str,
+  packument: &serde_json::Value,
+  packument_url: &url::Url,
+  registry: &NpmRegistryResolution,
+  environment: &impl Environment,
+) -> Result<NpmTarballInfo> {
+  let tarball_url_str = get_tarball_url_from_packument(packument, version, name)?;
   let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
-  let tarball_auth = same_origin_auth(&packument_url, &tarball_url, registry.auth_header.as_deref());
+  let tarball_auth = same_origin_auth(packument_url, &tarball_url, registry.auth_header.as_deref());
   let (_, tarball_file) = environment
     .download_file_err_404(&tarball_url, tarball_auth)
     .await
     .with_context(|| format!("Failed to download npm tarball for {}@{}", name, version))?;
-  Ok(tarball_file.content)
+  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_file.content).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
+  Ok(NpmTarballInfo {
+    plugin_kind,
+    tarball_sha256: get_sha256_checksum(&tarball_file.content),
+  })
 }
 
 /// Inspects an npm tarball to determine whether it ships a top-level
@@ -1258,7 +1275,6 @@ mod tests {
         specifier: &specifier,
         start_dir: Some(std::path::Path::new("/repo")),
         want_tarball_sha: false,
-        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1333,7 +1349,6 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: false,
-        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1368,7 +1383,6 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: true,
-        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1401,7 +1415,6 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: false,
-        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1435,7 +1448,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn fetch_npm_latest_info_detects_process_plugin_kind() {
+  async fn fetch_npm_latest_tarball_info_resolves_detects_and_checksums() {
     use crate::environment::TestEnvironment;
     use crate::test_helpers::create_test_npm_tarball;
 
@@ -1449,25 +1462,10 @@ mod tests {
     let expected_checksum = get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-3.0.0.tgz", tarball_bytes);
 
-    let specifier = NpmSpecifier {
-      name: "foo".to_string(),
-      version: None,
-      path: "plugin.wasm".to_string(),
-    };
-    let info = fetch_npm_latest_info(
-      FetchNpmLatestInfo {
-        specifier: &specifier,
-        start_dir: None,
-        want_tarball_sha: false,
-        detect_plugin_kind: true,
-      },
-      &environment,
-    )
-    .await
-    .unwrap();
+    let info = fetch_npm_latest_tarball_info("foo", None, &environment).await.unwrap();
     assert_eq!(info.version, "3.0.0");
-    assert_eq!(info.detected_plugin_kind, Some(PluginKind::Process));
-    assert_eq!(info.tarball_sha256.as_deref(), Some(expected_checksum.as_str()));
+    assert_eq!(info.plugin_kind, PluginKind::Process);
+    assert_eq!(info.tarball_sha256, expected_checksum);
   }
 
   #[tokio::test]

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -61,6 +61,9 @@ pub struct NpmLatestInfo {
   /// on the request, or whenever the plugin is non-wasm (where a checksum is
   /// always required in the dprint.json specifier).
   pub tarball_sha256: Option<String>,
+  /// The plugin kind discovered by inspecting the tarball's contents.
+  /// Populated only when `detect_plugin_kind` was set on the request.
+  pub detected_plugin_kind: Option<PluginKind>,
 }
 
 /// Inputs to [`fetch_npm_latest_info`].
@@ -74,6 +77,19 @@ pub struct FetchNpmLatestInfo<'a> {
   /// pins to the new tarball rather than carrying the stale hash. Non-wasm
   /// plugins always compute the checksum regardless.
   pub want_tarball_sha: bool,
+  /// Download the tarball and inspect it to determine whether the package
+  /// ships a `plugin.wasm` or `plugin.json`, returning the result in
+  /// `detected_plugin_kind`. Used by `dprint add` when the user gave an npm
+  /// specifier without a path. Implies downloading the tarball, so the
+  /// checksum is computed too.
+  pub detect_plugin_kind: bool,
+}
+
+/// The plugin kind and tarball checksum for a specific `name@version`,
+/// discovered by downloading and inspecting the package tarball.
+pub struct NpmTarballInfo {
+  pub plugin_kind: PluginKind,
+  pub tarball_sha256: String,
 }
 
 /// Fetches the latest version of an npm-distributed plugin (and, when needed,
@@ -83,6 +99,7 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
     specifier,
     start_dir,
     want_tarball_sha,
+    detect_plugin_kind,
   } = args;
   let registry = resolve_registry_for_package(&specifier.name, start_dir, environment);
   let packument_url_str = get_packument_url(&registry.url, &specifier.name);
@@ -101,8 +118,8 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
     .ok_or_else(|| anyhow::anyhow!("Missing dist-tags.latest for {}", specifier.name))?
     .to_string();
 
-  let need_tarball_sha = want_tarball_sha || specifier.plugin_kind() != PluginKind::Wasm;
-  let tarball_sha256 = if need_tarball_sha {
+  let need_tarball = want_tarball_sha || detect_plugin_kind || specifier.plugin_kind() != PluginKind::Wasm;
+  let (tarball_sha256, detected_plugin_kind) = if need_tarball {
     let tarball_url_str = get_tarball_url_from_packument(&packument, &latest_version, &specifier.name)?;
     let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
     let tarball_auth = same_origin_auth(&packument_url, &tarball_url, registry.auth_header.as_deref());
@@ -110,15 +127,123 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
       .download_file_err_404(&tarball_url, tarball_auth)
       .await
       .with_context(|| format!("Failed to download npm tarball for {}@{}", specifier.name, latest_version))?;
-    Some(get_sha256_checksum(&tarball_file.content))
+    let detected = if detect_plugin_kind {
+      Some(detect_plugin_kind_from_tarball(&tarball_file.content).with_context(|| format!("Detecting plugin kind for {}@{}", specifier.name, latest_version))?)
+    } else {
+      None
+    };
+    (Some(get_sha256_checksum(&tarball_file.content)), detected)
   } else {
-    None
+    (None, None)
   };
 
   Ok(NpmLatestInfo {
     version: latest_version,
     tarball_sha256,
+    detected_plugin_kind,
   })
+}
+
+/// Downloads the tarball for a specific `name@version`, inspects it to
+/// determine whether the package ships a `plugin.wasm` or `plugin.json`, and
+/// computes its SHA-256. Used by `dprint add` when the user pins a version but
+/// doesn't give a plugin path.
+pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballInfo> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let tarball_bytes = download_npm_tarball_bytes(name, version, &registry, environment).await?;
+  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_bytes).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
+  Ok(NpmTarballInfo {
+    plugin_kind,
+    tarball_sha256: get_sha256_checksum(&tarball_bytes),
+  })
+}
+
+/// Inspects whether an npm package installed in `node_modules` (walking up from
+/// `start_dir`) is a wasm or process plugin, based on which plugin file sits at
+/// its root. Returns `None` if the package isn't installed or contains neither
+/// file. Lets `dprint add` write `/plugin.json` for an unversioned process
+/// plugin without hitting the registry.
+pub fn detect_npm_plugin_kind_in_node_modules(package_name: &str, start_dir: &Path, environment: &impl Environment) -> Option<PluginKind> {
+  let package_dir = find_package_in_node_modules(package_name, start_dir, environment)?;
+  if environment.path_exists(package_dir.join("plugin.wasm")) {
+    Some(PluginKind::Wasm)
+  } else if environment.path_exists(package_dir.join("plugin.json")) {
+    Some(PluginKind::Process)
+  } else {
+    None
+  }
+}
+
+/// Downloads the tarball bytes for `name@version` from `registry` without
+/// verifying a checksum — the caller computes one. Fetches the packument to
+/// find the version's tarball URL, sending registry auth only when the tarball
+/// shares the registry's origin.
+async fn download_npm_tarball_bytes(name: &str, version: &str, registry: &NpmRegistryResolution, environment: &impl Environment) -> Result<Vec<u8>> {
+  let packument_url_str = get_packument_url(&registry.url, name);
+  let packument_url = url::Url::parse(&packument_url_str).with_context(|| format!("Failed to parse npm packument URL: {}", packument_url_str))?;
+  let (_, packument_file) = environment
+    .download_file_err_404(&packument_url, registry.auth_header.as_deref())
+    .await
+    .with_context(|| format!("Failed to fetch npm packument for {}", name))?;
+  let packument: serde_json::Value = serde_json::from_slice(&packument_file.content).with_context(|| format!("Failed to parse npm packument for {}", name))?;
+
+  let tarball_url_str = get_tarball_url_from_packument(&packument, version, name)?;
+  let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
+  let tarball_auth = same_origin_auth(&packument_url, &tarball_url, registry.auth_header.as_deref());
+  let (_, tarball_file) = environment
+    .download_file_err_404(&tarball_url, tarball_auth)
+    .await
+    .with_context(|| format!("Failed to download npm tarball for {}@{}", name, version))?;
+  Ok(tarball_file.content)
+}
+
+/// Inspects an npm tarball to determine whether it ships a top-level
+/// `plugin.wasm` (wasm plugin) or `plugin.json` (process plugin), preferring
+/// wasm if (unusually) both are present. Errors if neither is found.
+fn detect_plugin_kind_from_tarball(tarball_bytes: &[u8]) -> Result<PluginKind> {
+  let decoder = GzDecoder::new(tarball_bytes);
+  let mut archive = Archive::new(decoder);
+  let mut has_wasm = false;
+  let mut has_json = false;
+
+  for entry in archive.entries().context("Failed to read npm tarball entries")? {
+    let entry = entry.context("Failed to read npm tarball entry")?;
+    let path = entry.path().context("Failed to get entry path")?;
+
+    // npm tarballs wrap every entry under a single top-level directory (usually
+    // "package/"). Skip any leading "./" then that wrapper so we compare paths
+    // relative to the package root.
+    let mut components = path.components().peekable();
+    while let Some(std::path::Component::CurDir) = components.peek() {
+      components.next();
+    }
+    if components.next().is_none() {
+      continue; // the wrapper directory entry itself
+    }
+
+    // only a plugin file sitting directly at the package root counts
+    let relative: PathBuf = components.collect();
+    let mut relative_components = relative.components();
+    let (Some(std::path::Component::Normal(file_name)), None) = (relative_components.next(), relative_components.next()) else {
+      continue;
+    };
+    let Some(file_name) = file_name.to_str() else {
+      continue;
+    };
+    if file_name.eq_ignore_ascii_case("plugin.wasm") {
+      has_wasm = true;
+    } else if file_name.eq_ignore_ascii_case("plugin.json") {
+      has_json = true;
+    }
+  }
+
+  if has_wasm {
+    Ok(PluginKind::Wasm)
+  } else if has_json {
+    Ok(PluginKind::Process)
+  } else {
+    bail!("Could not find a plugin.wasm or plugin.json at the root of the npm package. Is it a dprint plugin?");
+  }
 }
 
 /// Resolves an npm plugin from the registry (versioned specifier).
@@ -1133,6 +1258,7 @@ mod tests {
         specifier: &specifier,
         start_dir: Some(std::path::Path::new("/repo")),
         want_tarball_sha: false,
+        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1207,6 +1333,7 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: false,
+        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1241,6 +1368,7 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: true,
+        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1273,6 +1401,7 @@ mod tests {
         specifier: &specifier,
         start_dir: None,
         want_tarball_sha: false,
+        detect_plugin_kind: false,
       },
       &environment,
     )
@@ -1280,6 +1409,108 @@ mod tests {
     .unwrap();
     assert_eq!(info.version, "2.0.0");
     assert_eq!(info.tarball_sha256.as_deref(), Some(expected_checksum.as_str()));
+  }
+
+  #[test]
+  fn detect_plugin_kind_from_tarball_distinguishes_wasm_and_process() {
+    use crate::test_helpers::create_test_npm_tarball;
+
+    let wasm = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    assert_eq!(detect_plugin_kind_from_tarball(&wasm).unwrap(), PluginKind::Wasm);
+
+    let process = create_test_npm_tarball(&[("package/plugin.json", b"{}"), ("package/package.json", b"{}")]);
+    assert_eq!(detect_plugin_kind_from_tarball(&process).unwrap(), PluginKind::Process);
+
+    // wasm wins if a package unusually ships both
+    let both = create_test_npm_tarball(&[("package/plugin.json", b"{}"), ("package/plugin.wasm", b"\0asm")]);
+    assert_eq!(detect_plugin_kind_from_tarball(&both).unwrap(), PluginKind::Wasm);
+
+    // a plugin file nested below the root doesn't count
+    let nested = create_test_npm_tarball(&[("package/sub/plugin.json", b"{}")]);
+    assert!(detect_plugin_kind_from_tarball(&nested).is_err());
+
+    let neither = create_test_npm_tarball(&[("package/index.js", b"")]);
+    let err = detect_plugin_kind_from_tarball(&neither).unwrap_err().to_string();
+    assert!(err.contains("plugin.wasm or plugin.json"), "got: {err}");
+  }
+
+  #[tokio::test]
+  async fn fetch_npm_latest_info_detects_process_plugin_kind() {
+    use crate::environment::TestEnvironment;
+    use crate::test_helpers::create_test_npm_tarball;
+
+    let environment = TestEnvironment::new();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "3.0.0" },
+      "versions": { "3.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-3.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
+    let expected_checksum = get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-3.0.0.tgz", tarball_bytes);
+
+    let specifier = NpmSpecifier {
+      name: "foo".to_string(),
+      version: None,
+      path: "plugin.wasm".to_string(),
+    };
+    let info = fetch_npm_latest_info(
+      FetchNpmLatestInfo {
+        specifier: &specifier,
+        start_dir: None,
+        want_tarball_sha: false,
+        detect_plugin_kind: true,
+      },
+      &environment,
+    )
+    .await
+    .unwrap();
+    assert_eq!(info.version, "3.0.0");
+    assert_eq!(info.detected_plugin_kind, Some(PluginKind::Process));
+    assert_eq!(info.tarball_sha256.as_deref(), Some(expected_checksum.as_str()));
+  }
+
+  #[tokio::test]
+  async fn fetch_npm_versioned_tarball_info_detects_and_checksums() {
+    use crate::environment::TestEnvironment;
+    use crate::test_helpers::create_test_npm_tarball;
+
+    let environment = TestEnvironment::new();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "9.9.9" },
+      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let expected_checksum = get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
+
+    let info = fetch_npm_versioned_tarball_info("foo", "1.2.3", None, &environment).await.unwrap();
+    assert_eq!(info.plugin_kind, PluginKind::Wasm);
+    assert_eq!(info.tarball_sha256, expected_checksum);
+  }
+
+  #[test]
+  fn detect_npm_plugin_kind_in_node_modules_reads_installed_package() {
+    use crate::environment::TestEnvironment;
+    let environment = TestEnvironment::new();
+    environment.mk_dir_all("/repo/node_modules/proc").unwrap();
+    environment.mk_dir_all("/repo/node_modules/wasmy").unwrap();
+    environment.write_file("/repo/node_modules/proc/plugin.json", "{}").unwrap();
+    environment.write_file("/repo/node_modules/wasmy/plugin.wasm", "\0asm").unwrap();
+
+    assert_eq!(
+      detect_npm_plugin_kind_in_node_modules("proc", std::path::Path::new("/repo"), &environment),
+      Some(PluginKind::Process)
+    );
+    assert_eq!(
+      detect_npm_plugin_kind_in_node_modules("wasmy", std::path::Path::new("/repo"), &environment),
+      Some(PluginKind::Wasm)
+    );
+    assert_eq!(
+      detect_npm_plugin_kind_in_node_modules("missing", std::path::Path::new("/repo"), &environment),
+      None
+    );
   }
 
   #[test]

--- a/crates/dprint/src/utils/npm_specifier.rs
+++ b/crates/dprint/src/utils/npm_specifier.rs
@@ -25,6 +25,11 @@ pub struct ParsedNpmSpecifier {
   pub specifier: NpmSpecifier,
   /// The checksum of the npm tarball, if specified.
   pub checksum: Option<String>,
+  /// Whether the user wrote an explicit plugin path (e.g. `/plugin.json`).
+  /// When false, `specifier.path` is the `plugin.wasm` default — `dprint add`
+  /// uses this to know it may auto-detect the real plugin kind by inspecting
+  /// the package rather than trusting the defaulted extension.
+  pub path_was_explicit: bool,
 }
 
 impl NpmSpecifier {
@@ -75,6 +80,7 @@ pub fn parse_npm_specifier(text: &str) -> Result<ParsedNpmSpecifier> {
         path: DEFAULT_NPM_PLUGIN_FILE.to_string(),
       },
       checksum: None,
+      path_was_explicit: false,
     });
   }
 
@@ -85,6 +91,7 @@ pub fn parse_npm_specifier(text: &str) -> Result<ParsedNpmSpecifier> {
     return Ok(ParsedNpmSpecifier {
       specifier: NpmSpecifier { name, version: None, path },
       checksum,
+      path_was_explicit: true,
     });
   }
 
@@ -106,6 +113,7 @@ pub fn parse_npm_specifier(text: &str) -> Result<ParsedNpmSpecifier> {
         path: DEFAULT_NPM_PLUGIN_FILE.to_string(),
       },
       checksum: None,
+      path_was_explicit: false,
     });
   }
 
@@ -119,6 +127,7 @@ pub fn parse_npm_specifier(text: &str) -> Result<ParsedNpmSpecifier> {
         path,
       },
       checksum,
+      path_was_explicit: true,
     });
   }
 
@@ -134,6 +143,7 @@ pub fn parse_npm_specifier(text: &str) -> Result<ParsedNpmSpecifier> {
         path: DEFAULT_NPM_PLUGIN_FILE.to_string(),
       },
       checksum: Some(checksum.to_string()),
+      path_was_explicit: false,
     });
   }
 
@@ -375,6 +385,34 @@ mod tests {
     assert_eq!(result.specifier.version, None);
     assert_eq!(result.specifier.path, "plugin.json");
     assert_eq!(result.specifier.plugin_kind(), PluginKind::Process);
+  }
+
+  #[test]
+  fn parse_tracks_whether_path_was_explicit() {
+    // a defaulted path (no `/...` in the input) must be flagged so `dprint add`
+    // knows it may auto-detect the real plugin kind from the package.
+    for defaulted in [
+      "npm:@dprint/typescript",
+      "npm:@dprint/typescript@0.23.0",
+      "npm:@dprint/typescript@0.23.0@abc123",
+      "npm:dprint-plugin-foo",
+    ] {
+      assert!(
+        !parse_npm_specifier(defaulted).unwrap().path_was_explicit,
+        "expected defaulted path for {defaulted}"
+      );
+    }
+    for explicit in [
+      "npm:@dprint/prettier/plugin.json",
+      "npm:@dprint/prettier@0.23.0/plugin.json",
+      "npm:@dprint/prettier@0.23.0/plugin.json@abc123",
+      "npm:@dprint/typescript@0.23.0/plugin.wasm",
+    ] {
+      assert!(
+        parse_npm_specifier(explicit).unwrap().path_was_explicit,
+        "expected explicit path for {explicit}"
+      );
+    }
   }
 
   #[test]

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -133,7 +133,7 @@ Behaviour:
 - Omitting the version (`npm:@scope/name`) tells dprint to look up the package in `node_modules` walking up from the config file's directory. Use this when you want npm and your lockfile to be the source of truth.
 - The registry is resolved from `NPM_CONFIG_REGISTRY`, then `.npmrc` files walking up from the config, then `~/.npmrc`, then the default `https://registry.npmjs.org`. Scoped registries are supported.
 - `dprint config update` will bump versioned npm specifiers to the latest published version (and compute the new checksum for process plugins). Unversioned specifiers are managed by your package manager, so they're skipped.
-- `dprint add npm:@scope/name` resolves to the latest version and writes the pinned form, unless the package is listed in a nearby `package.json` under `devDependencies` — in which case the unversioned form is written so npm/`package-lock.json` stays the source of truth.
+- `dprint add npm:@scope/name` resolves to the latest version and writes the pinned form, unless the package is listed in a nearby `package.json` under `devDependencies` — in which case the unversioned form is written so npm/`package-lock.json` stays the source of truth. When you don't include a plugin path, dprint inspects the package to detect whether it's a Wasm or process plugin and writes the right form automatically — for a process plugin that means `npm:@scope/name@<version>/plugin.json@<sha256>`.
 
 Available npm packages include `@dprint/typescript`, `@dprint/json`, `@dprint/markdown`, `@dprint/toml`, `@dprint/dockerfile`, `@dprint/biome`, `@dprint/oxc`, `@dprint/ruff`, `@dprint/sql`, `@dprint/mago`, `@dprint/jupyter`, `@dprint/exec`, `@dprint/prettier`, and `@dprint/roslyn`.
 


### PR DESCRIPTION
## Summary

`dprint add npm:@dprint/exec` previously defaulted to the `plugin.wasm` path and wrote `npm:@dprint/exec@<version>` — which then fails to resolve, because `@dprint/exec` is a **process plugin** that ships a `plugin.json` (and process plugins require a checksum).

Now, when a user gives an `npm:` specifier **without an explicit plugin path**, `dprint add` inspects the package to detect whether it's a Wasm or process plugin and writes the correct entry. For a process plugin that means:

```
npm:@dprint/exec@<version>/plugin.json@<sha256>
```

For a Wasm plugin it stays `npm:@dprint/exec@<version>`.

## Behaviour

- **Pinned / resolve-latest adds** (no path) download the tarball, detect the kind from its contents, and write the matching form (with the mandatory checksum for process plugins). This means a versioned add like `dprint add npm:foo@1.2.3` now hits the registry instead of passing through verbatim.
- **Unversioned adds** that don't pin a version read the kind from `node_modules` if the package is installed; `--package-json` detects from the tarball it already fetches for the caret range (since the package usually isn't installed yet).
- **Explicit-path specifiers** (e.g. `npm:foo/plugin.json`) keep their existing behaviour.

## Implementation

- `ParsedNpmSpecifier` gains `path_was_explicit` so the add command knows when it may auto-detect rather than trust the defaulted extension.
- `npm_resolution.rs`: new `detect_plugin_kind_from_tarball`, `fetch_npm_versioned_tarball_info`, and `detect_npm_plugin_kind_in_node_modules`; `fetch_npm_latest_info` gains an opt-in `detect_plugin_kind`.
- `resolve_npm_plugin_to_add` rewritten to branch on explicit vs. detected path.
- Docs updated in `website/src/config.md`.

## Tests

Added unit + integration coverage for tarball inspection (wasm/process/both/nested/neither), versioned & unversioned autodetection, `--package-json` tarball detection, and node_modules detection. Full `dprint` bin suite passes (634 tests); clippy clean.