### PR TITLE
feat(npm): add `--checksum` flag to `dprint add`

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -209,6 +209,10 @@ pub enum ConfigSubCommand {
     /// resolved latest version (as a caret range). Implies `no_version`,
     /// since pinning in dprint.json would just duplicate the version.
     package_json: bool,
+    /// Force a checksum onto the written plugin entry, even for Wasm plugins
+    /// (which are otherwise added without one). Conflicts with `no_version` /
+    /// `package_json`, since an unversioned entry can't carry a checksum.
+    checksum: bool,
   },
   Edit,
 }
@@ -287,10 +291,12 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
     // --package-json implies --no-version: writing a pinned spec to
     // dprint.json on top of a devDependencies entry would be duplication.
     let no_version = package_json || matches.get_flag("no-version");
+    let checksum = matches.get_flag("checksum");
     ConfigSubCommand::Add {
       names,
       no_version,
       package_json,
+      checksum,
     }
   }
 
@@ -580,6 +586,14 @@ pub fn create_cli_parser(kind: CliArgParserKind) -> clap::Command {
           .help("Like --no-version, and also add the package to the nearest package.json's devDependencies as a caret range.")
           .num_args(0)
           .required(false),
+      )
+      .arg(
+        Arg::new("checksum")
+          .long("checksum")
+          .help("Add a checksum to the plugin entry, even for Wasm plugins (which are otherwise added without one).")
+          .num_args(0)
+          .required(false)
+          .conflicts_with_all(["no-version", "package-json"]),
       )
   }
 
@@ -1201,10 +1215,12 @@ mod test {
         names,
         no_version,
         package_json,
+        checksum,
       }) => {
         assert!(names.is_empty());
         assert!(!no_version);
         assert!(!package_json);
+        assert!(!checksum);
       }
       _ => unreachable!(),
     }
@@ -1234,13 +1250,33 @@ mod test {
         names,
         no_version,
         package_json,
+        checksum,
       }) => {
         assert_eq!(names, &["npm:@dprint/typescript"]);
         assert!(*no_version);
         assert!(!*package_json);
+        assert!(!*checksum);
       }
       _ => unreachable!(),
     }
+  }
+
+  #[test]
+  fn add_checksum_flag() {
+    let args = test_args(vec!["add", "--checksum", "npm:@dprint/typescript"]).unwrap();
+    match &args.sub_command {
+      SubCommand::Config(ConfigSubCommand::Add { names, checksum, .. }) => {
+        assert_eq!(names, &["npm:@dprint/typescript"]);
+        assert!(*checksum);
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  #[test]
+  fn add_checksum_conflicts_with_no_version_and_package_json() {
+    assert!(test_args(vec!["add", "--checksum", "--no-version", "npm:@dprint/typescript"]).is_err());
+    assert!(test_args(vec!["add", "--checksum", "--package-json", "npm:@dprint/typescript"]).is_err());
   }
 
   #[test]

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -3161,6 +3161,68 @@ mod test {
   }
 
   #[tokio::test]
+  async fn npm_add_explicit_path_in_multi_plugin_package_uses_path_kind() {
+    // a package shipping several plugins: an explicit path picks its own file
+    // and derives the kind from the extension, ignoring a sibling plugin.json.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.0.0" },
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/plugins/-/plugins-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/plugins", packument.to_string().into_bytes());
+    // the package ships a wasm plugin AND a (sibling) plugin.json
+    let tarball_bytes = create_test_npm_tarball(&[
+      ("package/typescript.wasm", crate::test_helpers::WASM_PLUGIN_BYTES),
+      ("package/plugin.json", b"{}"),
+    ]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/plugins/-/plugins-1.0.0.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add_checksum("npm:plugins@1.0.0/typescript.wasm", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:plugins@1.0.0/typescript.wasm@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_explicit_process_path_after_wasm_add_derives_kind_from_path() {
+    // regression: a second add of a *different* plugin file in the same package
+    // hits the cached tarball checksum but must derive the kind from its own
+    // path — not the kind cached for the first plugin. Here the first (wasm) add
+    // seeds the sidecar; the second names the process plugin and must still get
+    // a checksum (process plugins require one).
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.0.0" },
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/plugins/-/plugins-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/plugins", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[
+      ("package/typescript.wasm", crate::test_helpers::WASM_PLUGIN_BYTES),
+      ("package/config.json", b"{}"),
+    ]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/plugins/-/plugins-1.0.0.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+
+    // first add (wasm, --checksum) sets the wasm plugin up and writes the sidecar
+    call_resolve_npm_plugin_to_add_checksum("npm:plugins/typescript.wasm", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+
+    // second add (process, no --checksum) reuses the cached checksum but derives
+    // Process from `config.json`, so a checksum is still written.
+    let result = call_resolve_npm_plugin_to_add("npm:plugins/config.json", &config_path, false, false, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:plugins@1.0.0/config.json@{}", expected));
+  }
+
+  #[tokio::test]
   async fn npm_add_checksum_pins_instead_of_deferring_to_devdep() {
     // `--checksum` requires a pinned version, so it overrides the usual
     // deferral to an unversioned spec when the package is in package.json.

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -28,7 +28,9 @@ use crate::plugins::PluginSourceReference;
 use crate::plugins::PluginWrapper;
 use crate::plugins::detect_npm_plugin_kind_in_node_modules;
 use crate::plugins::fetch_npm_latest_info;
+use crate::plugins::fetch_npm_latest_tarball_download;
 use crate::plugins::fetch_npm_latest_tarball_info;
+use crate::plugins::fetch_npm_versioned_tarball_download;
 use crate::plugins::fetch_npm_versioned_tarball_info;
 use crate::plugins::read_info_file;
 use crate::plugins::read_update_url;
@@ -184,16 +186,16 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
       &possible_plugins.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
     )?;
     let selected = possible_plugins.remove(index);
-    let url = if checksum {
+    let (url, prefetched) = if checksum {
       ensure_url_checksum(selected.full_url(), environment).await?
     } else {
-      selected.full_url_no_wasm_checksum()
+      (selected.full_url_no_wasm_checksum(), None)
     };
-    vec![url]
+    vec![(url, prefetched)]
   } else {
     let mut urls = Vec::with_capacity(plugin_names_or_urls.len());
     for plugin_name_or_url in plugin_names_or_urls {
-      if let Some(url) = resolve_plugin_url_to_add(
+      if let Some(resolved) = resolve_plugin_url_to_add(
         ResolvePluginUrlOptions {
           plugin_name_or_url,
           config_path: &config_path,
@@ -209,21 +211,53 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
       )
       .await?
       {
-        urls.push(url);
+        urls.push(resolved);
       }
     }
     urls
   };
 
+  let urls_only = plugin_urls_to_add.iter().map(|(url, _)| url.clone()).collect::<Vec<_>>();
   let file_text = environment.read_file(&config_path)?;
-  let file_text = add_plugins_to_config(&file_text, &npm_packages_to_replace, &plugin_urls_to_add)?;
+  let file_text = add_plugins_to_config(&file_text, &npm_packages_to_replace, &urls_only)?;
   environment.write_file(&config_path, &file_text)?;
 
   if update_package_json && !package_json_additions.is_empty() {
     apply_package_json_additions(&config_path, &package_json_additions, environment)?;
   }
 
+  // reuse anything we already downloaded while resolving (to compute a
+  // checksum) to populate the plugin cache, so the first `dprint fmt` is a
+  // cache hit instead of downloading and compiling it again. Best-effort: a
+  // failure here just means the plugin gets set up lazily on first use.
+  setup_prefetched_plugins(&config_path, plugin_urls_to_add, environment, plugin_resolver).await;
+
   Ok(())
+}
+
+/// Populates the plugin cache from the bytes captured during resolution (see
+/// the `prefetched` payloads). Failures are logged at debug and otherwise
+/// ignored — pre-caching is an optimization, not part of the add's contract.
+async fn setup_prefetched_plugins<TEnvironment: Environment>(
+  config_path: &CanonicalizedPathBuf,
+  resolved: Vec<(String, Option<Vec<u8>>)>,
+  environment: &TEnvironment,
+  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
+) {
+  let base = PathSource::new_local(config_path.clone());
+  for (url, prefetched) in resolved {
+    let Some(bytes) = prefetched else { continue };
+    let reference = match crate::plugins::parse_plugin_source_reference(&url, &base, environment) {
+      Ok(reference) => reference,
+      Err(err) => {
+        log_debug!(environment, "Skipping pre-cache of {}: {:#}", url, err);
+        continue;
+      }
+    };
+    if let Err(err) = plugin_resolver.setup_from_prefetched_download(&reference, bytes).await {
+      log_debug!(environment, "Failed to pre-cache {}: {:#}", url, err);
+    }
+  }
 }
 
 /// Inputs to [`resolve_plugin_url_to_add`]. Bundled to keep the function
@@ -248,12 +282,17 @@ struct ResolvedNpmPluginAdd {
   /// same package before appending this one.
   package_name: String,
   package_json_addition: Option<(String, String)>,
+  /// The package tarball downloaded to compute a checksum, if any — handed to
+  /// the plugin cache so the first `dprint fmt` doesn't re-download it.
+  prefetched_tarball: Option<Vec<u8>>,
 }
 
 /// Resolves a plugin name or URL to a plugin URL to add to the config.
 ///
-/// Returns `Some(url)` for new plugins, or `None` if the plugin was already
-/// present and was updated in-place. When the input is an `npm:` specifier
+/// Returns `Some((url, prefetched_bytes))` for new plugins, or `None` if the
+/// plugin was already present and was updated in-place. `prefetched_bytes` is
+/// `Some` when we downloaded the plugin (to compute a checksum) and can reuse
+/// the bytes to warm the plugin cache. When the input is an `npm:` specifier
 /// resolved with `--package-json`, the caller queues the returned
 /// devDependencies entry via `package_json_additions`.
 async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
@@ -262,7 +301,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
   npm_packages_to_replace: &mut Vec<String>,
   environment: &TEnvironment,
   plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
-) -> Result<Option<String>> {
+) -> Result<Option<(String, Option<Vec<u8>>)>> {
   let ResolvePluginUrlOptions {
     plugin_name_or_url,
     config_path,
@@ -296,7 +335,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
     // duplicate. The caller prunes these names from the config in the same
     // read/write that appends `resolved.url`.
     npm_packages_to_replace.push(resolved.package_name);
-    return Ok(Some(resolved.url));
+    return Ok(Some((resolved.url, resolved.prefetched_tarball)));
   }
   if no_version || update_package_json {
     bail!("--no-version / --package-json only apply to `npm:` specifiers (got '{}').", plugin_name_or_url);
@@ -304,8 +343,12 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
   match Url::parse(plugin_name_or_url) {
     Ok(url) => {
       let url = url.to_string();
-      let url = if checksum { ensure_url_checksum(url, environment).await? } else { url };
-      Ok(Some(url))
+      let (url, prefetched) = if checksum {
+        ensure_url_checksum(url, environment).await?
+      } else {
+        (url, None)
+      };
+      Ok(Some((url, prefetched)))
     }
     Err(_) => {
       let cached_downloader = CachedDownloader::new(environment.clone());
@@ -367,29 +410,35 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
         }
       }
       if checksum {
-        Ok(Some(ensure_url_checksum(plugin.full_url(), environment).await?))
+        let (url, prefetched) = ensure_url_checksum(plugin.full_url(), environment).await?;
+        Ok(Some((url, prefetched)))
       } else {
-        Ok(Some(plugin.full_url_no_wasm_checksum()))
+        Ok(Some((plugin.full_url_no_wasm_checksum(), None)))
       }
     }
   }
 }
 
 /// Ensures a resolved plugin URL carries a checksum, downloading the file to
-/// compute one when the registry/info didn't already supply it. Only wasm/json
-/// plugin URLs can be checksummed; any other URL is returned unchanged.
-async fn ensure_url_checksum(url: String, environment: &impl Environment) -> Result<String> {
+/// compute one when the registry/info didn't already supply it. Returns the
+/// (possibly checksummed) URL plus the downloaded bytes when a download
+/// happened, so the caller can reuse them to warm the plugin cache. Only
+/// wasm/json plugin URLs can be checksummed; any other URL is returned
+/// unchanged with no bytes.
+async fn ensure_url_checksum(url: String, environment: &impl Environment) -> Result<(String, Option<Vec<u8>>)> {
   let parsed = crate::utils::parse_checksum_path_or_url(&url);
   if parsed.checksum.is_some() {
-    return Ok(url);
+    return Ok((url, None));
   }
   let lower = parsed.path_or_url.to_lowercase();
   if !(lower.ends_with(".wasm") || lower.ends_with(".json")) {
-    return Ok(url); // not a plugin file we can checksum
+    return Ok((url, None)); // not a plugin file we can checksum
   }
   let parsed_url = Url::parse(&parsed.path_or_url)?;
   let (_, file) = environment.download_file_err_404(&parsed_url, None).await?;
-  Ok(format!("{}@{}", parsed.path_or_url, crate::utils::get_sha256_checksum(&file.content)))
+  let bytes = file.content;
+  let url = format!("{}@{}", parsed.path_or_url, crate::utils::get_sha256_checksum(&bytes));
+  Ok((url, Some(bytes)))
 }
 
 struct ResolveNpmPluginOptions<'a> {
@@ -470,26 +519,31 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
         url: text.to_string(),
         package_name: name,
         package_json_addition: None,
+        prefetched_tarball: None,
       });
     }
-    // otherwise download the tarball to detect the kind for a defaulted path
-    // and/or compute the checksum, then write the matching plugin file.
-    let info = fetch_npm_versioned_tarball_info(&name, version, Some(start_dir_ref), environment).await?;
-    let path = if explicit_path {
-      parsed.specifier.path.clone()
+    // otherwise download the tarball to compute the checksum (and, for a
+    // defaulted path, detect the plugin kind), then write the matching entry.
+    let (path, tarball_sha256, tarball_bytes) = if explicit_path {
+      // the user named the plugin file, so don't inspect the package — that
+      // would wrongly require a root plugin.wasm/plugin.json.
+      let download = fetch_npm_versioned_tarball_download(&name, version, Some(start_dir_ref), environment).await?;
+      (parsed.specifier.path.clone(), download.tarball_sha256, download.tarball_bytes)
     } else {
-      default_plugin_path(info.plugin_kind).to_string()
+      let info = fetch_npm_versioned_tarball_info(&name, version, Some(start_dir_ref), environment).await?;
+      (default_plugin_path(info.plugin_kind).to_string(), info.tarball_sha256, info.tarball_bytes)
     };
     let specifier = crate::utils::NpmSpecifier {
       name,
       version: Some(version.clone()),
       path,
     };
-    let url = npm_add_url(&specifier, &info.tarball_sha256, checksum);
+    let url = npm_add_url(&specifier, &tarball_sha256, checksum);
     return Ok(ResolvedNpmPluginAdd {
       url,
       package_name: specifier.name,
       package_json_addition: None,
+      prefetched_tarball: Some(tarball_bytes),
     });
   }
 
@@ -531,6 +585,9 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
       url: unversioned_npm_add_url(&parsed, explicit_path, detected_kind, start_dir_ref, environment),
       package_name: name,
       package_json_addition,
+      // unversioned specifiers resolve from node_modules, so there's nothing to
+      // pre-cache (any tarball we fetched above was only for the caret range).
+      prefetched_tarball: None,
     });
   }
 
@@ -542,35 +599,47 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
       url: unversioned_npm_add_url(&parsed, explicit_path, None, start_dir_ref, environment),
       package_name: name,
       package_json_addition: None,
+      prefetched_tarball: None,
     });
   }
 
   if explicit_path {
     // the user named the plugin file; pin the latest version and add a checksum
-    // for non-wasm plugins (and for wasm too when `--checksum` was passed).
-    let info = fetch_npm_latest_info(
-      FetchNpmLatestInfo {
-        specifier: &parsed.specifier,
-        start_dir: Some(start_dir_ref),
-        want_tarball_sha: checksum,
-      },
-      environment,
-    )
-    .await?;
+    // for non-wasm plugins (and for wasm too when `--checksum` was passed). Only
+    // download the tarball when a checksum is actually needed — a wasm explicit
+    // path without `--checksum` just needs the version.
+    let needs_tarball = checksum || parsed.specifier.plugin_kind() == PluginKind::Process;
+    let (version, sha_and_bytes) = if needs_tarball {
+      // explicit path → don't inspect the package for a kind, just download.
+      let download = fetch_npm_latest_tarball_download(&name, Some(start_dir_ref), environment).await?;
+      (download.version, Some((download.tarball_sha256, download.tarball_bytes)))
+    } else {
+      let info = fetch_npm_latest_info(
+        FetchNpmLatestInfo {
+          specifier: &parsed.specifier,
+          start_dir: Some(start_dir_ref),
+          want_tarball_sha: false,
+        },
+        environment,
+      )
+      .await?;
+      (info.version, None)
+    };
     let pinned = crate::utils::NpmSpecifier {
       name,
-      version: Some(info.version),
+      version: Some(version),
       path: parsed.specifier.path,
     };
     let display = pinned.display();
-    let url = match info.tarball_sha256 {
-      Some(tarball_sha256) => format!("{}@{}", display, tarball_sha256),
-      None => display,
+    let (url, prefetched_tarball) = match sha_and_bytes {
+      Some((sha, bytes)) => (format!("{}@{}", display, sha), Some(bytes)),
+      None => (display, None),
     };
     return Ok(ResolvedNpmPluginAdd {
       url,
       package_name: pinned.name,
       package_json_addition: None,
+      prefetched_tarball,
     });
   }
 
@@ -587,6 +656,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     url,
     package_name: specifier.name,
     package_json_addition: None,
+    prefetched_tarball: Some(info.tarball_bytes),
   })
 }
 
@@ -3135,6 +3205,30 @@ mod test {
   }
 
   #[tokio::test]
+  async fn npm_add_checksum_explicit_non_root_path_does_not_inspect_package() {
+    // an explicit plugin path that isn't at the tarball root must not trigger
+    // kind detection (which only looks for a root plugin.wasm/plugin.json and
+    // would bail). We just download to compute the checksum.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.0.0" },
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    // tarball ships the plugin in a subdirectory, with no root plugin file
+    let tarball_bytes = create_test_npm_tarball(&[("package/sub/foo.wasm", b"\0asm")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add_checksum("npm:foo@1.0.0/sub/foo.wasm", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@1.0.0/sub/foo.wasm@{}", expected));
+  }
+
+  #[tokio::test]
   async fn npm_add_checksum_pins_instead_of_deferring_to_devdep() {
     // `--checksum` requires a pinned version, so it overrides the usual
     // deferral to an unversioned spec when the package is in package.json.
@@ -3162,26 +3256,30 @@ mod test {
     let environment = TestEnvironment::new();
     let bytes = vec![1u8, 2, 3, 4];
     let expected = crate::utils::get_sha256_checksum(&bytes);
-    environment.add_remote_file_bytes("https://example.com/plugin.wasm", bytes);
-    let result = super::ensure_url_checksum("https://example.com/plugin.wasm".to_string(), &environment)
+    environment.add_remote_file_bytes("https://example.com/plugin.wasm", bytes.clone());
+    let (url, prefetched) = super::ensure_url_checksum("https://example.com/plugin.wasm".to_string(), &environment)
       .await
       .unwrap();
-    assert_eq!(result, format!("https://example.com/plugin.wasm@{}", expected));
+    assert_eq!(url, format!("https://example.com/plugin.wasm@{}", expected));
+    // the downloaded bytes are returned so the caller can warm the cache
+    assert_eq!(prefetched, Some(bytes));
   }
 
   #[tokio::test]
   async fn ensure_url_checksum_preserves_existing_and_ignores_non_plugin_urls() {
     let environment = TestEnvironment::new();
     // already has a checksum → returned unchanged, no download attempted
-    let result = super::ensure_url_checksum("https://example.com/plugin.wasm@abc123".to_string(), &environment)
+    let (url, prefetched) = super::ensure_url_checksum("https://example.com/plugin.wasm@abc123".to_string(), &environment)
       .await
       .unwrap();
-    assert_eq!(result, "https://example.com/plugin.wasm@abc123");
+    assert_eq!(url, "https://example.com/plugin.wasm@abc123");
+    assert_eq!(prefetched, None);
     // not a plugin file → returned unchanged
-    let result = super::ensure_url_checksum("https://example.com/readme.txt".to_string(), &environment)
+    let (url, prefetched) = super::ensure_url_checksum("https://example.com/readme.txt".to_string(), &environment)
       .await
       .unwrap();
-    assert_eq!(result, "https://example.com/readme.txt");
+    assert_eq!(url, "https://example.com/readme.txt");
+    assert_eq!(prefetched, None);
   }
 
   #[tokio::test]

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -543,7 +543,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
       url,
       package_name: specifier.name,
       package_json_addition: None,
-      prefetched_tarball: Some(tarball_bytes),
+      prefetched_tarball: tarball_bytes,
     });
   }
 
@@ -632,7 +632,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     };
     let display = pinned.display();
     let (url, prefetched_tarball) = match sha_and_bytes {
-      Some((sha, bytes)) => (format!("{}@{}", display, sha), Some(bytes)),
+      Some((sha, bytes)) => (format!("{}@{}", display, sha), bytes),
       None => (display, None),
     };
     return Ok(ResolvedNpmPluginAdd {
@@ -656,7 +656,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     url,
     package_name: specifier.name,
     package_json_addition: None,
-    prefetched_tarball: Some(info.tarball_bytes),
+    prefetched_tarball: info.tarball_bytes,
   })
 }
 

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -137,6 +137,10 @@ pub struct AddPluginsOptions<'a> {
   /// `npm:` package to the nearest `package.json`'s `devDependencies`
   /// (as a caret range). Implies `no_version`.
   pub update_package_json: bool,
+  /// Force a checksum onto each written entry, even for Wasm plugins (which
+  /// are otherwise added without one). Mutually exclusive with `no_version` /
+  /// `update_package_json`.
+  pub checksum: bool,
 }
 
 pub async fn add_plugin_config_file<TEnvironment: Environment>(
@@ -149,6 +153,7 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
     plugin_names_or_urls,
     no_version,
     update_package_json,
+    checksum,
   } = options;
   let config = resolve_config_from_args(args, environment).await?;
   let config_path = match config.source {
@@ -178,7 +183,13 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
       0,
       &possible_plugins.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
     )?;
-    vec![possible_plugins.remove(index).full_url_no_wasm_checksum()]
+    let selected = possible_plugins.remove(index);
+    let url = if checksum {
+      ensure_url_checksum(selected.full_url(), environment).await?
+    } else {
+      selected.full_url_no_wasm_checksum()
+    };
+    vec![url]
   } else {
     let mut urls = Vec::with_capacity(plugin_names_or_urls.len());
     for plugin_name_or_url in plugin_names_or_urls {
@@ -189,6 +200,7 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
           config_plugins: &config.plugins,
           no_version,
           update_package_json,
+          checksum,
         },
         &mut package_json_additions,
         &mut npm_packages_to_replace,
@@ -223,6 +235,7 @@ struct ResolvePluginUrlOptions<'a> {
   config_plugins: &'a [PluginSourceReference],
   no_version: bool,
   update_package_json: bool,
+  checksum: bool,
 }
 
 /// What `resolve_npm_plugin_to_add` decided to write into the config plus
@@ -256,6 +269,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
     config_plugins,
     no_version,
     update_package_json,
+    checksum,
   } = options;
   // intercept npm: specifiers before URL parsing. For unversioned forms,
   // defer to package.json devDependencies if present (so npm/node_modules
@@ -269,6 +283,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
         config_path,
         no_version,
         update_package_json,
+        checksum,
       },
       environment,
     )
@@ -287,7 +302,11 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
     bail!("--no-version / --package-json only apply to `npm:` specifiers (got '{}').", plugin_name_or_url);
   }
   match Url::parse(plugin_name_or_url) {
-    Ok(url) => Ok(Some(url.to_string())),
+    Ok(url) => {
+      let url = url.to_string();
+      let url = if checksum { ensure_url_checksum(url, environment).await? } else { url };
+      Ok(Some(url))
+    }
     Err(_) => {
       let cached_downloader = CachedDownloader::new(environment.clone());
       let plugin_name = if plugin_name_or_url.contains('/') {
@@ -347,9 +366,30 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
           }
         }
       }
-      Ok(Some(plugin.full_url_no_wasm_checksum()))
+      if checksum {
+        Ok(Some(ensure_url_checksum(plugin.full_url(), environment).await?))
+      } else {
+        Ok(Some(plugin.full_url_no_wasm_checksum()))
+      }
     }
   }
+}
+
+/// Ensures a resolved plugin URL carries a checksum, downloading the file to
+/// compute one when the registry/info didn't already supply it. Only wasm/json
+/// plugin URLs can be checksummed; any other URL is returned unchanged.
+async fn ensure_url_checksum(url: String, environment: &impl Environment) -> Result<String> {
+  let parsed = crate::utils::parse_checksum_path_or_url(&url);
+  if parsed.checksum.is_some() {
+    return Ok(url);
+  }
+  let lower = parsed.path_or_url.to_lowercase();
+  if !(lower.ends_with(".wasm") || lower.ends_with(".json")) {
+    return Ok(url); // not a plugin file we can checksum
+  }
+  let parsed_url = Url::parse(&parsed.path_or_url)?;
+  let (_, file) = environment.download_file_err_404(&parsed_url, None).await?;
+  Ok(format!("{}@{}", parsed.path_or_url, crate::utils::get_sha256_checksum(&file.content)))
 }
 
 struct ResolveNpmPluginOptions<'a> {
@@ -357,6 +397,9 @@ struct ResolveNpmPluginOptions<'a> {
   config_path: &'a CanonicalizedPathBuf,
   no_version: bool,
   update_package_json: bool,
+  /// Force a checksum onto the written entry even for Wasm plugins. Process
+  /// plugins always carry one regardless.
+  checksum: bool,
 }
 
 /// Resolves an `npm:` specifier from `dprint add` into the string to write
@@ -368,7 +411,13 @@ struct ResolveNpmPluginOptions<'a> {
 /// (`plugin.json`) plugin and writes the matching form — for the pinned forms
 /// it downloads the tarball; for the unversioned forms it reads `node_modules`.
 ///
-/// - `npm:foo@1.2.3/plugin.json[@sha]` (explicit path) → pass through verbatim.
+/// With `--checksum` (mutually exclusive with `--no-version` / `--package-json`)
+/// a checksum is forced onto the written entry even for Wasm plugins, and an
+/// otherwise-deferred unversioned add is pinned instead (since a checksum
+/// requires a version).
+///
+/// - `npm:foo@1.2.3/plugin.json[@sha]` (explicit path) → pass through verbatim
+///   (unless `--checksum` and it has none, in which case one is computed).
 /// - `npm:foo@1.2.3` (versioned, no path) → download that version's tarball to
 ///   detect the kind and pin the matching form (with checksum for process).
 /// - `npm:foo` with `--no-version` or `--package-json` → keep unversioned. With
@@ -388,6 +437,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     config_path,
     no_version,
     update_package_json,
+    checksum,
   } = options;
   let parsed = crate::utils::parse_npm_specifier(text)?;
   // when the user wrote an explicit plugin path, enforce the same .wasm/.json
@@ -412,21 +462,33 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     if no_version {
       bail!("--no-version cannot be combined with a versioned specifier: {}", text);
     }
-    if explicit_path {
-      // the user fully specified name, version, and plugin file — pass through.
+    // pass the user's spec through verbatim when there's nothing to add: it
+    // already carries a checksum, or it names a plugin file and we aren't
+    // forcing one.
+    if parsed.checksum.is_some() || (explicit_path && !checksum) {
       return Ok(ResolvedNpmPluginAdd {
         url: text.to_string(),
         package_name: name,
         package_json_addition: None,
       });
     }
-    // no path given: inspect the package to learn whether it's a wasm or
-    // process plugin, then write the matching plugin file (with a checksum for
-    // process plugins).
+    // otherwise download the tarball to detect the kind for a defaulted path
+    // and/or compute the checksum, then write the matching plugin file.
     let info = fetch_npm_versioned_tarball_info(&name, version, Some(start_dir_ref), environment).await?;
+    let path = if explicit_path {
+      parsed.specifier.path.clone()
+    } else {
+      default_plugin_path(info.plugin_kind).to_string()
+    };
+    let specifier = crate::utils::NpmSpecifier {
+      name,
+      version: Some(version.clone()),
+      path,
+    };
+    let url = npm_add_url(&specifier, &info.tarball_sha256, checksum);
     return Ok(ResolvedNpmPluginAdd {
-      url: build_npm_add_url(&name, Some(version), info.plugin_kind, &info.tarball_sha256),
-      package_name: name,
+      url,
+      package_name: specifier.name,
       package_json_addition: None,
     });
   }
@@ -472,7 +534,9 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     });
   }
 
-  if is_in_package_json_deps(&name, start_dir_ref, environment) {
+  // `--checksum` forces a pinned, checksummed entry, so don't defer to the
+  // unversioned node_modules form when it's set.
+  if !checksum && is_in_package_json_deps(&name, start_dir_ref, environment) {
     log_stderr_info!(environment, "Found {} in package.json — adding unversioned npm specifier.", name);
     return Ok(ResolvedNpmPluginAdd {
       url: unversioned_npm_add_url(&parsed, explicit_path, None, start_dir_ref, environment),
@@ -483,12 +547,12 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
 
   if explicit_path {
     // the user named the plugin file; pin the latest version and add a checksum
-    // for non-wasm plugins (fetch_npm_latest_info computes it when needed).
+    // for non-wasm plugins (and for wasm too when `--checksum` was passed).
     let info = fetch_npm_latest_info(
       FetchNpmLatestInfo {
         specifier: &parsed.specifier,
         start_dir: Some(start_dir_ref),
-        want_tarball_sha: false,
+        want_tarball_sha: checksum,
       },
       environment,
     )
@@ -500,7 +564,7 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     };
     let display = pinned.display();
     let url = match info.tarball_sha256 {
-      Some(checksum) => format!("{}@{}", display, checksum),
+      Some(tarball_sha256) => format!("{}@{}", display, tarball_sha256),
       None => display,
     };
     return Ok(ResolvedNpmPluginAdd {
@@ -511,33 +575,38 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
   }
 
   // no path given: resolve the latest version and inspect its tarball to learn
-  // the plugin kind (and checksum, required for process plugins).
+  // the plugin kind (and checksum, required for process plugins / `--checksum`).
   let info = fetch_npm_latest_tarball_info(&name, Some(start_dir_ref), environment).await?;
+  let specifier = crate::utils::NpmSpecifier {
+    name,
+    version: Some(info.version),
+    path: default_plugin_path(info.plugin_kind).to_string(),
+  };
+  let url = npm_add_url(&specifier, &info.tarball_sha256, checksum);
   Ok(ResolvedNpmPluginAdd {
-    url: build_npm_add_url(&name, Some(&info.version), info.plugin_kind, &info.tarball_sha256),
-    package_name: name,
+    url,
+    package_name: specifier.name,
     package_json_addition: None,
   })
 }
 
-/// Builds the plugins-array entry for an npm plugin whose kind was detected by
-/// inspecting the package: `npm:name[@version]` for wasm plugins, and
-/// `npm:name[@version]/plugin.json@<sha256>` for process plugins (which always
-/// require a checksum).
-fn build_npm_add_url(name: &str, version: Option<&str>, kind: PluginKind, tarball_sha256: &str) -> String {
-  let path = match kind {
+/// The default file name within an npm package for each plugin kind.
+fn default_plugin_path(kind: PluginKind) -> &'static str {
+  match kind {
     PluginKind::Wasm => "plugin.wasm",
     PluginKind::Process => "plugin.json",
-  };
-  let specifier = crate::utils::NpmSpecifier {
-    name: name.to_string(),
-    version: version.map(|v| v.to_string()),
-    path: path.to_string(),
-  };
+  }
+}
+
+/// Joins a resolved npm specifier with its tarball checksum when one should be
+/// written: process plugins always require it; wasm plugins only when the user
+/// passed `--checksum` (`force_checksum`).
+fn npm_add_url(specifier: &crate::utils::NpmSpecifier, tarball_sha256: &str, force_checksum: bool) -> String {
   let display = specifier.display();
-  match kind {
-    PluginKind::Wasm => display,
-    PluginKind::Process => format!("{}@{}", display, tarball_sha256),
+  if force_checksum || specifier.plugin_kind() == PluginKind::Process {
+    format!("{}@{}", display, tarball_sha256)
+  } else {
+    display
   }
 }
 
@@ -1732,6 +1801,24 @@ mod test {
       new_wasm_url, new_ps_url,
     );
     assert_eq!(environment.read_file("./dprint.json").unwrap(), expected_text);
+  }
+
+  #[test]
+  fn config_add_checksum_named_wasm_plugin() {
+    // `--checksum` makes a named wasm add carry the registry's checksum,
+    // which is otherwise omitted for wasm plugins.
+    let environment = get_setup_env(SetupEnvOptions {
+      config_has_wasm: false,
+      config_has_wasm_checksum: false,
+      config_has_process: false,
+      remote_has_wasm_checksum: true,
+      remote_has_process_checksum: false,
+    });
+    run_test_cli(vec!["config", "add", "--checksum", "test-plugin"], &environment).unwrap();
+    let expected = format!("https://plugins.dprint.dev/test-plugin.wasm@{}", get_test_wasm_plugin_checksum());
+    let dprint_json = environment.read_file("./dprint.json").unwrap();
+    assert!(dprint_json.contains(&expected), "got: {dprint_json}");
+    let _ = environment.take_stderr_messages();
   }
 
   #[test]
@@ -2941,12 +3028,25 @@ mod test {
     update_package_json: bool,
     environment: &TestEnvironment,
   ) -> Result<super::ResolvedNpmPluginAdd> {
+    call_resolve_npm_plugin_to_add_checksum(text, config_path, no_version, update_package_json, false, environment).await
+  }
+
+  /// Like [`call_resolve_npm_plugin_to_add`] but lets a test set `--checksum`.
+  async fn call_resolve_npm_plugin_to_add_checksum(
+    text: &str,
+    config_path: &CanonicalizedPathBuf,
+    no_version: bool,
+    update_package_json: bool,
+    checksum: bool,
+    environment: &TestEnvironment,
+  ) -> Result<super::ResolvedNpmPluginAdd> {
     super::resolve_npm_plugin_to_add(
       super::ResolveNpmPluginOptions {
         text,
         config_path,
         no_version,
         update_package_json,
+        checksum,
       },
       environment,
     )
@@ -2989,6 +3089,99 @@ mod test {
       .unwrap();
     assert_eq!(result.url, "npm:@dprint/typescript@0.95.15/plugin.wasm");
     assert!(result.package_json_addition.is_none());
+  }
+
+  #[tokio::test]
+  async fn npm_add_checksum_forces_wasm_checksum_for_unversioned() {
+    // `--checksum` makes an otherwise checksum-free wasm add carry one.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.2.3" },
+      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add_checksum("npm:foo", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@1.2.3@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_checksum_forces_wasm_checksum_for_versioned() {
+    // a pinned wasm add that would otherwise pass through verbatim gets a
+    // checksum appended.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "9.9.9" },
+      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add_checksum("npm:foo@1.2.3", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@1.2.3@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn npm_add_checksum_pins_instead_of_deferring_to_devdep() {
+    // `--checksum` requires a pinned version, so it overrides the usual
+    // deferral to an unversioned spec when the package is in package.json.
+    use crate::test_helpers::create_test_npm_tarball;
+    let environment = TestEnvironment::new();
+    environment.write_file("/dprint.json", "{}").unwrap();
+    environment.write_file("/package.json", r#"{"devDependencies": {"foo": "^1.0.0"}}"#).unwrap();
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.2.3" },
+      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
+    let config_path = environment.canonicalize("/dprint.json").unwrap();
+    let result = call_resolve_npm_plugin_to_add_checksum("npm:foo", &config_path, false, false, true, &environment)
+      .await
+      .unwrap();
+    assert_eq!(result.url, format!("npm:foo@1.2.3@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn ensure_url_checksum_appends_for_plugin_url_without_one() {
+    let environment = TestEnvironment::new();
+    let bytes = vec![1u8, 2, 3, 4];
+    let expected = crate::utils::get_sha256_checksum(&bytes);
+    environment.add_remote_file_bytes("https://example.com/plugin.wasm", bytes);
+    let result = super::ensure_url_checksum("https://example.com/plugin.wasm".to_string(), &environment)
+      .await
+      .unwrap();
+    assert_eq!(result, format!("https://example.com/plugin.wasm@{}", expected));
+  }
+
+  #[tokio::test]
+  async fn ensure_url_checksum_preserves_existing_and_ignores_non_plugin_urls() {
+    let environment = TestEnvironment::new();
+    // already has a checksum → returned unchanged, no download attempted
+    let result = super::ensure_url_checksum("https://example.com/plugin.wasm@abc123".to_string(), &environment)
+      .await
+      .unwrap();
+    assert_eq!(result, "https://example.com/plugin.wasm@abc123");
+    // not a plugin file → returned unchanged
+    let result = super::ensure_url_checksum("https://example.com/readme.txt".to_string(), &environment)
+      .await
+      .unwrap();
+    assert_eq!(result, "https://example.com/readme.txt");
   }
 
   #[tokio::test]

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -491,7 +491,7 @@ async fn resolve_npm_plugin_to_add<TEnvironment: Environment>(
       path: resolution.path,
     };
     return Ok(ResolvedNpmPluginAdd {
-      url: npm_add_url(&pinned, &resolution.checksum, checksum),
+      url: npm_add_url(&pinned, resolution.plugin_kind, &resolution.checksum, checksum),
       package_name: name,
       package_json_addition: None,
     });
@@ -566,7 +566,7 @@ async fn resolve_npm_plugin_to_add<TEnvironment: Environment>(
     path: resolution.path,
   };
   Ok(ResolvedNpmPluginAdd {
-    url: npm_add_url(&pinned, &resolution.checksum, checksum),
+    url: npm_add_url(&pinned, resolution.plugin_kind, &resolution.checksum, checksum),
     package_name: name,
     package_json_addition: None,
   })
@@ -575,9 +575,9 @@ async fn resolve_npm_plugin_to_add<TEnvironment: Environment>(
 /// Joins a resolved npm specifier with its tarball checksum when one should be
 /// written: process plugins always require it; wasm plugins only when the user
 /// passed `--checksum` (`force_checksum`).
-fn npm_add_url(specifier: &crate::utils::NpmSpecifier, tarball_sha256: &str, force_checksum: bool) -> String {
+fn npm_add_url(specifier: &crate::utils::NpmSpecifier, plugin_kind: PluginKind, tarball_sha256: &str, force_checksum: bool) -> String {
   let display = specifier.display();
-  if force_checksum || specifier.plugin_kind() == PluginKind::Process {
+  if force_checksum || plugin_kind == PluginKind::Process {
     format!("{}@{}", display, tarball_sha256)
   } else {
     display

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -28,12 +28,9 @@ use crate::plugins::PluginSourceReference;
 use crate::plugins::PluginWrapper;
 use crate::plugins::detect_npm_plugin_kind_in_node_modules;
 use crate::plugins::fetch_npm_latest_info;
-use crate::plugins::fetch_npm_latest_tarball_download;
-use crate::plugins::fetch_npm_latest_tarball_info;
-use crate::plugins::fetch_npm_versioned_tarball_download;
-use crate::plugins::fetch_npm_versioned_tarball_info;
 use crate::plugins::read_info_file;
 use crate::plugins::read_update_url;
+use crate::plugins::resolve_npm_latest_version;
 use crate::resolution::GetPluginResult;
 use crate::resolution::ResolvePluginsScopeAndPathsOptions;
 use crate::resolution::resolve_plugins_scope;
@@ -140,8 +137,7 @@ pub struct AddPluginsOptions<'a> {
   /// (as a caret range). Implies `no_version`.
   pub update_package_json: bool,
   /// Force a checksum onto each written entry, even for Wasm plugins (which
-  /// are otherwise added without one). Mutually exclusive with `no_version` /
-  /// `update_package_json`.
+  /// are otherwise added without one).
   pub checksum: bool,
 }
 
@@ -186,12 +182,12 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
       &possible_plugins.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
     )?;
     let selected = possible_plugins.remove(index);
-    let (url, prefetched) = if checksum {
-      ensure_url_checksum(selected.full_url(), environment).await?
+    let url = if checksum {
+      ensure_url_checksum(selected.full_url(), plugin_resolver).await?
     } else {
-      (selected.full_url_no_wasm_checksum(), None)
+      selected.full_url_no_wasm_checksum()
     };
-    vec![(url, prefetched)]
+    vec![url]
   } else {
     let mut urls = Vec::with_capacity(plugin_names_or_urls.len());
     for plugin_name_or_url in plugin_names_or_urls {
@@ -217,47 +213,15 @@ pub async fn add_plugin_config_file<TEnvironment: Environment>(
     urls
   };
 
-  let urls_only = plugin_urls_to_add.iter().map(|(url, _)| url.clone()).collect::<Vec<_>>();
   let file_text = environment.read_file(&config_path)?;
-  let file_text = add_plugins_to_config(&file_text, &npm_packages_to_replace, &urls_only)?;
+  let file_text = add_plugins_to_config(&file_text, &npm_packages_to_replace, &plugin_urls_to_add)?;
   environment.write_file(&config_path, &file_text)?;
 
   if update_package_json && !package_json_additions.is_empty() {
     apply_package_json_additions(&config_path, &package_json_additions, environment)?;
   }
 
-  // reuse anything we already downloaded while resolving (to compute a
-  // checksum) to populate the plugin cache, so the first `dprint fmt` is a
-  // cache hit instead of downloading and compiling it again. Best-effort: a
-  // failure here just means the plugin gets set up lazily on first use.
-  setup_prefetched_plugins(&config_path, plugin_urls_to_add, environment, plugin_resolver).await;
-
   Ok(())
-}
-
-/// Populates the plugin cache from the bytes captured during resolution (see
-/// the `prefetched` payloads). Failures are logged at debug and otherwise
-/// ignored — pre-caching is an optimization, not part of the add's contract.
-async fn setup_prefetched_plugins<TEnvironment: Environment>(
-  config_path: &CanonicalizedPathBuf,
-  resolved: Vec<(String, Option<Vec<u8>>)>,
-  environment: &TEnvironment,
-  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
-) {
-  let base = PathSource::new_local(config_path.clone());
-  for (url, prefetched) in resolved {
-    let Some(bytes) = prefetched else { continue };
-    let reference = match crate::plugins::parse_plugin_source_reference(&url, &base, environment) {
-      Ok(reference) => reference,
-      Err(err) => {
-        log_debug!(environment, "Skipping pre-cache of {}: {:#}", url, err);
-        continue;
-      }
-    };
-    if let Err(err) = plugin_resolver.setup_from_prefetched_download(&reference, bytes).await {
-      log_debug!(environment, "Failed to pre-cache {}: {:#}", url, err);
-    }
-  }
 }
 
 /// Inputs to [`resolve_plugin_url_to_add`]. Bundled to keep the function
@@ -282,17 +246,12 @@ struct ResolvedNpmPluginAdd {
   /// same package before appending this one.
   package_name: String,
   package_json_addition: Option<(String, String)>,
-  /// The package tarball downloaded to compute a checksum, if any — handed to
-  /// the plugin cache so the first `dprint fmt` doesn't re-download it.
-  prefetched_tarball: Option<Vec<u8>>,
 }
 
 /// Resolves a plugin name or URL to a plugin URL to add to the config.
 ///
-/// Returns `Some((url, prefetched_bytes))` for new plugins, or `None` if the
-/// plugin was already present and was updated in-place. `prefetched_bytes` is
-/// `Some` when we downloaded the plugin (to compute a checksum) and can reuse
-/// the bytes to warm the plugin cache. When the input is an `npm:` specifier
+/// Returns `Some(url)` for new plugins, or `None` if the plugin was already
+/// present and was updated in-place. When the input is an `npm:` specifier
 /// resolved with `--package-json`, the caller queues the returned
 /// devDependencies entry via `package_json_additions`.
 async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
@@ -301,7 +260,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
   npm_packages_to_replace: &mut Vec<String>,
   environment: &TEnvironment,
   plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
-) -> Result<Option<(String, Option<Vec<u8>>)>> {
+) -> Result<Option<String>> {
   let ResolvePluginUrlOptions {
     plugin_name_or_url,
     config_path,
@@ -325,6 +284,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
         checksum,
       },
       environment,
+      plugin_resolver,
     )
     .await?;
     if let Some(addition) = resolved.package_json_addition {
@@ -335,7 +295,7 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
     // duplicate. The caller prunes these names from the config in the same
     // read/write that appends `resolved.url`.
     npm_packages_to_replace.push(resolved.package_name);
-    return Ok(Some((resolved.url, resolved.prefetched_tarball)));
+    return Ok(Some(resolved.url));
   }
   if no_version || update_package_json {
     bail!("--no-version / --package-json only apply to `npm:` specifiers (got '{}').", plugin_name_or_url);
@@ -343,12 +303,8 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
   match Url::parse(plugin_name_or_url) {
     Ok(url) => {
       let url = url.to_string();
-      let (url, prefetched) = if checksum {
-        ensure_url_checksum(url, environment).await?
-      } else {
-        (url, None)
-      };
-      Ok(Some((url, prefetched)))
+      let url = if checksum { ensure_url_checksum(url, plugin_resolver).await? } else { url };
+      Ok(Some(url))
     }
     Err(_) => {
       let cached_downloader = CachedDownloader::new(environment.clone());
@@ -410,35 +366,34 @@ async fn resolve_plugin_url_to_add<TEnvironment: Environment>(
         }
       }
       if checksum {
-        let (url, prefetched) = ensure_url_checksum(plugin.full_url(), environment).await?;
-        Ok(Some((url, prefetched)))
+        Ok(Some(ensure_url_checksum(plugin.full_url(), plugin_resolver).await?))
       } else {
-        Ok(Some((plugin.full_url_no_wasm_checksum(), None)))
+        Ok(Some(plugin.full_url_no_wasm_checksum()))
       }
     }
   }
 }
 
-/// Ensures a resolved plugin URL carries a checksum, downloading the file to
-/// compute one when the registry/info didn't already supply it. Returns the
-/// (possibly checksummed) URL plus the downloaded bytes when a download
-/// happened, so the caller can reuse them to warm the plugin cache. Only
-/// wasm/json plugin URLs can be checksummed; any other URL is returned
-/// unchanged with no bytes.
-async fn ensure_url_checksum(url: String, environment: &impl Environment) -> Result<(String, Option<Vec<u8>>)> {
+/// Ensures a resolved plugin URL carries a checksum. When one isn't already
+/// present, the plugin is downloaded and set up via the resolver (warming the
+/// cache so the first `dprint fmt` is a hit) and the computed checksum is
+/// appended. Only wasm/json plugin URLs can be checksummed; any other URL is
+/// returned unchanged.
+async fn ensure_url_checksum<TEnvironment: Environment>(url: String, plugin_resolver: &Rc<PluginResolver<TEnvironment>>) -> Result<String> {
   let parsed = crate::utils::parse_checksum_path_or_url(&url);
   if parsed.checksum.is_some() {
-    return Ok((url, None));
+    return Ok(url);
   }
   let lower = parsed.path_or_url.to_lowercase();
   if !(lower.ends_with(".wasm") || lower.ends_with(".json")) {
-    return Ok((url, None)); // not a plugin file we can checksum
+    return Ok(url); // not a plugin file we can checksum
   }
-  let parsed_url = Url::parse(&parsed.path_or_url)?;
-  let (_, file) = environment.download_file_err_404(&parsed_url, None).await?;
-  let bytes = file.content;
-  let url = format!("{}@{}", parsed.path_or_url, crate::utils::get_sha256_checksum(&bytes));
-  Ok((url, Some(bytes)))
+  let reference = PluginSourceReference {
+    path_source: PathSource::new_remote(Url::parse(&parsed.path_or_url)?),
+    checksum: None,
+  };
+  let checksum = plugin_resolver.resolve_remote_for_add(&reference).await?;
+  Ok(format!("{}@{}", parsed.path_or_url, checksum))
 }
 
 struct ResolveNpmPluginOptions<'a> {
@@ -467,20 +422,26 @@ struct ResolveNpmPluginOptions<'a> {
 ///
 /// - `npm:foo@1.2.3/plugin.json[@sha]` (explicit path) → pass through verbatim
 ///   (unless `--checksum` and it has none, in which case one is computed).
-/// - `npm:foo@1.2.3` (versioned, no path) → download that version's tarball to
-///   detect the kind and pin the matching form (with checksum for process).
+/// - `npm:foo@1.2.3` (versioned, no path) → set the package up to detect the
+///   kind and pin the matching form (with checksum for process / `--checksum`).
 /// - `npm:foo` with `--no-version` or `--package-json` → keep unversioned. With
 ///   `--package-json`, also return a `devDependencies` entry for the nearest
-///   `package.json` (caret range pinning the resolved latest) and detect the
-///   kind from that tarball; with bare `--no-version` the registry isn't
-///   touched, so the kind is read from `node_modules` if installed.
+///   `package.json` (caret range pinning the resolved latest). The kind for the
+///   written path is read from `node_modules` if the package is installed.
 /// - `npm:foo` (unversioned) and the package is in a nearby `package.json`'s
-///   `devDependencies` → keep unversioned (defer to npm/node_modules), reading
-///   the kind from `node_modules` if installed.
-/// - `npm:foo` (unversioned) otherwise → resolve `dist-tags.latest`, download
-///   the tarball to detect the kind, and write the pinned form (with checksum
-///   for process plugins).
-async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environment: &impl Environment) -> Result<ResolvedNpmPluginAdd> {
+///   `devDependencies` → keep unversioned (defer to npm/node_modules).
+/// - `npm:foo` (unversioned) otherwise → resolve `dist-tags.latest`, set the
+///   package up (detecting the kind), and write the pinned form.
+///
+/// Whenever the package is set up here (to detect the kind and/or compute a
+/// checksum), the plugin cache is warmed as a side effect, so the first
+/// `dprint fmt` is a cache hit with no re-download — see
+/// [`PluginCache::resolve_npm_for_add`].
+async fn resolve_npm_plugin_to_add<TEnvironment: Environment>(
+  options: ResolveNpmPluginOptions<'_>,
+  environment: &TEnvironment,
+  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
+) -> Result<ResolvedNpmPluginAdd> {
   let ResolveNpmPluginOptions {
     text,
     config_path,
@@ -519,31 +480,20 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
         url: text.to_string(),
         package_name: name,
         package_json_addition: None,
-        prefetched_tarball: None,
       });
     }
-    // otherwise download the tarball to compute the checksum (and, for a
+    // otherwise set the package up to compute the checksum (and, for a
     // defaulted path, detect the plugin kind), then write the matching entry.
-    let (path, tarball_sha256, tarball_bytes) = if explicit_path {
-      // the user named the plugin file, so don't inspect the package — that
-      // would wrongly require a root plugin.wasm/plugin.json.
-      let download = fetch_npm_versioned_tarball_download(&name, version, Some(start_dir_ref), environment).await?;
-      (parsed.specifier.path.clone(), download.tarball_sha256, download.tarball_bytes)
-    } else {
-      let info = fetch_npm_versioned_tarball_info(&name, version, Some(start_dir_ref), environment).await?;
-      (default_plugin_path(info.plugin_kind).to_string(), info.tarball_sha256, info.tarball_bytes)
-    };
-    let specifier = crate::utils::NpmSpecifier {
-      name,
+    let resolution = plugin_resolver.resolve_npm_for_add(&parsed.specifier, explicit_path, Some(&start_dir)).await?;
+    let pinned = crate::utils::NpmSpecifier {
+      name: name.clone(),
       version: Some(version.clone()),
-      path,
+      path: resolution.path,
     };
-    let url = npm_add_url(&specifier, &tarball_sha256, checksum);
     return Ok(ResolvedNpmPluginAdd {
-      url,
-      package_name: specifier.name,
+      url: npm_add_url(&pinned, &resolution.checksum, checksum),
+      package_name: name,
       package_json_addition: None,
-      prefetched_tarball: tarball_bytes,
     });
   }
 
@@ -551,69 +501,9 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
     // Look up the latest version so we can write a caret range. If the
     // registry is unreachable we still write the unversioned spec to
     // dprint.json but bail on the package.json update so the user notices
-    // (rather than ending up with an out-of-sync state). When the path was
-    // defaulted we also detect the kind from that tarball — `--package-json`
-    // is usually run before the package is installed, so node_modules
-    // detection alone wouldn't find it.
-    let mut detected_kind = None;
+    // (rather than ending up with an out-of-sync state). The written path's
+    // kind is detected from node_modules (these forms resolve from there).
     let package_json_addition = if update_package_json {
-      let version = if explicit_path {
-        // an explicit path already tells us the kind; only the version is needed.
-        fetch_npm_latest_info(
-          FetchNpmLatestInfo {
-            specifier: &parsed.specifier,
-            start_dir: Some(start_dir_ref),
-            want_tarball_sha: false,
-          },
-          environment,
-        )
-        .await
-        .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?
-        .version
-      } else {
-        let info = fetch_npm_latest_tarball_info(&name, Some(start_dir_ref), environment)
-          .await
-          .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?;
-        detected_kind = Some(info.plugin_kind);
-        info.version
-      };
-      Some((name.clone(), format!("^{}", version)))
-    } else {
-      None
-    };
-    return Ok(ResolvedNpmPluginAdd {
-      url: unversioned_npm_add_url(&parsed, explicit_path, detected_kind, start_dir_ref, environment),
-      package_name: name,
-      package_json_addition,
-      // unversioned specifiers resolve from node_modules, so there's nothing to
-      // pre-cache (any tarball we fetched above was only for the caret range).
-      prefetched_tarball: None,
-    });
-  }
-
-  // `--checksum` forces a pinned, checksummed entry, so don't defer to the
-  // unversioned node_modules form when it's set.
-  if !checksum && is_in_package_json_deps(&name, start_dir_ref, environment) {
-    log_stderr_info!(environment, "Found {} in package.json — adding unversioned npm specifier.", name);
-    return Ok(ResolvedNpmPluginAdd {
-      url: unversioned_npm_add_url(&parsed, explicit_path, None, start_dir_ref, environment),
-      package_name: name,
-      package_json_addition: None,
-      prefetched_tarball: None,
-    });
-  }
-
-  if explicit_path {
-    // the user named the plugin file; pin the latest version and add a checksum
-    // for non-wasm plugins (and for wasm too when `--checksum` was passed). Only
-    // download the tarball when a checksum is actually needed — a wasm explicit
-    // path without `--checksum` just needs the version.
-    let needs_tarball = checksum || parsed.specifier.plugin_kind() == PluginKind::Process;
-    let (version, sha_and_bytes) = if needs_tarball {
-      // explicit path → don't inspect the package for a kind, just download.
-      let download = fetch_npm_latest_tarball_download(&name, Some(start_dir_ref), environment).await?;
-      (download.version, Some((download.tarball_sha256, download.tarball_bytes)))
-    } else {
       let info = fetch_npm_latest_info(
         FetchNpmLatestInfo {
           specifier: &parsed.specifier,
@@ -622,50 +512,64 @@ async fn resolve_npm_plugin_to_add(options: ResolveNpmPluginOptions<'_>, environ
         },
         environment,
       )
-      .await?;
-      (info.version, None)
-    };
-    let pinned = crate::utils::NpmSpecifier {
-      name,
-      version: Some(version),
-      path: parsed.specifier.path,
-    };
-    let display = pinned.display();
-    let (url, prefetched_tarball) = match sha_and_bytes {
-      Some((sha, bytes)) => (format!("{}@{}", display, sha), bytes),
-      None => (display, None),
+      .await
+      .with_context(|| format!("Resolving latest version for package.json entry of {}", name))?;
+      Some((name.clone(), format!("^{}", info.version)))
+    } else {
+      None
     };
     return Ok(ResolvedNpmPluginAdd {
-      url,
-      package_name: pinned.name,
-      package_json_addition: None,
-      prefetched_tarball,
+      url: unversioned_npm_add_url(&parsed, explicit_path, start_dir_ref, environment),
+      package_name: name,
+      package_json_addition,
     });
   }
 
-  // no path given: resolve the latest version and inspect its tarball to learn
-  // the plugin kind (and checksum, required for process plugins / `--checksum`).
-  let info = fetch_npm_latest_tarball_info(&name, Some(start_dir_ref), environment).await?;
-  let specifier = crate::utils::NpmSpecifier {
-    name,
-    version: Some(info.version),
-    path: default_plugin_path(info.plugin_kind).to_string(),
-  };
-  let url = npm_add_url(&specifier, &info.tarball_sha256, checksum);
-  Ok(ResolvedNpmPluginAdd {
-    url,
-    package_name: specifier.name,
-    package_json_addition: None,
-    prefetched_tarball: info.tarball_bytes,
-  })
-}
-
-/// The default file name within an npm package for each plugin kind.
-fn default_plugin_path(kind: PluginKind) -> &'static str {
-  match kind {
-    PluginKind::Wasm => "plugin.wasm",
-    PluginKind::Process => "plugin.json",
+  // `--checksum` forces a pinned, checksummed entry, so don't defer to the
+  // unversioned node_modules form when it's set.
+  if !checksum && is_in_package_json_deps(&name, start_dir_ref, environment) {
+    log_stderr_info!(environment, "Found {} in package.json — adding unversioned npm specifier.", name);
+    return Ok(ResolvedNpmPluginAdd {
+      url: unversioned_npm_add_url(&parsed, explicit_path, start_dir_ref, environment),
+      package_name: name,
+      package_json_addition: None,
+    });
   }
+
+  // resolve the latest version, then pin it. We only set the package up (a
+  // download) when there's actually something to compute: a pathless specifier
+  // (to detect the kind), a process plugin, or `--checksum`. A wasm plugin with
+  // an explicit path and no `--checksum` just needs the version.
+  let version = resolve_npm_latest_version(&name, Some(start_dir_ref), environment).await?;
+  let needs_setup = !explicit_path || checksum || parsed.specifier.plugin_kind() == PluginKind::Process;
+  if !needs_setup {
+    let pinned = crate::utils::NpmSpecifier {
+      name: name.clone(),
+      version: Some(version),
+      path: parsed.specifier.path.clone(),
+    };
+    return Ok(ResolvedNpmPluginAdd {
+      url: pinned.display(),
+      package_name: name,
+      package_json_addition: None,
+    });
+  }
+  let versioned = crate::utils::NpmSpecifier {
+    name: name.clone(),
+    version: Some(version.clone()),
+    path: parsed.specifier.path.clone(),
+  };
+  let resolution = plugin_resolver.resolve_npm_for_add(&versioned, explicit_path, Some(&start_dir)).await?;
+  let pinned = crate::utils::NpmSpecifier {
+    name: name.clone(),
+    version: Some(version),
+    path: resolution.path,
+  };
+  Ok(ResolvedNpmPluginAdd {
+    url: npm_add_url(&pinned, &resolution.checksum, checksum),
+    package_name: name,
+    package_json_addition: None,
+  })
 }
 
 /// Joins a resolved npm specifier with its tarball checksum when one should be
@@ -682,21 +586,13 @@ fn npm_add_url(specifier: &crate::utils::NpmSpecifier, tarball_sha256: &str, for
 
 /// Picks the unversioned specifier string to write for an npm plugin we aren't
 /// pinning (deferring to node_modules / package.json). When the user didn't
-/// give a path, use `detected_kind` if the caller already learned it from the
-/// registry tarball, else fall back to inspecting `node_modules`, so a process
-/// plugin gets `/plugin.json`; otherwise keep the bare form.
-fn unversioned_npm_add_url(
-  parsed: &crate::utils::ParsedNpmSpecifier,
-  explicit_path: bool,
-  detected_kind: Option<PluginKind>,
-  start_dir: &Path,
-  environment: &impl Environment,
-) -> String {
+/// give a path, inspect `node_modules` so an installed process plugin gets
+/// `/plugin.json`; otherwise keep the bare form.
+fn unversioned_npm_add_url(parsed: &crate::utils::ParsedNpmSpecifier, explicit_path: bool, start_dir: &Path, environment: &impl Environment) -> String {
   if explicit_path {
     return parsed.specifier.display();
   }
-  let kind = detected_kind.or_else(|| detect_npm_plugin_kind_in_node_modules(&parsed.specifier.name, start_dir, environment));
-  let path = match kind {
+  let path = match detect_npm_plugin_kind_in_node_modules(&parsed.specifier.name, start_dir, environment) {
     Some(PluginKind::Process) => "plugin.json".to_string(),
     _ => parsed.specifier.path.clone(),
   };
@@ -3089,6 +2985,35 @@ mod test {
     assert_eq!(args[args.len() - 1], "/custom.config.json");
   }
 
+  fn test_plugin_resolver(environment: &TestEnvironment) -> std::rc::Rc<crate::plugins::PluginResolver<TestEnvironment>> {
+    let plugin_cache = crate::plugins::PluginCache::new(environment.clone());
+    std::rc::Rc::new(crate::plugins::PluginResolver::new(environment.clone(), plugin_cache))
+  }
+
+  /// Builds a self-contained npm process-plugin tarball (a `plugin.json` that
+  /// references an in-package `bin.zip`) so `dprint add` can actually set it up.
+  fn process_plugin_npm_tarball() -> Vec<u8> {
+    use crate::test_helpers::PROCESS_PLUGIN_ZIP_BYTES;
+    use crate::test_helpers::create_test_npm_tarball;
+    let zip: &[u8] = &PROCESS_PLUGIN_ZIP_BYTES;
+    let zip_checksum = crate::utils::get_sha256_checksum(zip);
+    let plugin_json = format!(
+      r#"{{
+  "schemaVersion": 2,
+  "name": "test-process-plugin",
+  "version": "0.1.0",
+  "linux-x86_64":    {{ "reference": "./bin.zip", "checksum": "{0}" }},
+  "linux-aarch64":   {{ "reference": "./bin.zip", "checksum": "{0}" }},
+  "darwin-x86_64":   {{ "reference": "./bin.zip", "checksum": "{0}" }},
+  "darwin-aarch64":  {{ "reference": "./bin.zip", "checksum": "{0}" }},
+  "windows-x86_64":  {{ "reference": "./bin.zip", "checksum": "{0}" }},
+  "windows-aarch64": {{ "reference": "./bin.zip", "checksum": "{0}" }}
+}}"#,
+      zip_checksum
+    );
+    create_test_npm_tarball(&[("package/plugin.json", plugin_json.as_bytes()), ("package/bin.zip", zip)])
+  }
+
   /// Convenience for tests: most calls only vary the spec text and the
   /// two flags, so wrap the struct-building boilerplate here.
   async fn call_resolve_npm_plugin_to_add(
@@ -3110,7 +3035,8 @@ mod test {
     checksum: bool,
     environment: &TestEnvironment,
   ) -> Result<super::ResolvedNpmPluginAdd> {
-    super::resolve_npm_plugin_to_add(
+    let plugin_resolver = test_plugin_resolver(environment);
+    let result = super::resolve_npm_plugin_to_add(
       super::ResolveNpmPluginOptions {
         text,
         config_path,
@@ -3119,8 +3045,14 @@ mod test {
         checksum,
       },
       environment,
+      &plugin_resolver,
     )
-    .await
+    .await;
+    // resolving warms the plugin cache (compiling wasm / extracting process
+    // plugins), which logs progress — drain it so the test only asserts the url.
+    let _ = environment.take_stderr_messages();
+    let _ = environment.take_stdout_messages();
+    result
   }
 
   #[tokio::test]
@@ -3137,7 +3069,7 @@ mod test {
     environment.add_remote_file_bytes("https://registry.npmjs.org/@dprint/typescript", packument.to_string().into_bytes());
     environment.add_remote_file_bytes(
       "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.95.15.tgz",
-      create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+      create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]),
     );
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:@dprint/typescript@0.95.15", &config_path, false, false, &environment)
@@ -3172,7 +3104,7 @@ mod test {
       "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3194,7 +3126,7 @@ mod test {
       "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3218,7 +3150,7 @@ mod test {
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
     // tarball ships the plugin in a subdirectory, with no root plugin file
-    let tarball_bytes = create_test_npm_tarball(&[("package/sub/foo.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/sub/foo.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3241,7 +3173,7 @@ mod test {
       "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3254,32 +3186,31 @@ mod test {
   #[tokio::test]
   async fn ensure_url_checksum_appends_for_plugin_url_without_one() {
     let environment = TestEnvironment::new();
-    let bytes = vec![1u8, 2, 3, 4];
-    let expected = crate::utils::get_sha256_checksum(&bytes);
-    environment.add_remote_file_bytes("https://example.com/plugin.wasm", bytes.clone());
-    let (url, prefetched) = super::ensure_url_checksum("https://example.com/plugin.wasm".to_string(), &environment)
+    environment.set_cpu_arch("aarch64");
+    environment.add_remote_file("https://plugins.dprint.dev/test.wasm", crate::test_helpers::WASM_PLUGIN_BYTES);
+    let expected = crate::utils::get_sha256_checksum(crate::test_helpers::WASM_PLUGIN_BYTES);
+    let resolver = test_plugin_resolver(&environment);
+    let url = super::ensure_url_checksum("https://plugins.dprint.dev/test.wasm".to_string(), &resolver)
       .await
       .unwrap();
-    assert_eq!(url, format!("https://example.com/plugin.wasm@{}", expected));
-    // the downloaded bytes are returned so the caller can warm the cache
-    assert_eq!(prefetched, Some(bytes));
+    assert_eq!(url, format!("https://plugins.dprint.dev/test.wasm@{}", expected));
+    let _ = environment.take_stderr_messages();
   }
 
   #[tokio::test]
   async fn ensure_url_checksum_preserves_existing_and_ignores_non_plugin_urls() {
     let environment = TestEnvironment::new();
+    let resolver = test_plugin_resolver(&environment);
     // already has a checksum → returned unchanged, no download attempted
-    let (url, prefetched) = super::ensure_url_checksum("https://example.com/plugin.wasm@abc123".to_string(), &environment)
+    let url = super::ensure_url_checksum("https://example.com/plugin.wasm@abc123".to_string(), &resolver)
       .await
       .unwrap();
     assert_eq!(url, "https://example.com/plugin.wasm@abc123");
-    assert_eq!(prefetched, None);
     // not a plugin file → returned unchanged
-    let (url, prefetched) = super::ensure_url_checksum("https://example.com/readme.txt".to_string(), &environment)
+    let url = super::ensure_url_checksum("https://example.com/readme.txt".to_string(), &resolver)
       .await
       .unwrap();
     assert_eq!(url, "https://example.com/readme.txt");
-    assert_eq!(prefetched, None);
   }
 
   #[tokio::test]
@@ -3346,7 +3277,7 @@ mod test {
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
     // detection downloads the tarball to learn the plugin kind — ship a wasm one
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
@@ -3364,7 +3295,7 @@ mod test {
       "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = vec![9u8, 8, 7, 6];
+    let tarball_bytes = process_plugin_npm_tarball();
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-2.0.0.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3378,7 +3309,6 @@ mod test {
   async fn npm_add_autodetects_process_plugin_without_path() {
     // `dprint add npm:foo` (no path) should inspect the package, discover it
     // ships a plugin.json, and write the pinned process form with a checksum.
-    use crate::test_helpers::create_test_npm_tarball;
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
     let packument = serde_json::json!({
@@ -3386,7 +3316,7 @@ mod test {
       "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
+    let tarball_bytes = process_plugin_npm_tarball();
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-2.0.0.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3408,7 +3338,7 @@ mod test {
       "versions": { "2.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-2.0.0.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, false, false, &environment)
@@ -3421,7 +3351,6 @@ mod test {
   async fn npm_add_autodetects_process_plugin_for_versioned_without_path() {
     // a pinned version without a path still inspects that version's tarball
     // rather than passing through verbatim as wasm.
-    use crate::test_helpers::create_test_npm_tarball;
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
     let packument = serde_json::json!({
@@ -3429,7 +3358,7 @@ mod test {
       "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
+    let tarball_bytes = process_plugin_npm_tarball();
     let expected = crate::utils::get_sha256_checksum(&tarball_bytes);
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3515,7 +3444,7 @@ mod test {
     environment.add_remote_file_bytes("https://registry.npmjs.org/@dprint/typescript", packument.to_string().into_bytes());
     environment.add_remote_file_bytes(
       "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.99.0.tgz",
-      create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+      create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]),
     );
 
     let config_path = environment.canonicalize("/dprint.json").unwrap();
@@ -3527,23 +3456,18 @@ mod test {
   }
 
   #[tokio::test]
-  async fn npm_add_package_json_detects_process_path_from_tarball() {
-    // --package-json is usually run before the package is installed, so detect
-    // the kind from the registry tarball and write `/plugin.json` even though
-    // node_modules has nothing yet. No checksum is written: the unversioned
-    // form resolves from node_modules, which doesn't require one.
-    use crate::test_helpers::create_test_npm_tarball;
+  async fn npm_add_package_json_detects_process_path_from_node_modules() {
+    // `--package-json` writes the unversioned form (resolved from node_modules),
+    // so a process plugin's `/plugin.json` is picked up when it's installed.
     let environment = TestEnvironment::new();
     environment.write_file("/dprint.json", "{}").unwrap();
+    environment.mk_dir_all("/node_modules/foo").unwrap();
+    environment.write_file("/node_modules/foo/plugin.json", "{}").unwrap();
     let packument = serde_json::json!({
       "dist-tags": { "latest": "1.0.0" },
       "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    environment.add_remote_file_bytes(
-      "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
-      create_test_npm_tarball(&[("package/plugin.json", b"{}")]),
-    );
 
     let config_path = environment.canonicalize("/dprint.json").unwrap();
     let result = call_resolve_npm_plugin_to_add("npm:foo", &config_path, true, true, &environment).await.unwrap();
@@ -3646,7 +3570,7 @@ mod test {
       .add_remote_file_bytes("https://registry.npmjs.org/test-plugin", packument.to_string().into_bytes())
       .add_remote_file_bytes(
         "https://registry.npmjs.org/test-plugin/-/test-plugin-2.0.0.tgz",
-        create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]),
+        create_test_npm_tarball(&[("package/plugin.wasm", crate::test_helpers::WASM_PLUGIN_BYTES)]),
       )
       .build();
 

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -46,10 +46,11 @@ pub struct PluginCacheItem {
   pub plugin_kind: PluginKind,
 }
 
-/// What [`PluginCache::resolve_npm_for_add`] resolved: the plugin file path
-/// within the package (detected for a pathless specifier) and the tarball
-/// checksum, for the caller to write into the config entry.
+/// What [`PluginCache::resolve_npm_for_add`] resolved: the plugin kind, the
+/// plugin file path within the package (detected for a pathless specifier), and
+/// the tarball checksum — for the caller to write into the config entry.
 pub struct NpmAddResolution {
+  pub plugin_kind: PluginKind,
   pub path: String,
   pub checksum: String,
 }
@@ -268,6 +269,7 @@ where
         default_plugin_path(entry.plugin_kind).to_string()
       };
       return Ok(NpmAddResolution {
+        plugin_kind: entry.plugin_kind,
         path,
         checksum: entry.tarball_sha256,
       });
@@ -316,6 +318,7 @@ where
     }
 
     Ok(NpmAddResolution {
+      plugin_kind: resolved.plugin_kind,
       path: resolved.resolved_path,
       checksum,
     })
@@ -845,6 +848,7 @@ mod test {
     };
 
     let resolution = plugin_cache.resolve_npm_for_add(&specifier, false, None).await?;
+    assert_eq!(resolution.plugin_kind, PluginKind::Wasm);
     assert_eq!(resolution.path, "plugin.wasm");
     assert_eq!(resolution.checksum, expected);
     let _ = environment.take_stderr_messages();

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -189,6 +189,56 @@ where
       .with_context(|| format!("Setting up {}", specifier.display()))
   }
 
+  /// Like [`get_npm_registry_plugin`] but reuses a package tarball that was
+  /// already downloaded (e.g. by `dprint add`), so the registry tarball isn't
+  /// fetched a second time. Returns early on a cache hit.
+  async fn setup_npm_registry_plugin_from_tarball(
+    &self,
+    source_reference: &PluginSourceReference,
+    npm_source: &crate::utils::NpmPathSource,
+    tarball_bytes: Vec<u8>,
+  ) -> Result<()> {
+    let (cache_key, hash, _setup_guard) = match self.lookup_or_lock(&source_reference.path_source).await? {
+      CacheLookup::Hit(_) => return Ok(()),
+      CacheLookup::Miss { cache_key, hash, guard } => (cache_key, hash, guard),
+    };
+
+    let specifier = &npm_source.specifier;
+    let checksum = source_reference.checksum.as_deref();
+    let base_dir = npm_source.base_dir.as_ref().map(|d| d.as_ref());
+    let registry = self.resolve_registry(&specifier.name, base_dir);
+    let resolved = npm_resolution::resolve_npm_from_prefetched_tarball(specifier, checksum, tarball_bytes, &registry, base_dir, &self.environment).await?;
+
+    self
+      .setup_and_store(
+        &hash,
+        &cache_key,
+        &resolved.local_path,
+        resolved.plugin_bytes,
+        resolved.plugin_kind,
+        resolved.pre_resolved_tarball,
+        None,
+      )
+      .await
+      .with_context(|| format!("Setting up {}", specifier.display()))?;
+    Ok(())
+  }
+
+  /// Populates the plugin cache from bytes already downloaded during `dprint
+  /// add` (to compute a checksum), so the first `dprint fmt` is a cache hit
+  /// with no second download. Remote/local plugins use the plugin file bytes;
+  /// versioned npm plugins use the package tarball bytes. Other sources (e.g.
+  /// unversioned npm, which resolves from node_modules) are a no-op.
+  pub async fn setup_from_prefetched_download(&self, source_reference: &PluginSourceReference, bytes: Vec<u8>) -> Result<()> {
+    match &source_reference.path_source {
+      PathSource::Remote(_) | PathSource::Local(_) => self.setup_remote_plugin_from_bytes(source_reference, bytes).await,
+      PathSource::Npm(npm_source) if npm_source.specifier.version.is_some() => {
+        self.setup_npm_registry_plugin_from_tarball(source_reference, npm_source, bytes).await
+      }
+      PathSource::Npm(_) => Ok(()),
+    }
+  }
+
   /// Gets a plugin from a local path (node_modules). No checksum required since it's a local file.
   async fn get_local_plugin(
     &self,
@@ -264,6 +314,40 @@ where
       PathSource::Npm(_) => bail!("npm plugins should be resolved before reaching get_plugin"),
     };
 
+    self
+      .verify_and_store_plugin(source_reference, &cache_key, &hash, file_bytes, resolved_source, primary_stamp)
+      .await
+  }
+
+  /// Sets up and caches a remote/local plugin from bytes already downloaded
+  /// elsewhere — e.g. `dprint add` downloads a Wasm/JSON plugin to compute its
+  /// checksum, then hands the bytes here so the first `dprint fmt` is a cache
+  /// hit instead of downloading and compiling again. Returns early on a hit.
+  async fn setup_remote_plugin_from_bytes(&self, source_reference: &PluginSourceReference, file_bytes: Vec<u8>) -> Result<()> {
+    let (cache_key, hash, _setup_guard) = match self.lookup_or_lock(&source_reference.path_source).await? {
+      CacheLookup::Hit(_) => return Ok(()),
+      CacheLookup::Miss { cache_key, hash, guard } => (cache_key, hash, guard),
+    };
+    let primary_stamp = source_reference.path_source.maybe_local_path().and_then(|p| self.stamp_for(p));
+    let resolved_source = source_reference.path_source.clone();
+    self
+      .verify_and_store_plugin(source_reference, &cache_key, &hash, file_bytes, resolved_source, primary_stamp)
+      .await?;
+    Ok(())
+  }
+
+  /// Shared tail of plugin setup once the file bytes are in hand (whether
+  /// freshly downloaded by `get_plugin` or handed in pre-downloaded): verifies
+  /// the checksum, computes local stamps, and stores the cached entry.
+  async fn verify_and_store_plugin(
+    &self,
+    source_reference: &PluginSourceReference,
+    cache_key: &str,
+    hash: &str,
+    file_bytes: Vec<u8>,
+    resolved_source: PathSource,
+    primary_stamp: Option<LocalStamp>,
+  ) -> Result<PluginCacheItem> {
     let plugin_kind = source_reference
       .plugin_kind()
       .ok_or_else(|| anyhow::anyhow!("Could not determine plugin kind for {}", source_reference.display()))?;
@@ -297,7 +381,7 @@ where
     };
 
     self
-      .setup_and_store(&hash, &cache_key, &resolved_source, file_bytes, plugin_kind, None, local_stamps)
+      .setup_and_store(hash, cache_key, &resolved_source, file_bytes, plugin_kind, None, local_stamps)
       .await
   }
 
@@ -594,6 +678,51 @@ mod test {
     assert!(!environment.path_exists(&file_path));
     assert!(read_meta(&hash, &environment).is_none());
 
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn setup_remote_plugin_from_bytes_warms_cache_without_download() -> Result<()> {
+    // the remote url is intentionally NOT registered — a later resolve must be
+    // a pure cache hit, proving the prefetch set the plugin up from the bytes
+    // without going to the network.
+    let environment = TestEnvironment::new();
+    environment.set_cpu_arch("aarch64");
+    let plugin_cache = PluginCache::new(environment.clone());
+    let plugin_source = PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test.wasm");
+
+    plugin_cache.setup_remote_plugin_from_bytes(&plugin_source, WASM_PLUGIN_BYTES.to_vec()).await?;
+    assert_eq!(environment.take_stderr_messages(), vec!["Compiling https://plugins.dprint.dev/test.wasm"]);
+
+    let item = plugin_cache.get_plugin_cache_item(&plugin_source).await?;
+    assert_eq!(item.info.name, "test-plugin");
+    assert!(environment.take_stderr_messages().is_empty(), "resolve should have been a cache hit");
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn setup_from_prefetched_download_warms_npm_cache_without_download() -> Result<()> {
+    use crate::test_helpers::create_test_npm_tarball;
+    // neither the registry packument nor the tarball are registered — the
+    // prefetch must set the plugin up entirely from the provided tarball bytes,
+    // and the later resolve must be a cache hit.
+    let environment = TestEnvironment::new();
+    environment.set_cpu_arch("aarch64");
+    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", WASM_PLUGIN_BYTES)]);
+    let checksum = crate::utils::get_sha256_checksum(&tarball);
+    let plugin_cache = PluginCache::new(environment.clone());
+    let reference = crate::plugins::parse_plugin_source_reference(
+      &format!("npm:foo@1.0.0/plugin.wasm@{}", checksum),
+      &PathSource::new_local(crate::environment::CanonicalizedPathBuf::new_for_testing("/dprint.json")),
+      &environment,
+    )?;
+
+    plugin_cache.setup_from_prefetched_download(&reference, tarball).await?;
+    let _ = environment.take_stderr_messages();
+
+    let item = plugin_cache.get_plugin_cache_item(&reference).await?;
+    assert_eq!(item.info.name, "test-plugin");
+    assert!(environment.take_stderr_messages().is_empty(), "resolve should have been a cache hit");
     Ok(())
   }
 

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -78,14 +78,6 @@ struct VerifyAndStoreOptions<'a> {
   primary_stamp: Option<LocalStamp>,
 }
 
-/// The default plugin file name within an npm package for each kind.
-fn default_plugin_path(kind: PluginKind) -> &'static str {
-  match kind {
-    PluginKind::Wasm => "plugin.wasm",
-    PluginKind::Process => "plugin.json",
-  }
-}
-
 /// On-disk cache of set-up plugins.
 ///
 /// Each plugin gets a flat pair of files under `<cache>/plugins/` keyed by a
@@ -260,19 +252,24 @@ where
       .ok_or_else(|| anyhow::anyhow!("Internal error: resolve_npm_for_add requires a versioned specifier"))?;
     let base_dir_ref = base_dir.map(|d| d.as_ref());
 
-    // a prior add/format cached this version's checksum + kind — reuse it
-    // instead of re-downloading the tarball.
-    if let Some(entry) = npm_resolution::read_npm_add_cache(&specifier.name, version, base_dir_ref, &self.environment) {
-      let path = if path_was_explicit {
-        specifier.path.clone()
-      } else {
-        default_plugin_path(entry.plugin_kind).to_string()
-      };
-      return Ok(NpmAddResolution {
-        plugin_kind: entry.plugin_kind,
-        path,
-        checksum: entry.tarball_sha256,
-      });
+    // fast path: a prior add/format cached this version's tarball checksum, so
+    // skip the re-download. The kind comes from the real path/files (NOT a
+    // package-level cached kind, which would be wrong for a package shipping
+    // multiple plugins): an explicit path determines its own kind; a pathless
+    // specifier is re-detected from the already-extracted package.
+    if let Some(checksum) = npm_resolution::read_npm_tarball_checksum(&specifier.name, version, base_dir_ref, &self.environment) {
+      if path_was_explicit {
+        return Ok(NpmAddResolution {
+          plugin_kind: specifier.plugin_kind(),
+          path: specifier.path.clone(),
+          checksum,
+        });
+      }
+      if let Some((path, plugin_kind)) = npm_resolution::detect_extracted_npm_plugin(&specifier.name, version, base_dir_ref, &self.environment) {
+        return Ok(NpmAddResolution { plugin_kind, path, checksum });
+      }
+      // the extract dir is gone (or has no conventional plugin file) — fall
+      // through to a full resolve, which re-downloads and re-detects.
     }
 
     let registry = self.resolve_registry(&specifier.name, base_dir_ref);

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -25,6 +25,7 @@ use super::cache_meta::to_unix_millis;
 use super::cache_meta::wasm_artifact_path;
 use super::cache_meta::write_meta;
 use super::implementations::SetupPluginDest;
+use super::implementations::SetupPluginOptions;
 use super::implementations::get_process_plugin_os_path;
 use super::implementations::parse_process_plugin_file;
 use super::implementations::setup_plugin;
@@ -51,6 +52,29 @@ pub struct PluginCacheItem {
 pub struct NpmAddResolution {
   pub path: String,
   pub checksum: String,
+}
+
+/// Inputs to [`PluginCache::setup_and_store`]. `hash`/`cache_key` identify the
+/// cache entry; the rest is the resolved plugin to set up.
+struct SetupAndStoreOptions<'a> {
+  hash: &'a str,
+  cache_key: &'a str,
+  resolved_source: &'a PathSource,
+  file_bytes: Vec<u8>,
+  plugin_kind: PluginKind,
+  pre_resolved_tarball: Option<npm_resolution::PreResolvedProcessPluginTarball>,
+  local_stamps: Option<Vec<LocalStamp>>,
+}
+
+/// Inputs to [`PluginCache::verify_and_store_plugin`]: the resolved bytes plus
+/// the cache identity, ready to verify and store.
+struct VerifyAndStoreOptions<'a> {
+  source_reference: &'a PluginSourceReference,
+  cache_key: &'a str,
+  hash: &'a str,
+  file_bytes: Vec<u8>,
+  resolved_source: PathSource,
+  primary_stamp: Option<LocalStamp>,
 }
 
 /// The default plugin file name within an npm package for each kind.
@@ -205,15 +229,15 @@ where
     // npm-versioned content is pinned by name@version, so there are no local
     // stamps — a present entry is always a hit.
     self
-      .setup_and_store(
-        &hash,
-        &cache_key,
-        &resolved.local_path,
-        resolved.plugin_bytes,
-        resolved.plugin_kind,
-        resolved.pre_resolved_tarball,
-        None,
-      )
+      .setup_and_store(SetupAndStoreOptions {
+        hash: &hash,
+        cache_key: &cache_key,
+        resolved_source: &resolved.local_path,
+        file_bytes: resolved.plugin_bytes,
+        plugin_kind: resolved.plugin_kind,
+        pre_resolved_tarball: resolved.pre_resolved_tarball,
+        local_stamps: None,
+      })
       .await
       .with_context(|| format!("Setting up {}", specifier.display()))
   }
@@ -278,15 +302,15 @@ where
     let path_source = PathSource::new_npm(resolved_specifier, base_dir.cloned());
     if let CacheLookup::Miss { cache_key, hash, .. } = self.lookup_or_lock(&path_source).await? {
       self
-        .setup_and_store(
-          &hash,
-          &cache_key,
-          &resolved.local_path,
-          resolved.plugin_bytes,
-          resolved.plugin_kind,
-          resolved.pre_resolved_tarball,
-          None,
-        )
+        .setup_and_store(SetupAndStoreOptions {
+          hash: &hash,
+          cache_key: &cache_key,
+          resolved_source: &resolved.local_path,
+          file_bytes: resolved.plugin_bytes,
+          plugin_kind: resolved.plugin_kind,
+          pre_resolved_tarball: resolved.pre_resolved_tarball,
+          local_stamps: None,
+        })
         .await
         .with_context(|| format!("Setting up {}", specifier.display()))?;
     }
@@ -315,7 +339,15 @@ where
     if let CacheLookup::Miss { cache_key, hash, .. } = self.lookup_or_lock(&source_reference.path_source).await? {
       let resolved_source = PathSource::new_remote(resolved_url.into_owned());
       self
-        .setup_and_store(&hash, &cache_key, &resolved_source, file_bytes, plugin_kind, None, None)
+        .setup_and_store(SetupAndStoreOptions {
+          hash: &hash,
+          cache_key: &cache_key,
+          resolved_source: &resolved_source,
+          file_bytes,
+          plugin_kind,
+          pre_resolved_tarball: None,
+          local_stamps: None,
+        })
         .await
         .with_context(|| format!("Setting up {}", source_reference.display()))?;
     }
@@ -362,15 +394,15 @@ where
       pre_resolved_tarball.as_ref(),
     );
     self
-      .setup_and_store(
-        &hash,
-        &cache_key,
-        &source_reference.path_source,
+      .setup_and_store(SetupAndStoreOptions {
+        hash: &hash,
+        cache_key: &cache_key,
+        resolved_source: &source_reference.path_source,
         file_bytes,
         plugin_kind,
         pre_resolved_tarball,
         local_stamps,
-      )
+      })
       .await
   }
 
@@ -399,21 +431,28 @@ where
     };
 
     self
-      .verify_and_store_plugin(source_reference, &cache_key, &hash, file_bytes, resolved_source, primary_stamp)
+      .verify_and_store_plugin(VerifyAndStoreOptions {
+        source_reference,
+        cache_key: &cache_key,
+        hash: &hash,
+        file_bytes,
+        resolved_source,
+        primary_stamp,
+      })
       .await
   }
 
   /// Shared tail of plugin setup once the file bytes are in hand: verifies the
   /// checksum, computes local stamps, and stores the cached entry.
-  async fn verify_and_store_plugin(
-    &self,
-    source_reference: &PluginSourceReference,
-    cache_key: &str,
-    hash: &str,
-    file_bytes: Vec<u8>,
-    resolved_source: PathSource,
-    primary_stamp: Option<LocalStamp>,
-  ) -> Result<PluginCacheItem> {
+  async fn verify_and_store_plugin(&self, options: VerifyAndStoreOptions<'_>) -> Result<PluginCacheItem> {
+    let VerifyAndStoreOptions {
+      source_reference,
+      cache_key,
+      hash,
+      file_bytes,
+      resolved_source,
+      primary_stamp,
+    } = options;
     let plugin_kind = source_reference
       .plugin_kind()
       .ok_or_else(|| anyhow::anyhow!("Could not determine plugin kind for {}", source_reference.display()))?;
@@ -447,7 +486,15 @@ where
     };
 
     self
-      .setup_and_store(hash, cache_key, &resolved_source, file_bytes, plugin_kind, None, local_stamps)
+      .setup_and_store(SetupAndStoreOptions {
+        hash,
+        cache_key,
+        resolved_source: &resolved_source,
+        file_bytes,
+        plugin_kind,
+        pre_resolved_tarball: None,
+        local_stamps,
+      })
       .await
   }
 
@@ -472,23 +519,32 @@ where
   /// Sets up a freshly resolved plugin into the flat cache layout, writes its
   /// sidecar, and returns the cache item. Overwrites any existing entry for the
   /// same hash (e.g. a changed local file), so no explicit forget is needed.
-  #[allow(clippy::too_many_arguments)]
-  async fn setup_and_store(
-    &self,
-    hash: &str,
-    cache_key: &str,
-    resolved_source: &PathSource,
-    file_bytes: Vec<u8>,
-    plugin_kind: PluginKind,
-    pre_resolved_tarball: Option<npm_resolution::PreResolvedProcessPluginTarball>,
-    local_stamps: Option<Vec<LocalStamp>>,
-  ) -> Result<PluginCacheItem> {
+  async fn setup_and_store(&self, options: SetupAndStoreOptions<'_>) -> Result<PluginCacheItem> {
+    let SetupAndStoreOptions {
+      hash,
+      cache_key,
+      resolved_source,
+      file_bytes,
+      plugin_kind,
+      pre_resolved_tarball,
+      local_stamps,
+    } = options;
     self.environment.mk_dir_all(plugins_dir(&self.environment))?;
     let dest = SetupPluginDest {
       wasm_file_path: wasm_artifact_path(hash, &self.environment),
       process_dir_path: process_dir_path(hash, &self.environment),
     };
-    let setup_result = setup_plugin(resolved_source, file_bytes, plugin_kind, pre_resolved_tarball, &dest, &self.environment).await?;
+    let setup_result = setup_plugin(
+      SetupPluginOptions {
+        resolved_source,
+        file_bytes,
+        plugin_kind,
+        pre_resolved_tarball,
+        dest: &dest,
+      },
+      &self.environment,
+    )
+    .await?;
 
     let meta = PluginCacheMeta {
       source: cache_key.to_string(),

--- a/crates/dprint/src/plugins/cache.rs
+++ b/crates/dprint/src/plugins/cache.rs
@@ -29,8 +29,10 @@ use super::implementations::get_process_plugin_os_path;
 use super::implementations::parse_process_plugin_file;
 use super::implementations::setup_plugin;
 use super::npm_resolution;
+use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::plugins::PluginSourceReference;
+use crate::utils::NpmSpecifier;
 use crate::utils::PathSource;
 use crate::utils::PluginKind;
 use crate::utils::get_sha256_checksum;
@@ -41,6 +43,22 @@ pub struct PluginCacheItem {
   pub file_path: PathBuf,
   pub info: PluginInfo,
   pub plugin_kind: PluginKind,
+}
+
+/// What [`PluginCache::resolve_npm_for_add`] resolved: the plugin file path
+/// within the package (detected for a pathless specifier) and the tarball
+/// checksum, for the caller to write into the config entry.
+pub struct NpmAddResolution {
+  pub path: String,
+  pub checksum: String,
+}
+
+/// The default plugin file name within an npm package for each kind.
+fn default_plugin_path(kind: PluginKind) -> &'static str {
+  match kind {
+    PluginKind::Wasm => "plugin.wasm",
+    PluginKind::Process => "plugin.json",
+  }
 }
 
 /// On-disk cache of set-up plugins.
@@ -171,7 +189,18 @@ where
     let checksum = source_reference.checksum.as_deref();
     let base_dir = npm_source.base_dir.as_ref().map(|d| d.as_ref());
     let registry = self.resolve_registry(&specifier.name, base_dir);
-    let resolved = npm_resolution::resolve_npm_from_registry(specifier, checksum, &registry, base_dir, &self.environment).await?;
+    let resolved = npm_resolution::resolve_npm_from_registry(
+      npm_resolution::ResolveNpmRegistryOptions {
+        specifier,
+        checksum,
+        detect_path: false,
+        establish_checksum: false,
+        registry: &registry,
+        config_dir: base_dir,
+      },
+      &self.environment,
+    )
+    .await?;
 
     // npm-versioned content is pinned by name@version, so there are no local
     // stamps — a present entry is always a hit.
@@ -189,54 +218,109 @@ where
       .with_context(|| format!("Setting up {}", specifier.display()))
   }
 
-  /// Like [`get_npm_registry_plugin`] but reuses a package tarball that was
-  /// already downloaded (e.g. by `dprint add`), so the registry tarball isn't
-  /// fetched a second time. Returns early on a cache hit.
-  async fn setup_npm_registry_plugin_from_tarball(
+  /// Sets up a versioned npm plugin for `dprint add`: resolves the plugin file
+  /// (detecting it for a pathless specifier), computes the tarball checksum, and
+  /// warms the plugin cache so the first `dprint fmt` is a hit. Returns the
+  /// resolved path + checksum for the caller to write into config. Reuses the
+  /// checksum sidecar to skip the download on a repeat add.
+  pub async fn resolve_npm_for_add(
     &self,
-    source_reference: &PluginSourceReference,
-    npm_source: &crate::utils::NpmPathSource,
-    tarball_bytes: Vec<u8>,
-  ) -> Result<()> {
-    let (cache_key, hash, _setup_guard) = match self.lookup_or_lock(&source_reference.path_source).await? {
-      CacheLookup::Hit(_) => return Ok(()),
-      CacheLookup::Miss { cache_key, hash, guard } => (cache_key, hash, guard),
+    specifier: &NpmSpecifier,
+    path_was_explicit: bool,
+    base_dir: Option<&CanonicalizedPathBuf>,
+  ) -> Result<NpmAddResolution> {
+    let version = specifier
+      .version
+      .as_deref()
+      .ok_or_else(|| anyhow::anyhow!("Internal error: resolve_npm_for_add requires a versioned specifier"))?;
+    let base_dir_ref = base_dir.map(|d| d.as_ref());
+
+    // a prior add/format cached this version's checksum + kind — reuse it
+    // instead of re-downloading the tarball.
+    if let Some(entry) = npm_resolution::read_npm_add_cache(&specifier.name, version, base_dir_ref, &self.environment) {
+      let path = if path_was_explicit {
+        specifier.path.clone()
+      } else {
+        default_plugin_path(entry.plugin_kind).to_string()
+      };
+      return Ok(NpmAddResolution {
+        path,
+        checksum: entry.tarball_sha256,
+      });
+    }
+
+    let registry = self.resolve_registry(&specifier.name, base_dir_ref);
+    let resolved = npm_resolution::resolve_npm_from_registry(
+      npm_resolution::ResolveNpmRegistryOptions {
+        specifier,
+        checksum: None,
+        detect_path: !path_was_explicit,
+        establish_checksum: true,
+        registry: &registry,
+        config_dir: base_dir_ref,
+      },
+      &self.environment,
+    )
+    .await?;
+    let checksum = resolved
+      .tarball_checksum
+      .clone()
+      .ok_or_else(|| anyhow::anyhow!("Internal error: registry resolve did not compute a checksum"))?;
+
+    // warm the compiled cache under the resolved path's key so the first
+    // `dprint fmt` is a hit (the key ignores the checksum, so writing it to
+    // config afterward still matches).
+    let resolved_specifier = NpmSpecifier {
+      name: specifier.name.clone(),
+      version: Some(version.to_string()),
+      path: resolved.resolved_path.clone(),
     };
+    let path_source = PathSource::new_npm(resolved_specifier, base_dir.cloned());
+    if let CacheLookup::Miss { cache_key, hash, .. } = self.lookup_or_lock(&path_source).await? {
+      self
+        .setup_and_store(
+          &hash,
+          &cache_key,
+          &resolved.local_path,
+          resolved.plugin_bytes,
+          resolved.plugin_kind,
+          resolved.pre_resolved_tarball,
+          None,
+        )
+        .await
+        .with_context(|| format!("Setting up {}", specifier.display()))?;
+    }
 
-    let specifier = &npm_source.specifier;
-    let checksum = source_reference.checksum.as_deref();
-    let base_dir = npm_source.base_dir.as_ref().map(|d| d.as_ref());
-    let registry = self.resolve_registry(&specifier.name, base_dir);
-    let resolved = npm_resolution::resolve_npm_from_prefetched_tarball(specifier, checksum, tarball_bytes, &registry, base_dir, &self.environment).await?;
-
-    self
-      .setup_and_store(
-        &hash,
-        &cache_key,
-        &resolved.local_path,
-        resolved.plugin_bytes,
-        resolved.plugin_kind,
-        resolved.pre_resolved_tarball,
-        None,
-      )
-      .await
-      .with_context(|| format!("Setting up {}", specifier.display()))?;
-    Ok(())
+    Ok(NpmAddResolution {
+      path: resolved.resolved_path,
+      checksum,
+    })
   }
 
-  /// Populates the plugin cache from bytes already downloaded during `dprint
-  /// add` (to compute a checksum), so the first `dprint fmt` is a cache hit
-  /// with no second download. Remote/local plugins use the plugin file bytes;
-  /// versioned npm plugins use the package tarball bytes. Other sources (e.g.
-  /// unversioned npm, which resolves from node_modules) are a no-op.
-  pub async fn setup_from_prefetched_download(&self, source_reference: &PluginSourceReference, bytes: Vec<u8>) -> Result<()> {
-    match &source_reference.path_source {
-      PathSource::Remote(_) | PathSource::Local(_) => self.setup_remote_plugin_from_bytes(source_reference, bytes).await,
-      PathSource::Npm(npm_source) if npm_source.specifier.version.is_some() => {
-        self.setup_npm_registry_plugin_from_tarball(source_reference, npm_source, bytes).await
-      }
-      PathSource::Npm(_) => Ok(()),
+  /// Downloads a remote plugin for `dprint add`, computes its checksum, and
+  /// warms the plugin cache so the first `dprint fmt` is a hit. Returns the
+  /// checksum for the caller to write into config.
+  pub async fn resolve_remote_for_add(&self, source_reference: &PluginSourceReference) -> Result<String> {
+    let remote = match &source_reference.path_source {
+      PathSource::Remote(remote) => remote,
+      _ => bail!("Internal error: resolve_remote_for_add requires a remote source"),
+    };
+    let plugin_kind = source_reference
+      .plugin_kind()
+      .ok_or_else(|| anyhow::anyhow!("Could not determine plugin kind for {}", source_reference.display()))?;
+    let (resolved_url, file) = self.environment.download_file_err_404(&remote.url, None).await?;
+    let file_bytes = file.content;
+    let checksum = get_sha256_checksum(&file_bytes);
+
+    if let CacheLookup::Miss { cache_key, hash, .. } = self.lookup_or_lock(&source_reference.path_source).await? {
+      let resolved_source = PathSource::new_remote(resolved_url.into_owned());
+      self
+        .setup_and_store(&hash, &cache_key, &resolved_source, file_bytes, plugin_kind, None, None)
+        .await
+        .with_context(|| format!("Setting up {}", source_reference.display()))?;
     }
+
+    Ok(checksum)
   }
 
   /// Gets a plugin from a local path (node_modules). No checksum required since it's a local file.
@@ -319,26 +403,8 @@ where
       .await
   }
 
-  /// Sets up and caches a remote/local plugin from bytes already downloaded
-  /// elsewhere — e.g. `dprint add` downloads a Wasm/JSON plugin to compute its
-  /// checksum, then hands the bytes here so the first `dprint fmt` is a cache
-  /// hit instead of downloading and compiling again. Returns early on a hit.
-  async fn setup_remote_plugin_from_bytes(&self, source_reference: &PluginSourceReference, file_bytes: Vec<u8>) -> Result<()> {
-    let (cache_key, hash, _setup_guard) = match self.lookup_or_lock(&source_reference.path_source).await? {
-      CacheLookup::Hit(_) => return Ok(()),
-      CacheLookup::Miss { cache_key, hash, guard } => (cache_key, hash, guard),
-    };
-    let primary_stamp = source_reference.path_source.maybe_local_path().and_then(|p| self.stamp_for(p));
-    let resolved_source = source_reference.path_source.clone();
-    self
-      .verify_and_store_plugin(source_reference, &cache_key, &hash, file_bytes, resolved_source, primary_stamp)
-      .await?;
-    Ok(())
-  }
-
-  /// Shared tail of plugin setup once the file bytes are in hand (whether
-  /// freshly downloaded by `get_plugin` or handed in pre-downloaded): verifies
-  /// the checksum, computes local stamps, and stores the cached entry.
+  /// Shared tail of plugin setup once the file bytes are in hand: verifies the
+  /// checksum, computes local stamps, and stores the cached entry.
   async fn verify_and_store_plugin(
     &self,
     source_reference: &PluginSourceReference,
@@ -682,18 +748,20 @@ mod test {
   }
 
   #[tokio::test]
-  async fn setup_remote_plugin_from_bytes_warms_cache_without_download() -> Result<()> {
-    // the remote url is intentionally NOT registered — a later resolve must be
-    // a pure cache hit, proving the prefetch set the plugin up from the bytes
-    // without going to the network.
+  async fn resolve_remote_for_add_returns_checksum_and_warms_cache() -> Result<()> {
     let environment = TestEnvironment::new();
     environment.set_cpu_arch("aarch64");
+    environment.add_remote_file("https://plugins.dprint.dev/test.wasm", WASM_PLUGIN_BYTES);
+    let expected = crate::utils::get_sha256_checksum(WASM_PLUGIN_BYTES);
     let plugin_cache = PluginCache::new(environment.clone());
     let plugin_source = PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test.wasm");
 
-    plugin_cache.setup_remote_plugin_from_bytes(&plugin_source, WASM_PLUGIN_BYTES.to_vec()).await?;
+    let checksum = plugin_cache.resolve_remote_for_add(&plugin_source).await?;
+    assert_eq!(checksum, expected);
+    // it compiled while warming the cache
     assert_eq!(environment.take_stderr_messages(), vec!["Compiling https://plugins.dprint.dev/test.wasm"]);
 
+    // the later resolve is a pure cache hit — no recompile
     let item = plugin_cache.get_plugin_cache_item(&plugin_source).await?;
     assert_eq!(item.info.name, "test-plugin");
     assert!(environment.take_stderr_messages().is_empty(), "resolve should have been a cache hit");
@@ -701,25 +769,36 @@ mod test {
   }
 
   #[tokio::test]
-  async fn setup_from_prefetched_download_warms_npm_cache_without_download() -> Result<()> {
+  async fn resolve_npm_for_add_detects_path_checksums_and_warms_cache() -> Result<()> {
     use crate::test_helpers::create_test_npm_tarball;
-    // neither the registry packument nor the tarball are registered — the
-    // prefetch must set the plugin up entirely from the provided tarball bytes,
-    // and the later resolve must be a cache hit.
     let environment = TestEnvironment::new();
     environment.set_cpu_arch("aarch64");
+    let packument = serde_json::json!({
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
     let tarball = create_test_npm_tarball(&[("package/plugin.wasm", WASM_PLUGIN_BYTES)]);
-    let checksum = crate::utils::get_sha256_checksum(&tarball);
+    let expected = crate::utils::get_sha256_checksum(&tarball);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz", tarball);
     let plugin_cache = PluginCache::new(environment.clone());
+    // pathless specifier → kind detected from the package
+    let specifier = NpmSpecifier {
+      name: "foo".to_string(),
+      version: Some("1.0.0".to_string()),
+      path: "plugin.wasm".to_string(),
+    };
+
+    let resolution = plugin_cache.resolve_npm_for_add(&specifier, false, None).await?;
+    assert_eq!(resolution.path, "plugin.wasm");
+    assert_eq!(resolution.checksum, expected);
+    let _ = environment.take_stderr_messages();
+
+    // the config entry the caller would write now resolves as a cache hit
     let reference = crate::plugins::parse_plugin_source_reference(
-      &format!("npm:foo@1.0.0/plugin.wasm@{}", checksum),
+      &format!("npm:foo@1.0.0@{}", expected),
       &PathSource::new_local(crate::environment::CanonicalizedPathBuf::new_for_testing("/dprint.json")),
       &environment,
     )?;
-
-    plugin_cache.setup_from_prefetched_download(&reference, tarball).await?;
-    let _ = environment.take_stderr_messages();
-
     let item = plugin_cache.get_plugin_cache_item(&reference).await?;
     assert_eq!(item.info.name, "test-plugin");
     assert!(environment.take_stderr_messages().is_empty(), "resolve should have been a cache hit");

--- a/crates/dprint/src/plugins/implementations/public.rs
+++ b/crates/dprint/src/plugins/implementations/public.rs
@@ -33,16 +33,25 @@ pub struct SetupPluginDest {
   pub process_dir_path: PathBuf,
 }
 
-pub async fn setup_plugin<TEnvironment: Environment>(
-  resolved_source: &PathSource,
-  file_bytes: Vec<u8>,
-  plugin_kind: PluginKind,
-  pre_resolved_tarball: Option<crate::plugins::npm_resolution::PreResolvedProcessPluginTarball>,
-  dest: &SetupPluginDest,
-  environment: &TEnvironment,
-) -> Result<SetupPluginResult> {
-  // pass the resolved source to setup functions so process plugins can
-  // resolve relative paths in their manifest after a redirect
+/// Inputs to [`setup_plugin`] (everything but the environment).
+pub struct SetupPluginOptions<'a> {
+  /// The plugin's source, post-redirect, so process plugins can resolve
+  /// relative paths in their manifest.
+  pub resolved_source: &'a PathSource,
+  pub file_bytes: Vec<u8>,
+  pub plugin_kind: PluginKind,
+  pub pre_resolved_tarball: Option<crate::plugins::npm_resolution::PreResolvedProcessPluginTarball>,
+  pub dest: &'a SetupPluginDest,
+}
+
+pub async fn setup_plugin<TEnvironment: Environment>(options: SetupPluginOptions<'_>, environment: &TEnvironment) -> Result<SetupPluginResult> {
+  let SetupPluginOptions {
+    resolved_source,
+    file_bytes,
+    plugin_kind,
+    pre_resolved_tarball,
+    dest,
+  } = options;
   match plugin_kind {
     PluginKind::Wasm => wasm::setup_wasm_plugin(resolved_source, file_bytes, &dest.wasm_file_path, environment).await,
     PluginKind::Process => process::setup_process_plugin(resolved_source, &file_bytes, pre_resolved_tarball, &dest.process_dir_path, environment).await,

--- a/crates/dprint/src/plugins/mod.rs
+++ b/crates/dprint/src/plugins/mod.rs
@@ -23,5 +23,7 @@ pub use name_resolution::PluginNameResolutionMaps;
 pub use npm_resolution::FetchNpmLatestInfo;
 pub use npm_resolution::detect_npm_plugin_kind_in_node_modules;
 pub use npm_resolution::fetch_npm_latest_info;
+pub use npm_resolution::fetch_npm_latest_tarball_download;
 pub use npm_resolution::fetch_npm_latest_tarball_info;
+pub use npm_resolution::fetch_npm_versioned_tarball_download;
 pub use npm_resolution::fetch_npm_versioned_tarball_info;

--- a/crates/dprint/src/plugins/mod.rs
+++ b/crates/dprint/src/plugins/mod.rs
@@ -23,7 +23,4 @@ pub use name_resolution::PluginNameResolutionMaps;
 pub use npm_resolution::FetchNpmLatestInfo;
 pub use npm_resolution::detect_npm_plugin_kind_in_node_modules;
 pub use npm_resolution::fetch_npm_latest_info;
-pub use npm_resolution::fetch_npm_latest_tarball_download;
-pub use npm_resolution::fetch_npm_latest_tarball_info;
-pub use npm_resolution::fetch_npm_versioned_tarball_download;
-pub use npm_resolution::fetch_npm_versioned_tarball_info;
+pub use npm_resolution::resolve_npm_latest_version;

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -123,23 +123,31 @@ pub async fn resolve_npm_latest_version(name: &str, start_dir: Option<&Path>, en
   latest_version_from_packument(&packument, name)
 }
 
-/// Reads the cached tarball sidecar for `name@version`, if present. Lets
-/// `dprint add` reuse a prior setup's checksum + kind without re-downloading.
-pub fn read_npm_add_cache(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Option<NpmAddCacheEntry> {
+/// Reads the cached tarball checksum for `name@version`, if a prior setup
+/// recorded one. The checksum is a package-version property (the same for any
+/// plugin file the package ships), so `dprint add` can reuse it without
+/// re-downloading the tarball.
+pub fn read_npm_tarball_checksum(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Option<String> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
   let registry_segment = registry_dir_segment(&registry.url);
-  let meta = read_npm_tarball_meta(&registry_segment, name, version, environment)?;
-  Some(NpmAddCacheEntry {
-    tarball_sha256: meta.tarball_sha256,
-    plugin_kind: meta.plugin_kind,
-  })
+  Some(read_npm_tarball_meta(&registry_segment, name, version, environment)?.tarball_sha256)
 }
 
-/// A tarball checksum + kind recovered from the sidecar cache (see
-/// [`read_npm_add_cache`]).
-pub struct NpmAddCacheEntry {
-  pub tarball_sha256: String,
-  pub plugin_kind: PluginKind,
+/// For a pathless `dprint add` on a repeat add: if `name@version` is already
+/// extracted in the cache, detect which plugin file it ships (preferring
+/// `plugin.wasm` over `plugin.json`) without re-downloading. Returns the path
+/// and its kind, or `None` if the package isn't extracted or ships neither
+/// conventional file (so the caller falls back to a full download).
+pub fn detect_extracted_npm_plugin(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Option<(String, PluginKind)> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let registry_segment = registry_dir_segment(&registry.url);
+  let extract_dir = get_npm_extract_dir(&registry_segment, name, version, environment);
+  if !environment.path_exists(&extract_dir) {
+    return None;
+  }
+  let path = detect_plugin_path_in_dir(&extract_dir, environment)?;
+  let kind = plugin_kind_from_path(&path);
+  Some((path, kind))
 }
 
 /// Inspects whether an npm package installed in `node_modules` (walking up from
@@ -343,9 +351,9 @@ pub async fn resolve_npm_from_registry(options: ResolveNpmRegistryOptions<'_>, e
     None
   };
 
-  // record the tarball's checksum + kind so a later `dprint add` of the same
-  // version can reuse them without re-downloading the tarball. Best-effort.
-  write_npm_tarball_meta(&registry_segment, &specifier.name, version, &tarball_sha256, plugin_kind, environment);
+  // record the tarball's checksum so a later `dprint add` of the same version
+  // can reuse it without re-downloading the tarball. Best-effort.
+  write_npm_tarball_meta(&registry_segment, &specifier.name, version, &tarball_sha256, environment);
 
   Ok(NpmResolvedPlugin {
     plugin_bytes,
@@ -644,23 +652,20 @@ pub(super) fn get_npm_extract_dir(registry_segment: &str, package_name: &str, ve
   environment.get_cache_dir().join("npm").join(registry_segment).join(dir_name)
 }
 
-/// The tarball's checksum and plugin kind, cached so a later `dprint add` of the
-/// same `name@version` can reuse them without re-downloading the tarball.
-///
-/// `plugin_kind` is the kind of the plugin file that was set up (derived from
-/// its path), not a fresh inspection of the archive — these only diverge for
-/// the unlikely package shipping both a plugin.wasm and plugin.json, and even
-/// then the cached kind names a file that provably exists. If a registry ever
-/// republishes the same version with different bytes the cached checksum goes
-/// stale, but that fails closed: the next `dprint fmt` re-downloads and errors
-/// on the mismatch rather than trusting it (and `clear-cache` fixes it).
+/// The tarball's SHA-256, cached so a later `dprint add` of the same
+/// `name@version` can reuse it without re-downloading the tarball. The checksum
+/// is a package-version property — the same regardless of which plugin file in
+/// the package an entry points at — so only it is cached here; the plugin kind
+/// is always derived from the specifier path or the extracted files. If a
+/// registry ever republishes the same version with different bytes the cached
+/// checksum goes stale, but that fails closed: the next `dprint fmt`
+/// re-downloads and errors on the mismatch (and `clear-cache` fixes it).
 struct NpmTarballMeta {
   tarball_sha256: String,
-  plugin_kind: PluginKind,
 }
 
-/// Path of the sidecar file caching a tarball's checksum + kind, kept next to
-/// (not inside) the `name@version` extract directory so it doesn't mix with the
+/// Path of the sidecar file caching a tarball's checksum, kept next to (not
+/// inside) the `name@version` extract directory so it doesn't mix with the
 /// package's own files. Wiped by `dprint clear-cache` along with the rest of
 /// the npm cache.
 fn npm_tarball_meta_path(registry_segment: &str, package_name: &str, version: &str, environment: &impl Environment) -> PathBuf {
@@ -674,29 +679,13 @@ fn read_npm_tarball_meta(registry_segment: &str, package_name: &str, version: &s
   let text = environment.read_file(&path).ok()?;
   let value: serde_json::Value = serde_json::from_str(&text).ok()?;
   let tarball_sha256 = value.get("tarballChecksum")?.as_str()?.to_string();
-  let plugin_kind = match value.get("pluginKind")?.as_str()? {
-    "wasm" => PluginKind::Wasm,
-    "process" => PluginKind::Process,
-    _ => return None,
-  };
-  Some(NpmTarballMeta { tarball_sha256, plugin_kind })
+  Some(NpmTarballMeta { tarball_sha256 })
 }
 
 /// Writes the tarball sidecar. Best-effort — a failure just means the next
 /// `dprint add` re-downloads to recompute the checksum.
-fn write_npm_tarball_meta(
-  registry_segment: &str,
-  package_name: &str,
-  version: &str,
-  tarball_sha256: &str,
-  plugin_kind: PluginKind,
-  environment: &impl Environment,
-) {
-  let kind = match plugin_kind {
-    PluginKind::Wasm => "wasm",
-    PluginKind::Process => "process",
-  };
-  let json = serde_json::json!({ "tarballChecksum": tarball_sha256, "pluginKind": kind });
+fn write_npm_tarball_meta(registry_segment: &str, package_name: &str, version: &str, tarball_sha256: &str, environment: &impl Environment) {
+  let json = serde_json::json!({ "tarballChecksum": tarball_sha256 });
   let path = npm_tarball_meta_path(registry_segment, package_name, version, environment);
   let _ = environment.write_file(&path, &json.to_string());
 }
@@ -1536,11 +1525,17 @@ mod tests {
     assert_eq!(resolved.plugin_kind, PluginKind::Wasm);
     assert_eq!(resolved.tarball_checksum.as_deref(), Some(expected.as_str()));
 
-    // the setup wrote the sidecar, so a later add can read the checksum + kind
-    // without re-downloading.
-    let entry = read_npm_add_cache("foo", "1.0.0", None, &environment).unwrap();
-    assert_eq!(entry.tarball_sha256, expected);
-    assert_eq!(entry.plugin_kind, PluginKind::Wasm);
+    // the setup wrote the checksum sidecar, so a later add can reuse it...
+    assert_eq!(
+      read_npm_tarball_checksum("foo", "1.0.0", None, &environment).as_deref(),
+      Some(expected.as_str())
+    );
+    // ...and re-detect the plugin file from the already-extracted package
+    // (no package-level cached "kind").
+    assert_eq!(
+      detect_extracted_npm_plugin("foo", "1.0.0", None, &environment),
+      Some(("plugin.wasm".to_string(), PluginKind::Wasm))
+    );
   }
 
   #[test]

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -40,6 +40,13 @@ pub struct NpmResolvedPlugin {
   /// checksum) so the executable can be unpacked alongside any sibling
   /// files it depends on — node_modules-style installs, data files, etc.
   pub pre_resolved_tarball: Option<PreResolvedProcessPluginTarball>,
+  /// The plugin file path within the package — the same as `specifier.path`,
+  /// except when the path was detected (pathless `dprint add`), in which case
+  /// it's the detected `plugin.wasm` / `plugin.json`.
+  pub resolved_path: String,
+  /// SHA-256 of the package tarball. For `dprint add` this is the checksum to
+  /// write into the config. `None` for node_modules resolution (no tarball).
+  pub tarball_checksum: Option<String>,
 }
 
 /// Per-platform npm tarball that's been fetched and SHA-verified for a
@@ -76,33 +83,6 @@ pub struct FetchNpmLatestInfo<'a> {
   pub want_tarball_sha: bool,
 }
 
-/// The plugin kind and tarball checksum for a specific `name@version`,
-/// discovered by downloading and inspecting the package tarball. The downloaded
-/// `tarball_bytes` are carried back so the caller can set the plugin up without
-/// re-downloading (see `dprint add`).
-pub struct NpmTarballInfo {
-  pub plugin_kind: PluginKind,
-  pub tarball_sha256: String,
-  pub tarball_bytes: Option<Vec<u8>>,
-}
-
-/// Like [`NpmTarballInfo`], but for the latest published version — carries the
-/// resolved version alongside the inspected kind, checksum, and tarball bytes.
-pub struct NpmLatestTarballInfo {
-  pub version: String,
-  pub plugin_kind: PluginKind,
-  pub tarball_sha256: String,
-  pub tarball_bytes: Option<Vec<u8>>,
-}
-
-/// A downloaded package tarball with its checksum, but no plugin-kind
-/// inspection — for explicit-path `dprint add` where the kind is already known.
-pub struct NpmTarballDownload {
-  pub version: String,
-  pub tarball_sha256: String,
-  pub tarball_bytes: Option<Vec<u8>>,
-}
-
 /// Fetches the latest version of an npm-distributed plugin (and, when needed,
 /// the SHA-256 of its tarball). Used by `dprint config update` and `dprint add`.
 pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &impl Environment) -> Result<NpmLatestInfo> {
@@ -135,100 +115,31 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
   })
 }
 
-/// Resolves the latest version, then downloads its tarball to determine whether
-/// the package ships a `plugin.wasm` or `plugin.json` and to compute the
-/// checksum. Used by `dprint add` when the user gave an unversioned npm
-/// specifier without a plugin path.
-pub async fn fetch_npm_latest_tarball_info(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmLatestTarballInfo> {
+/// Resolves the latest published version of a package from its packument.
+/// Used by `dprint add` to pin an unversioned specifier before setup.
+pub async fn resolve_npm_latest_version(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<String> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let (packument, _) = fetch_packument(name, &registry, environment).await?;
+  latest_version_from_packument(&packument, name)
+}
+
+/// Reads the cached tarball sidecar for `name@version`, if present. Lets
+/// `dprint add` reuse a prior setup's checksum + kind without re-downloading.
+pub fn read_npm_add_cache(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Option<NpmAddCacheEntry> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
   let registry_segment = registry_dir_segment(&registry.url);
-  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
-  let version = latest_version_from_packument(&packument, name)?;
-  // a prior add/format already extracted this version — reuse the cached
-  // checksum + kind instead of re-downloading the tarball.
-  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, &version, environment) {
-    return Ok(NpmLatestTarballInfo {
-      version,
-      plugin_kind: meta.plugin_kind,
-      tarball_sha256: meta.tarball_sha256,
-      tarball_bytes: None,
-    });
-  }
-  let info = inspect_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
-  Ok(NpmLatestTarballInfo {
-    version,
-    plugin_kind: info.plugin_kind,
-    tarball_sha256: info.tarball_sha256,
-    tarball_bytes: info.tarball_bytes,
+  let meta = read_npm_tarball_meta(&registry_segment, name, version, environment)?;
+  Some(NpmAddCacheEntry {
+    tarball_sha256: meta.tarball_sha256,
+    plugin_kind: meta.plugin_kind,
   })
 }
 
-/// Downloads the tarball for a specific `name@version`, inspects it to
-/// determine whether the package ships a `plugin.wasm` or `plugin.json`, and
-/// computes its SHA-256. Used by `dprint add` when the user pins a version but
-/// doesn't give a plugin path. Reuses the cached checksum sidecar when present.
-pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballInfo> {
-  let registry = resolve_registry_for_package(name, start_dir, environment);
-  let registry_segment = registry_dir_segment(&registry.url);
-  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, version, environment) {
-    return Ok(NpmTarballInfo {
-      plugin_kind: meta.plugin_kind,
-      tarball_sha256: meta.tarball_sha256,
-      tarball_bytes: None,
-    });
-  }
-  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
-  inspect_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await
-}
-
-/// Downloads a package tarball and computes its checksum, **without** inspecting
-/// the contents for a plugin kind. Used by `dprint add` when the user already
-/// gave an explicit plugin path (so the kind is known) but a checksum still
-/// needs computing — kind detection would wrongly require a root `plugin.wasm`
-/// / `plugin.json` there. Reuses the cached checksum sidecar when present.
-pub async fn fetch_npm_latest_tarball_download(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballDownload> {
-  let registry = resolve_registry_for_package(name, start_dir, environment);
-  let registry_segment = registry_dir_segment(&registry.url);
-  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
-  let version = latest_version_from_packument(&packument, name)?;
-  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, &version, environment) {
-    return Ok(NpmTarballDownload {
-      version,
-      tarball_sha256: meta.tarball_sha256,
-      tarball_bytes: None,
-    });
-  }
-  let tarball_bytes = download_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
-  Ok(NpmTarballDownload {
-    version,
-    tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes: Some(tarball_bytes),
-  })
-}
-
-/// Like [`fetch_npm_latest_tarball_download`] but for an explicit version.
-pub async fn fetch_npm_versioned_tarball_download(
-  name: &str,
-  version: &str,
-  start_dir: Option<&Path>,
-  environment: &impl Environment,
-) -> Result<NpmTarballDownload> {
-  let registry = resolve_registry_for_package(name, start_dir, environment);
-  let registry_segment = registry_dir_segment(&registry.url);
-  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, version, environment) {
-    return Ok(NpmTarballDownload {
-      version: version.to_string(),
-      tarball_sha256: meta.tarball_sha256,
-      tarball_bytes: None,
-    });
-  }
-  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
-  let tarball_bytes = download_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await?;
-  Ok(NpmTarballDownload {
-    version: version.to_string(),
-    tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes: Some(tarball_bytes),
-  })
+/// A tarball checksum + kind recovered from the sidecar cache (see
+/// [`read_npm_add_cache`]).
+pub struct NpmAddCacheEntry {
+  pub tarball_sha256: String,
+  pub plugin_kind: PluginKind,
 }
 
 /// Inspects whether an npm package installed in `node_modules` (walking up from
@@ -271,110 +182,67 @@ fn latest_version_from_packument(packument: &serde_json::Value, name: &str) -> R
     .ok_or_else(|| anyhow::anyhow!("Missing dist-tags.latest for {}", name))
 }
 
-/// Downloads `name@version`'s tarball (auth sent only when it shares the
-/// registry's origin) and inspects it to determine the plugin kind and
-/// checksum.
-async fn inspect_npm_tarball(
-  name: &str,
-  version: &str,
-  packument: &serde_json::Value,
-  packument_url: &url::Url,
-  registry: &NpmRegistryResolution,
-  environment: &impl Environment,
-) -> Result<NpmTarballInfo> {
-  let tarball_bytes = download_npm_tarball(name, version, packument, packument_url, registry, environment).await?;
-  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_bytes).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
-  Ok(NpmTarballInfo {
-    plugin_kind,
-    tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes: Some(tarball_bytes),
-  })
-}
-
-/// Downloads `name@version`'s tarball bytes (auth sent only when the tarball
-/// shares the registry's origin), without inspecting the contents.
-async fn download_npm_tarball(
-  name: &str,
-  version: &str,
-  packument: &serde_json::Value,
-  packument_url: &url::Url,
-  registry: &NpmRegistryResolution,
-  environment: &impl Environment,
-) -> Result<Vec<u8>> {
-  let tarball_url_str = get_tarball_url_from_packument(packument, version, name)?;
-  let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
-  let tarball_auth = same_origin_auth(packument_url, &tarball_url, registry.auth_header.as_deref());
-  let (_, tarball_file) = environment
-    .download_file_err_404(&tarball_url, tarball_auth)
-    .await
-    .with_context(|| format!("Failed to download npm tarball for {}@{}", name, version))?;
-  Ok(tarball_file.content)
-}
-
-/// Inspects an npm tarball to determine whether it ships a top-level
-/// `plugin.wasm` (wasm plugin) or `plugin.json` (process plugin), preferring
-/// wasm if (unusually) both are present. Errors if neither is found.
-fn detect_plugin_kind_from_tarball(tarball_bytes: &[u8]) -> Result<PluginKind> {
-  let decoder = GzDecoder::new(tarball_bytes);
-  let mut archive = Archive::new(decoder);
-  let mut has_wasm = false;
-  let mut has_json = false;
-
-  for entry in archive.entries().context("Failed to read npm tarball entries")? {
-    let entry = entry.context("Failed to read npm tarball entry")?;
-    let path = entry.path().context("Failed to get entry path")?;
-
-    // npm tarballs wrap every entry under a single top-level directory (usually
-    // "package/"). Skip any leading "./" then that wrapper so we compare paths
-    // relative to the package root.
-    let mut components = path.components().peekable();
-    while let Some(std::path::Component::CurDir) = components.peek() {
-      components.next();
-    }
-    if components.next().is_none() {
-      continue; // the wrapper directory entry itself
-    }
-
-    // only a plugin file sitting directly at the package root counts
-    let relative: PathBuf = components.collect();
-    let mut relative_components = relative.components();
-    let (Some(std::path::Component::Normal(file_name)), None) = (relative_components.next(), relative_components.next()) else {
-      continue;
-    };
-    let Some(file_name) = file_name.to_str() else {
-      continue;
-    };
-    if file_name.eq_ignore_ascii_case("plugin.wasm") {
-      has_wasm = true;
-    } else if file_name.eq_ignore_ascii_case("plugin.json") {
-      has_json = true;
-    }
-  }
-
-  if has_wasm {
-    Ok(PluginKind::Wasm)
-  } else if has_json {
-    Ok(PluginKind::Process)
+/// Picks the plugin file a package ships at its root, preferring `plugin.wasm`
+/// over `plugin.json` if (unusually) both are present. Returns `None` if
+/// neither exists. Run against the extracted package directory for a pathless
+/// `dprint add`.
+fn detect_plugin_path_in_dir(extract_dir: &Path, environment: &impl Environment) -> Option<String> {
+  if environment.path_exists(extract_dir.join("plugin.wasm")) {
+    Some("plugin.wasm".to_string())
+  } else if environment.path_exists(extract_dir.join("plugin.json")) {
+    Some("plugin.json".to_string())
   } else {
-    bail!("Could not find a plugin.wasm or plugin.json at the root of the npm package. Is it a dprint plugin?");
+    None
   }
 }
 
-/// Resolves an npm plugin from the registry (versioned specifier).
-/// Downloads the tarball, extracts it to the cache directory, and reads the plugin file.
-/// `config_dir` is the dprint config's directory; it seeds the `.npmrc` walk
-/// when a process plugin's plugin.json references a per-platform npm package.
-pub async fn resolve_npm_from_registry(
-  specifier: &NpmSpecifier,
-  checksum: Option<&str>,
-  registry: &NpmRegistryResolution,
-  config_dir: Option<&Path>,
-  environment: &impl Environment,
-) -> Result<NpmResolvedPlugin> {
+/// Maps a plugin file path to its kind by extension (`.json` → process, else
+/// wasm), matching `NpmSpecifier::plugin_kind`.
+fn plugin_kind_from_path(path: &str) -> PluginKind {
+  if path.rsplit_once('.').is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("json")) {
+    PluginKind::Process
+  } else {
+    PluginKind::Wasm
+  }
+}
+
+/// Inputs to [`resolve_npm_from_registry`].
+pub struct ResolveNpmRegistryOptions<'a> {
+  /// The package to resolve. Must carry a concrete version.
+  pub specifier: &'a NpmSpecifier,
+  /// Expected checksum to verify the tarball against. Ignored when
+  /// `establish_checksum` is set (we're computing it, not verifying).
+  pub checksum: Option<&'a str>,
+  /// Pathless `dprint add`: ignore `specifier.path` and detect the plugin file
+  /// (`plugin.wasm` / `plugin.json`) from the extracted package instead.
+  pub detect_path: bool,
+  /// `dprint add` mode: compute the checksum from the download rather than
+  /// requiring one for process plugins. `dprint fmt` leaves this false so a
+  /// process plugin without a checksum is still rejected.
+  pub establish_checksum: bool,
+  pub registry: &'a NpmRegistryResolution,
+  /// The dprint config's directory; seeds the `.npmrc` walk when a process
+  /// plugin's plugin.json references a per-platform npm package.
+  pub config_dir: Option<&'a Path>,
+}
+
+/// Resolves an npm plugin from the registry (versioned specifier): downloads the
+/// tarball, verifies (or computes) its checksum, extracts it, reads the plugin
+/// file, and resolves the per-platform binary for process plugins.
+pub async fn resolve_npm_from_registry(options: ResolveNpmRegistryOptions<'_>, environment: &impl Environment) -> Result<NpmResolvedPlugin> {
+  let ResolveNpmRegistryOptions {
+    specifier,
+    checksum,
+    detect_path,
+    establish_checksum,
+    registry,
+    config_dir,
+  } = options;
   let version = specifier
     .version
     .as_deref()
     .ok_or_else(|| anyhow::anyhow!("Cannot resolve npm plugin without a version from the registry"))?;
+  let registry_segment = registry_dir_segment(&registry.url);
 
   // fetch the packument to get the tarball URL
   let packument_url_str = get_packument_url(&registry.url, &specifier.name);
@@ -398,82 +266,54 @@ pub async fn resolve_npm_from_registry(
     .download_file_err_404(&tarball_url, tarball_auth)
     .await
     .with_context(|| format!("Failed to download npm tarball for {}@{}", specifier.name, version))?;
+  let tarball_bytes = tarball_file.content;
 
-  setup_npm_registry_tarball(specifier, checksum, tarball_file.content, registry, config_dir, environment).await
-}
+  let tarball_sha256 = get_sha256_checksum(&tarball_bytes);
 
-/// Like [`resolve_npm_from_registry`] but reuses tarball bytes that were
-/// already downloaded (e.g. by `dprint add` when computing a checksum), so the
-/// tarball isn't fetched a second time. The checksum is still verified against
-/// the provided bytes.
-pub async fn resolve_npm_from_prefetched_tarball(
-  specifier: &NpmSpecifier,
-  checksum: Option<&str>,
-  tarball_bytes: Vec<u8>,
-  registry: &NpmRegistryResolution,
-  config_dir: Option<&Path>,
-  environment: &impl Environment,
-) -> Result<NpmResolvedPlugin> {
-  setup_npm_registry_tarball(specifier, checksum, tarball_bytes, registry, config_dir, environment).await
-}
-
-/// Verifies a registry tarball's checksum, extracts it to the npm cache, reads
-/// the plugin file, and (for process plugins) resolves the per-platform
-/// binary. Shared by the download and prefetched-bytes entry points above.
-async fn setup_npm_registry_tarball(
-  specifier: &NpmSpecifier,
-  checksum: Option<&str>,
-  tarball_bytes: Vec<u8>,
-  registry: &NpmRegistryResolution,
-  config_dir: Option<&Path>,
-  environment: &impl Environment,
-) -> Result<NpmResolvedPlugin> {
-  let version = specifier
-    .version
-    .as_deref()
-    .ok_or_else(|| anyhow::anyhow!("Cannot resolve npm plugin without a version from the registry"))?;
-  let registry_segment = registry_dir_segment(&registry.url);
-
-  // verify checksum before doing any extraction work
-  let plugin_kind = specifier.plugin_kind();
-  if let Some(checksum) = checksum {
-    if let Err(err) = verify_sha256_checksum(&tarball_bytes, checksum) {
+  // verify the checksum before any extraction work — unless we're establishing
+  // it (add mode), where there's nothing to verify against yet.
+  if !establish_checksum {
+    if let Some(checksum) = checksum {
+      if tarball_sha256 != checksum {
+        bail!(
+          "Invalid checksum for npm package {}. Check the plugin's release notes for the expected checksum.\n\nActual: {}\nExpected: {}",
+          specifier.display(),
+          tarball_sha256,
+          checksum,
+        );
+      }
+    } else if specifier.plugin_kind() != PluginKind::Wasm {
       bail!(
-        "Invalid checksum for npm package {}. Check the plugin's release notes for the expected checksum.\n\n{:#}",
+        concat!(
+          "The npm plugin must have a checksum specified for security reasons ",
+          "since it is not a Wasm plugin. Check the plugin's release notes for what ",
+          "the checksum is or if you trust the source, you may specify: {}@{}"
+        ),
         specifier.display(),
-        err
+        tarball_sha256,
       );
     }
-  } else if plugin_kind != PluginKind::Wasm {
-    bail!(
-      concat!(
-        "The npm plugin must have a checksum specified for security reasons ",
-        "since it is not a Wasm plugin. Check the plugin's release notes for what ",
-        "the checksum is or if you trust the source, you may specify: {}@{}"
-      ),
-      specifier.display(),
-      get_sha256_checksum(&tarball_bytes),
-    );
   }
-
-  // the tarball's checksum, for the sidecar written after a successful setup
-  // (computed now, before `tarball_bytes` is moved into the blocking task).
-  let tarball_sha256 = match checksum {
-    Some(checksum) => checksum.to_string(),
-    None => get_sha256_checksum(&tarball_bytes),
-  };
 
   // extract and read the plugin file in a blocking task since
   // tarball decompression and file I/O can be slow
   let extract_dir = get_npm_extract_dir(&registry_segment, &specifier.name, version, environment);
-  let plugin_path = specifier.path.clone();
+  let requested_path = specifier.path.clone();
   let specifier_clone = specifier.clone();
   let environment_clone = environment.clone();
-  let (plugin_bytes, local_path) = dprint_core::async_runtime::spawn_blocking(move || -> Result<_> {
+  let (plugin_bytes, local_path, resolved_path) = dprint_core::async_runtime::spawn_blocking(move || -> Result<_> {
     let environment = environment_clone;
     extract_tarball_to_dir(&tarball_bytes, &extract_dir, &environment)?;
 
-    let plugin_file_path = extract_dir.join(&plugin_path);
+    // for a pathless add, pick whichever plugin file the package actually ships.
+    let resolved_path = if detect_path {
+      detect_plugin_path_in_dir(&extract_dir, &environment)
+        .ok_or_else(|| anyhow::anyhow!("Could not find a plugin.wasm or plugin.json in npm package {}", specifier_clone.name))?
+    } else {
+      requested_path
+    };
+
+    let plugin_file_path = extract_dir.join(&resolved_path);
     if !environment.path_exists(&plugin_file_path) {
       bail!(missing_plugin_file_message(
         &specifier_clone,
@@ -486,9 +326,11 @@ async fn setup_npm_registry_tarball(
       .read_file_bytes(&plugin_file_path)
       .with_context(|| format!("Failed to read {}", plugin_file_path.display()))?;
     let canonical = environment.canonicalize(&plugin_file_path)?;
-    Ok((plugin_bytes, PathSource::new_local(canonical)))
+    Ok((plugin_bytes, PathSource::new_local(canonical), resolved_path))
   })
   .await??;
+
+  let plugin_kind = plugin_kind_from_path(&resolved_path);
 
   // process plugins shipped via the npm registry mustn't silently fetch their
   // platform binary over http(s) at format time. For npm references in
@@ -510,6 +352,8 @@ async fn setup_npm_registry_tarball(
     plugin_kind,
     local_path,
     pre_resolved_tarball,
+    resolved_path,
+    tarball_checksum: Some(tarball_sha256),
   })
 }
 
@@ -549,6 +393,8 @@ pub async fn resolve_npm_from_node_modules(specifier: &NpmSpecifier, config_dir:
     plugin_kind: specifier.plugin_kind(),
     local_path,
     pre_resolved_tarball,
+    resolved_path: specifier.path.clone(),
+    tarball_checksum: None,
   })
 }
 
@@ -1623,135 +1469,78 @@ mod tests {
   }
 
   #[test]
-  fn detect_plugin_kind_from_tarball_distinguishes_wasm_and_process() {
-    use crate::test_helpers::create_test_npm_tarball;
-
-    let wasm = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
-    assert_eq!(detect_plugin_kind_from_tarball(&wasm).unwrap(), PluginKind::Wasm);
-
-    let process = create_test_npm_tarball(&[("package/plugin.json", b"{}"), ("package/package.json", b"{}")]);
-    assert_eq!(detect_plugin_kind_from_tarball(&process).unwrap(), PluginKind::Process);
-
+  fn detect_plugin_path_in_dir_prefers_wasm_then_json() {
+    use crate::environment::TestEnvironment;
+    let environment = TestEnvironment::new();
+    environment.mk_dir_all("/pkg").unwrap();
+    assert_eq!(detect_plugin_path_in_dir(std::path::Path::new("/pkg"), &environment), None);
+    environment.write_file("/pkg/plugin.json", "{}").unwrap();
+    assert_eq!(
+      detect_plugin_path_in_dir(std::path::Path::new("/pkg"), &environment).as_deref(),
+      Some("plugin.json")
+    );
     // wasm wins if a package unusually ships both
-    let both = create_test_npm_tarball(&[("package/plugin.json", b"{}"), ("package/plugin.wasm", b"\0asm")]);
-    assert_eq!(detect_plugin_kind_from_tarball(&both).unwrap(), PluginKind::Wasm);
+    environment.write_file("/pkg/plugin.wasm", "\0asm").unwrap();
+    assert_eq!(
+      detect_plugin_path_in_dir(std::path::Path::new("/pkg"), &environment).as_deref(),
+      Some("plugin.wasm")
+    );
+  }
 
-    // a plugin file nested below the root doesn't count
-    let nested = create_test_npm_tarball(&[("package/sub/plugin.json", b"{}")]);
-    assert!(detect_plugin_kind_from_tarball(&nested).is_err());
-
-    let neither = create_test_npm_tarball(&[("package/index.js", b"")]);
-    let err = detect_plugin_kind_from_tarball(&neither).unwrap_err().to_string();
-    assert!(err.contains("plugin.wasm or plugin.json"), "got: {err}");
+  #[test]
+  fn plugin_kind_from_path_by_extension() {
+    assert_eq!(plugin_kind_from_path("plugin.wasm"), PluginKind::Wasm);
+    assert_eq!(plugin_kind_from_path("plugin.json"), PluginKind::Process);
+    assert_eq!(plugin_kind_from_path("sub/plugin.JSON"), PluginKind::Process);
+    assert_eq!(plugin_kind_from_path("foo"), PluginKind::Wasm);
   }
 
   #[tokio::test]
-  async fn fetch_npm_latest_tarball_info_resolves_detects_and_checksums() {
+  async fn resolve_npm_from_registry_add_mode_detects_path_checksums_and_writes_sidecar() {
     use crate::environment::TestEnvironment;
     use crate::test_helpers::create_test_npm_tarball;
 
     let environment = TestEnvironment::new();
     let packument = serde_json::json!({
-      "dist-tags": { "latest": "3.0.0" },
-      "versions": { "3.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-3.0.0.tgz" } } }
-    });
-    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.json", b"{}")]);
-    let expected_checksum = get_sha256_checksum(&tarball_bytes);
-    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-3.0.0.tgz", tarball_bytes);
-
-    let info = fetch_npm_latest_tarball_info("foo", None, &environment).await.unwrap();
-    assert_eq!(info.version, "3.0.0");
-    assert_eq!(info.plugin_kind, PluginKind::Process);
-    assert_eq!(info.tarball_sha256, expected_checksum);
-  }
-
-  #[tokio::test]
-  async fn fetch_npm_versioned_tarball_info_detects_and_checksums() {
-    use crate::environment::TestEnvironment;
-    use crate::test_helpers::create_test_npm_tarball;
-
-    let environment = TestEnvironment::new();
-    let packument = serde_json::json!({
-      "dist-tags": { "latest": "9.9.9" },
-      "versions": { "1.2.3": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" } } }
-    });
-    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
-    let tarball_bytes = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
-    let expected_checksum = get_sha256_checksum(&tarball_bytes);
-    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.2.3.tgz", tarball_bytes);
-
-    let info = fetch_npm_versioned_tarball_info("foo", "1.2.3", None, &environment).await.unwrap();
-    assert_eq!(info.plugin_kind, PluginKind::Wasm);
-    assert_eq!(info.tarball_sha256, expected_checksum);
-    assert!(info.tarball_bytes.is_some());
-  }
-
-  #[tokio::test]
-  async fn fetch_npm_versioned_tarball_info_reuses_cached_checksum_sidecar() {
-    use crate::environment::TestEnvironment;
-    use crate::test_helpers::create_test_npm_tarball;
-
-    let environment = TestEnvironment::new();
-    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
-    let checksum = get_sha256_checksum(&tarball);
-    let registry = NpmRegistryResolution {
-      url: "https://registry.npmjs.org".to_string(),
-      auth_header: None,
-    };
-    let specifier = NpmSpecifier {
-      name: "foo".to_string(),
-      version: Some("1.0.0".to_string()),
-      path: "plugin.wasm".to_string(),
-    };
-    // setting the plugin up writes the checksum sidecar (no network — we pass
-    // the tarball bytes directly).
-    resolve_npm_from_prefetched_tarball(&specifier, Some(&checksum), tarball, &registry, None, &environment)
-      .await
-      .unwrap();
-
-    // a later add reuses the sidecar instead of re-downloading — neither the
-    // packument nor the tarball are registered, so any fetch would error.
-    let info = fetch_npm_versioned_tarball_info("foo", "1.0.0", None, &environment).await.unwrap();
-    assert_eq!(info.plugin_kind, PluginKind::Wasm);
-    assert_eq!(info.tarball_sha256, checksum);
-    assert!(info.tarball_bytes.is_none(), "a sidecar hit must not re-download");
-  }
-
-  #[tokio::test]
-  async fn fetch_npm_latest_tarball_info_reuses_sidecar_but_still_resolves_version() {
-    use crate::environment::TestEnvironment;
-    use crate::test_helpers::create_test_npm_tarball;
-
-    let environment = TestEnvironment::new();
-    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
-    let checksum = get_sha256_checksum(&tarball);
-    let registry = NpmRegistryResolution {
-      url: "https://registry.npmjs.org".to_string(),
-      auth_header: None,
-    };
-    let specifier = NpmSpecifier {
-      name: "foo".to_string(),
-      version: Some("1.0.0".to_string()),
-      path: "plugin.wasm".to_string(),
-    };
-    resolve_npm_from_prefetched_tarball(&specifier, Some(&checksum), tarball, &registry, None, &environment)
-      .await
-      .unwrap();
-
-    // the packument is still needed to discover the latest version, but the
-    // tarball (intentionally not registered) must be served from the sidecar.
-    let packument = serde_json::json!({
-      "dist-tags": { "latest": "1.0.0" },
       "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
     });
     environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let expected = get_sha256_checksum(&tarball);
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz", tarball);
+    let registry = NpmRegistryResolution {
+      url: "https://registry.npmjs.org".to_string(),
+      auth_header: None,
+    };
+    // a defaulted path + add mode: detect the file, compute the checksum (no
+    // checksum required to verify), and record the sidecar.
+    let specifier = NpmSpecifier {
+      name: "foo".to_string(),
+      version: Some("1.0.0".to_string()),
+      path: "plugin.wasm".to_string(),
+    };
+    let resolved = resolve_npm_from_registry(
+      ResolveNpmRegistryOptions {
+        specifier: &specifier,
+        checksum: None,
+        detect_path: true,
+        establish_checksum: true,
+        registry: &registry,
+        config_dir: None,
+      },
+      &environment,
+    )
+    .await
+    .unwrap();
+    assert_eq!(resolved.resolved_path, "plugin.wasm");
+    assert_eq!(resolved.plugin_kind, PluginKind::Wasm);
+    assert_eq!(resolved.tarball_checksum.as_deref(), Some(expected.as_str()));
 
-    let info = fetch_npm_latest_tarball_info("foo", None, &environment).await.unwrap();
-    assert_eq!(info.version, "1.0.0");
-    assert_eq!(info.plugin_kind, PluginKind::Wasm);
-    assert_eq!(info.tarball_sha256, checksum);
-    assert!(info.tarball_bytes.is_none(), "a sidecar hit must not re-download the tarball");
+    // the setup wrote the sidecar, so a later add can read the checksum + kind
+    // without re-downloading.
+    let entry = read_npm_add_cache("foo", "1.0.0", None, &environment).unwrap();
+    assert_eq!(entry.tarball_sha256, expected);
+    assert_eq!(entry.plugin_kind, PluginKind::Wasm);
   }
 
   #[test]
@@ -2087,9 +1876,19 @@ mod tests {
       version: Some("1.0.0".to_string()),
       path: "plugin.wasm".to_string(),
     };
-    let _ = resolve_npm_from_registry(&specifier, Some(&tarball_checksum), &registry, None, &environment)
-      .await
-      .unwrap();
+    let _ = resolve_npm_from_registry(
+      ResolveNpmRegistryOptions {
+        specifier: &specifier,
+        checksum: Some(&tarball_checksum),
+        detect_path: false,
+        establish_checksum: false,
+        registry: &registry,
+        config_dir: None,
+      },
+      &environment,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
       environment.take_remote_file_auth("https://private.example.com/foo").as_deref(),
@@ -2126,9 +1925,19 @@ mod tests {
       version: Some("1.0.0".to_string()),
       path: "plugin.wasm".to_string(),
     };
-    let _ = resolve_npm_from_registry(&specifier, Some(&tarball_checksum), &registry, None, &environment)
-      .await
-      .unwrap();
+    let _ = resolve_npm_from_registry(
+      ResolveNpmRegistryOptions {
+        specifier: &specifier,
+        checksum: Some(&tarball_checksum),
+        detect_path: false,
+        establish_checksum: false,
+        registry: &registry,
+        config_dir: None,
+      },
+      &environment,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
       environment.take_remote_file_auth("https://private.example.com/foo").as_deref(),
@@ -2355,7 +2164,19 @@ mod tests {
       version: Some("0.6.2".to_string()),
       path: "plugin.wasm".to_string(),
     };
-    let err = match resolve_npm_from_registry(&specifier, Some(&tarball_checksum), &registry, None, &environment).await {
+    let err = match resolve_npm_from_registry(
+      ResolveNpmRegistryOptions {
+        specifier: &specifier,
+        checksum: Some(&tarball_checksum),
+        detect_path: false,
+        establish_checksum: false,
+        registry: &registry,
+        config_dir: None,
+      },
+      &environment,
+    )
+    .await
+    {
       Ok(_) => panic!("expected an error"),
       Err(e) => e,
     };

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -77,18 +77,30 @@ pub struct FetchNpmLatestInfo<'a> {
 }
 
 /// The plugin kind and tarball checksum for a specific `name@version`,
-/// discovered by downloading and inspecting the package tarball.
+/// discovered by downloading and inspecting the package tarball. The downloaded
+/// `tarball_bytes` are carried back so the caller can set the plugin up without
+/// re-downloading (see `dprint add`).
 pub struct NpmTarballInfo {
   pub plugin_kind: PluginKind,
   pub tarball_sha256: String,
+  pub tarball_bytes: Vec<u8>,
 }
 
 /// Like [`NpmTarballInfo`], but for the latest published version — carries the
-/// resolved version alongside the inspected kind and checksum.
+/// resolved version alongside the inspected kind, checksum, and tarball bytes.
 pub struct NpmLatestTarballInfo {
   pub version: String,
   pub plugin_kind: PluginKind,
   pub tarball_sha256: String,
+  pub tarball_bytes: Vec<u8>,
+}
+
+/// A downloaded package tarball with its checksum, but no plugin-kind
+/// inspection — for explicit-path `dprint add` where the kind is already known.
+pub struct NpmTarballDownload {
+  pub version: String,
+  pub tarball_sha256: String,
+  pub tarball_bytes: Vec<u8>,
 }
 
 /// Fetches the latest version of an npm-distributed plugin (and, when needed,
@@ -136,6 +148,7 @@ pub async fn fetch_npm_latest_tarball_info(name: &str, start_dir: Option<&Path>,
     version,
     plugin_kind: info.plugin_kind,
     tarball_sha256: info.tarball_sha256,
+    tarball_bytes: info.tarball_bytes,
   })
 }
 
@@ -147,6 +160,40 @@ pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_d
   let registry = resolve_registry_for_package(name, start_dir, environment);
   let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
   inspect_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await
+}
+
+/// Downloads a package tarball and computes its checksum, **without** inspecting
+/// the contents for a plugin kind. Used by `dprint add` when the user already
+/// gave an explicit plugin path (so the kind is known) but a checksum still
+/// needs computing — kind detection would wrongly require a root `plugin.wasm`
+/// / `plugin.json` there.
+pub async fn fetch_npm_latest_tarball_download(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballDownload> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
+  let version = latest_version_from_packument(&packument, name)?;
+  let tarball_bytes = download_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
+  Ok(NpmTarballDownload {
+    version,
+    tarball_sha256: get_sha256_checksum(&tarball_bytes),
+    tarball_bytes,
+  })
+}
+
+/// Like [`fetch_npm_latest_tarball_download`] but for an explicit version.
+pub async fn fetch_npm_versioned_tarball_download(
+  name: &str,
+  version: &str,
+  start_dir: Option<&Path>,
+  environment: &impl Environment,
+) -> Result<NpmTarballDownload> {
+  let registry = resolve_registry_for_package(name, start_dir, environment);
+  let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
+  let tarball_bytes = download_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await?;
+  Ok(NpmTarballDownload {
+    version: version.to_string(),
+    tarball_sha256: get_sha256_checksum(&tarball_bytes),
+    tarball_bytes,
+  })
 }
 
 /// Inspects whether an npm package installed in `node_modules` (walking up from
@@ -200,6 +247,25 @@ async fn inspect_npm_tarball(
   registry: &NpmRegistryResolution,
   environment: &impl Environment,
 ) -> Result<NpmTarballInfo> {
+  let tarball_bytes = download_npm_tarball(name, version, packument, packument_url, registry, environment).await?;
+  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_bytes).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
+  Ok(NpmTarballInfo {
+    plugin_kind,
+    tarball_sha256: get_sha256_checksum(&tarball_bytes),
+    tarball_bytes,
+  })
+}
+
+/// Downloads `name@version`'s tarball bytes (auth sent only when the tarball
+/// shares the registry's origin), without inspecting the contents.
+async fn download_npm_tarball(
+  name: &str,
+  version: &str,
+  packument: &serde_json::Value,
+  packument_url: &url::Url,
+  registry: &NpmRegistryResolution,
+  environment: &impl Environment,
+) -> Result<Vec<u8>> {
   let tarball_url_str = get_tarball_url_from_packument(packument, version, name)?;
   let tarball_url = url::Url::parse(&tarball_url_str).with_context(|| format!("Failed to parse npm tarball URL: {}", tarball_url_str))?;
   let tarball_auth = same_origin_auth(packument_url, &tarball_url, registry.auth_header.as_deref());
@@ -207,11 +273,7 @@ async fn inspect_npm_tarball(
     .download_file_err_404(&tarball_url, tarball_auth)
     .await
     .with_context(|| format!("Failed to download npm tarball for {}@{}", name, version))?;
-  let plugin_kind = detect_plugin_kind_from_tarball(&tarball_file.content).with_context(|| format!("Detecting plugin kind for {}@{}", name, version))?;
-  Ok(NpmTarballInfo {
-    plugin_kind,
-    tarball_sha256: get_sha256_checksum(&tarball_file.content),
-  })
+  Ok(tarball_file.content)
 }
 
 /// Inspects an npm tarball to determine whether it ships a top-level
@@ -278,7 +340,6 @@ pub async fn resolve_npm_from_registry(
     .version
     .as_deref()
     .ok_or_else(|| anyhow::anyhow!("Cannot resolve npm plugin without a version from the registry"))?;
-  let registry_segment = registry_dir_segment(&registry.url);
 
   // fetch the packument to get the tarball URL
   let packument_url_str = get_packument_url(&registry.url, &specifier.name);
@@ -302,7 +363,41 @@ pub async fn resolve_npm_from_registry(
     .download_file_err_404(&tarball_url, tarball_auth)
     .await
     .with_context(|| format!("Failed to download npm tarball for {}@{}", specifier.name, version))?;
-  let tarball_bytes = tarball_file.content;
+
+  setup_npm_registry_tarball(specifier, checksum, tarball_file.content, registry, config_dir, environment).await
+}
+
+/// Like [`resolve_npm_from_registry`] but reuses tarball bytes that were
+/// already downloaded (e.g. by `dprint add` when computing a checksum), so the
+/// tarball isn't fetched a second time. The checksum is still verified against
+/// the provided bytes.
+pub async fn resolve_npm_from_prefetched_tarball(
+  specifier: &NpmSpecifier,
+  checksum: Option<&str>,
+  tarball_bytes: Vec<u8>,
+  registry: &NpmRegistryResolution,
+  config_dir: Option<&Path>,
+  environment: &impl Environment,
+) -> Result<NpmResolvedPlugin> {
+  setup_npm_registry_tarball(specifier, checksum, tarball_bytes, registry, config_dir, environment).await
+}
+
+/// Verifies a registry tarball's checksum, extracts it to the npm cache, reads
+/// the plugin file, and (for process plugins) resolves the per-platform
+/// binary. Shared by the download and prefetched-bytes entry points above.
+async fn setup_npm_registry_tarball(
+  specifier: &NpmSpecifier,
+  checksum: Option<&str>,
+  tarball_bytes: Vec<u8>,
+  registry: &NpmRegistryResolution,
+  config_dir: Option<&Path>,
+  environment: &impl Environment,
+) -> Result<NpmResolvedPlugin> {
+  let version = specifier
+    .version
+    .as_deref()
+    .ok_or_else(|| anyhow::anyhow!("Cannot resolve npm plugin without a version from the registry"))?;
+  let registry_segment = registry_dir_segment(&registry.url);
 
   // verify checksum before doing any extraction work
   let plugin_kind = specifier.plugin_kind();

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -83,7 +83,7 @@ pub struct FetchNpmLatestInfo<'a> {
 pub struct NpmTarballInfo {
   pub plugin_kind: PluginKind,
   pub tarball_sha256: String,
-  pub tarball_bytes: Vec<u8>,
+  pub tarball_bytes: Option<Vec<u8>>,
 }
 
 /// Like [`NpmTarballInfo`], but for the latest published version — carries the
@@ -92,7 +92,7 @@ pub struct NpmLatestTarballInfo {
   pub version: String,
   pub plugin_kind: PluginKind,
   pub tarball_sha256: String,
-  pub tarball_bytes: Vec<u8>,
+  pub tarball_bytes: Option<Vec<u8>>,
 }
 
 /// A downloaded package tarball with its checksum, but no plugin-kind
@@ -100,7 +100,7 @@ pub struct NpmLatestTarballInfo {
 pub struct NpmTarballDownload {
   pub version: String,
   pub tarball_sha256: String,
-  pub tarball_bytes: Vec<u8>,
+  pub tarball_bytes: Option<Vec<u8>>,
 }
 
 /// Fetches the latest version of an npm-distributed plugin (and, when needed,
@@ -141,8 +141,19 @@ pub async fn fetch_npm_latest_info(args: FetchNpmLatestInfo<'_>, environment: &i
 /// specifier without a plugin path.
 pub async fn fetch_npm_latest_tarball_info(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmLatestTarballInfo> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
+  let registry_segment = registry_dir_segment(&registry.url);
   let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
   let version = latest_version_from_packument(&packument, name)?;
+  // a prior add/format already extracted this version — reuse the cached
+  // checksum + kind instead of re-downloading the tarball.
+  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, &version, environment) {
+    return Ok(NpmLatestTarballInfo {
+      version,
+      plugin_kind: meta.plugin_kind,
+      tarball_sha256: meta.tarball_sha256,
+      tarball_bytes: None,
+    });
+  }
   let info = inspect_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
   Ok(NpmLatestTarballInfo {
     version,
@@ -155,9 +166,17 @@ pub async fn fetch_npm_latest_tarball_info(name: &str, start_dir: Option<&Path>,
 /// Downloads the tarball for a specific `name@version`, inspects it to
 /// determine whether the package ships a `plugin.wasm` or `plugin.json`, and
 /// computes its SHA-256. Used by `dprint add` when the user pins a version but
-/// doesn't give a plugin path.
+/// doesn't give a plugin path. Reuses the cached checksum sidecar when present.
 pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballInfo> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
+  let registry_segment = registry_dir_segment(&registry.url);
+  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, version, environment) {
+    return Ok(NpmTarballInfo {
+      plugin_kind: meta.plugin_kind,
+      tarball_sha256: meta.tarball_sha256,
+      tarball_bytes: None,
+    });
+  }
   let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
   inspect_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await
 }
@@ -166,16 +185,24 @@ pub async fn fetch_npm_versioned_tarball_info(name: &str, version: &str, start_d
 /// the contents for a plugin kind. Used by `dprint add` when the user already
 /// gave an explicit plugin path (so the kind is known) but a checksum still
 /// needs computing — kind detection would wrongly require a root `plugin.wasm`
-/// / `plugin.json` there.
+/// / `plugin.json` there. Reuses the cached checksum sidecar when present.
 pub async fn fetch_npm_latest_tarball_download(name: &str, start_dir: Option<&Path>, environment: &impl Environment) -> Result<NpmTarballDownload> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
+  let registry_segment = registry_dir_segment(&registry.url);
   let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
   let version = latest_version_from_packument(&packument, name)?;
+  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, &version, environment) {
+    return Ok(NpmTarballDownload {
+      version,
+      tarball_sha256: meta.tarball_sha256,
+      tarball_bytes: None,
+    });
+  }
   let tarball_bytes = download_npm_tarball(name, &version, &packument, &packument_url, &registry, environment).await?;
   Ok(NpmTarballDownload {
     version,
     tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes,
+    tarball_bytes: Some(tarball_bytes),
   })
 }
 
@@ -187,12 +214,20 @@ pub async fn fetch_npm_versioned_tarball_download(
   environment: &impl Environment,
 ) -> Result<NpmTarballDownload> {
   let registry = resolve_registry_for_package(name, start_dir, environment);
+  let registry_segment = registry_dir_segment(&registry.url);
+  if let Some(meta) = read_npm_tarball_meta(&registry_segment, name, version, environment) {
+    return Ok(NpmTarballDownload {
+      version: version.to_string(),
+      tarball_sha256: meta.tarball_sha256,
+      tarball_bytes: None,
+    });
+  }
   let (packument, packument_url) = fetch_packument(name, &registry, environment).await?;
   let tarball_bytes = download_npm_tarball(name, version, &packument, &packument_url, &registry, environment).await?;
   Ok(NpmTarballDownload {
     version: version.to_string(),
     tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes,
+    tarball_bytes: Some(tarball_bytes),
   })
 }
 
@@ -252,7 +287,7 @@ async fn inspect_npm_tarball(
   Ok(NpmTarballInfo {
     plugin_kind,
     tarball_sha256: get_sha256_checksum(&tarball_bytes),
-    tarball_bytes,
+    tarball_bytes: Some(tarball_bytes),
   })
 }
 
@@ -421,6 +456,13 @@ async fn setup_npm_registry_tarball(
     );
   }
 
+  // the tarball's checksum, for the sidecar written after a successful setup
+  // (computed now, before `tarball_bytes` is moved into the blocking task).
+  let tarball_sha256 = match checksum {
+    Some(checksum) => checksum.to_string(),
+    None => get_sha256_checksum(&tarball_bytes),
+  };
+
   // extract and read the plugin file in a blocking task since
   // tarball decompression and file I/O can be slow
   let extract_dir = get_npm_extract_dir(&registry_segment, &specifier.name, version, environment);
@@ -458,6 +500,10 @@ async fn setup_npm_registry_tarball(
   } else {
     None
   };
+
+  // record the tarball's checksum + kind so a later `dprint add` of the same
+  // version can reuse them without re-downloading the tarball. Best-effort.
+  write_npm_tarball_meta(&registry_segment, &specifier.name, version, &tarball_sha256, plugin_kind, environment);
 
   Ok(NpmResolvedPlugin {
     plugin_bytes,
@@ -750,6 +796,63 @@ pub(super) fn get_npm_extract_dir(registry_segment: &str, package_name: &str, ve
   // use a sanitized name for the directory (replace / with __)
   let dir_name = format!("{}@{}", package_name.replace('/', "__"), version);
   environment.get_cache_dir().join("npm").join(registry_segment).join(dir_name)
+}
+
+/// The tarball's checksum and plugin kind, cached so a later `dprint add` of the
+/// same `name@version` can reuse them without re-downloading the tarball.
+///
+/// `plugin_kind` is the kind of the plugin file that was set up (derived from
+/// its path), not a fresh inspection of the archive — these only diverge for
+/// the unlikely package shipping both a plugin.wasm and plugin.json, and even
+/// then the cached kind names a file that provably exists. If a registry ever
+/// republishes the same version with different bytes the cached checksum goes
+/// stale, but that fails closed: the next `dprint fmt` re-downloads and errors
+/// on the mismatch rather than trusting it (and `clear-cache` fixes it).
+struct NpmTarballMeta {
+  tarball_sha256: String,
+  plugin_kind: PluginKind,
+}
+
+/// Path of the sidecar file caching a tarball's checksum + kind, kept next to
+/// (not inside) the `name@version` extract directory so it doesn't mix with the
+/// package's own files. Wiped by `dprint clear-cache` along with the rest of
+/// the npm cache.
+fn npm_tarball_meta_path(registry_segment: &str, package_name: &str, version: &str, environment: &impl Environment) -> PathBuf {
+  let file_name = format!("{}@{}.meta.json", package_name.replace('/', "__"), version);
+  environment.get_cache_dir().join("npm").join(registry_segment).join(file_name)
+}
+
+/// Reads the cached tarball sidecar, or `None` if it's missing or unreadable.
+fn read_npm_tarball_meta(registry_segment: &str, package_name: &str, version: &str, environment: &impl Environment) -> Option<NpmTarballMeta> {
+  let path = npm_tarball_meta_path(registry_segment, package_name, version, environment);
+  let text = environment.read_file(&path).ok()?;
+  let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+  let tarball_sha256 = value.get("tarballChecksum")?.as_str()?.to_string();
+  let plugin_kind = match value.get("pluginKind")?.as_str()? {
+    "wasm" => PluginKind::Wasm,
+    "process" => PluginKind::Process,
+    _ => return None,
+  };
+  Some(NpmTarballMeta { tarball_sha256, plugin_kind })
+}
+
+/// Writes the tarball sidecar. Best-effort — a failure just means the next
+/// `dprint add` re-downloads to recompute the checksum.
+fn write_npm_tarball_meta(
+  registry_segment: &str,
+  package_name: &str,
+  version: &str,
+  tarball_sha256: &str,
+  plugin_kind: PluginKind,
+  environment: &impl Environment,
+) {
+  let kind = match plugin_kind {
+    PluginKind::Wasm => "wasm",
+    PluginKind::Process => "process",
+  };
+  let json = serde_json::json!({ "tarballChecksum": tarball_sha256, "pluginKind": kind });
+  let path = npm_tarball_meta_path(registry_segment, package_name, version, environment);
+  let _ = environment.write_file(&path, &json.to_string());
 }
 
 /// Returns a filesystem- and key-safe segment identifying a registry by host
@@ -1581,6 +1684,74 @@ mod tests {
     let info = fetch_npm_versioned_tarball_info("foo", "1.2.3", None, &environment).await.unwrap();
     assert_eq!(info.plugin_kind, PluginKind::Wasm);
     assert_eq!(info.tarball_sha256, expected_checksum);
+    assert!(info.tarball_bytes.is_some());
+  }
+
+  #[tokio::test]
+  async fn fetch_npm_versioned_tarball_info_reuses_cached_checksum_sidecar() {
+    use crate::environment::TestEnvironment;
+    use crate::test_helpers::create_test_npm_tarball;
+
+    let environment = TestEnvironment::new();
+    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let checksum = get_sha256_checksum(&tarball);
+    let registry = NpmRegistryResolution {
+      url: "https://registry.npmjs.org".to_string(),
+      auth_header: None,
+    };
+    let specifier = NpmSpecifier {
+      name: "foo".to_string(),
+      version: Some("1.0.0".to_string()),
+      path: "plugin.wasm".to_string(),
+    };
+    // setting the plugin up writes the checksum sidecar (no network — we pass
+    // the tarball bytes directly).
+    resolve_npm_from_prefetched_tarball(&specifier, Some(&checksum), tarball, &registry, None, &environment)
+      .await
+      .unwrap();
+
+    // a later add reuses the sidecar instead of re-downloading — neither the
+    // packument nor the tarball are registered, so any fetch would error.
+    let info = fetch_npm_versioned_tarball_info("foo", "1.0.0", None, &environment).await.unwrap();
+    assert_eq!(info.plugin_kind, PluginKind::Wasm);
+    assert_eq!(info.tarball_sha256, checksum);
+    assert!(info.tarball_bytes.is_none(), "a sidecar hit must not re-download");
+  }
+
+  #[tokio::test]
+  async fn fetch_npm_latest_tarball_info_reuses_sidecar_but_still_resolves_version() {
+    use crate::environment::TestEnvironment;
+    use crate::test_helpers::create_test_npm_tarball;
+
+    let environment = TestEnvironment::new();
+    let tarball = create_test_npm_tarball(&[("package/plugin.wasm", b"\0asm")]);
+    let checksum = get_sha256_checksum(&tarball);
+    let registry = NpmRegistryResolution {
+      url: "https://registry.npmjs.org".to_string(),
+      auth_header: None,
+    };
+    let specifier = NpmSpecifier {
+      name: "foo".to_string(),
+      version: Some("1.0.0".to_string()),
+      path: "plugin.wasm".to_string(),
+    };
+    resolve_npm_from_prefetched_tarball(&specifier, Some(&checksum), tarball, &registry, None, &environment)
+      .await
+      .unwrap();
+
+    // the packument is still needed to discover the latest version, but the
+    // tarball (intentionally not registered) must be served from the sidecar.
+    let packument = serde_json::json!({
+      "dist-tags": { "latest": "1.0.0" },
+      "versions": { "1.0.0": { "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz" } } }
+    });
+    environment.add_remote_file_bytes("https://registry.npmjs.org/foo", packument.to_string().into_bytes());
+
+    let info = fetch_npm_latest_tarball_info("foo", None, &environment).await.unwrap();
+    assert_eq!(info.version, "1.0.0");
+    assert_eq!(info.plugin_kind, PluginKind::Wasm);
+    assert_eq!(info.tarball_sha256, checksum);
+    assert!(info.tarball_bytes.is_none(), "a sidecar hit must not re-download the tarball");
   }
 
   #[test]

--- a/crates/dprint/src/plugins/resolver.rs
+++ b/crates/dprint/src/plugins/resolver.rs
@@ -98,6 +98,15 @@ impl<TEnvironment: Environment> PluginResolver<TEnvironment> {
     Ok(plugins)
   }
 
+  /// Populates the on-disk plugin cache from bytes already downloaded during
+  /// `dprint add` (to compute a checksum), so the first `dprint fmt` doesn't
+  /// download or compile them again. A failure here is non-fatal to the add —
+  /// the worst case is the plugin gets set up lazily on first use — so callers
+  /// treat it as best-effort.
+  pub async fn setup_from_prefetched_download(&self, plugin_reference: &PluginSourceReference, bytes: Vec<u8>) -> Result<()> {
+    self.plugin_cache.setup_from_prefetched_download(plugin_reference, bytes).await
+  }
+
   pub async fn resolve_plugin(&self, plugin_reference: PluginSourceReference) -> Result<Rc<PluginWrapper>> {
     let cell = {
       let mut mem_cache = self.memory_cache.borrow_mut();

--- a/crates/dprint/src/plugins/resolver.rs
+++ b/crates/dprint/src/plugins/resolver.rs
@@ -98,13 +98,23 @@ impl<TEnvironment: Environment> PluginResolver<TEnvironment> {
     Ok(plugins)
   }
 
-  /// Populates the on-disk plugin cache from bytes already downloaded during
-  /// `dprint add` (to compute a checksum), so the first `dprint fmt` doesn't
-  /// download or compile them again. A failure here is non-fatal to the add —
-  /// the worst case is the plugin gets set up lazily on first use — so callers
-  /// treat it as best-effort.
-  pub async fn setup_from_prefetched_download(&self, plugin_reference: &PluginSourceReference, bytes: Vec<u8>) -> Result<()> {
-    self.plugin_cache.setup_from_prefetched_download(plugin_reference, bytes).await
+  /// Sets up a versioned npm plugin for `dprint add` — downloads, resolves the
+  /// plugin file (detecting it when the specifier has no path), computes the
+  /// checksum, and warms the cache — returning the resolved path + checksum to
+  /// write into config. See [`PluginCache::resolve_npm_for_add`].
+  pub async fn resolve_npm_for_add(
+    &self,
+    specifier: &crate::utils::NpmSpecifier,
+    path_was_explicit: bool,
+    base_dir: Option<&crate::environment::CanonicalizedPathBuf>,
+  ) -> Result<crate::plugins::NpmAddResolution> {
+    self.plugin_cache.resolve_npm_for_add(specifier, path_was_explicit, base_dir).await
+  }
+
+  /// Downloads a remote plugin for `dprint add`, computes its checksum, and
+  /// warms the cache. See [`PluginCache::resolve_remote_for_add`].
+  pub async fn resolve_remote_for_add(&self, plugin_reference: &PluginSourceReference) -> Result<String> {
+    self.plugin_cache.resolve_remote_for_add(plugin_reference).await
   }
 
   pub async fn resolve_plugin(&self, plugin_reference: PluginSourceReference) -> Result<Rc<PluginWrapper>> {

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -131,6 +131,7 @@ pub async fn run_cli<TEnvironment: Environment>(args: &CliArgs, environment: &TE
         names,
         no_version,
         package_json,
+        checksum,
       } => {
         commands::add_plugin_config_file(
           args,
@@ -138,6 +139,7 @@ pub async fn run_cli<TEnvironment: Environment>(args: &CliArgs, environment: &TE
             plugin_names_or_urls: names,
             no_version: *no_version,
             update_package_json: *package_json,
+            checksum: *checksum,
           },
           environment,
           plugin_resolver,

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -91,6 +91,18 @@ Or specify a plugin url:
 dprint add https://plugins.dprint.dev/json-x.x.x.wasm
 ```
 
+Or from npm:
+
+```sh
+dprint add npm:@dprint/json
+```
+
+By default Wasm plugins are added without a checksum (process plugins always get one). Use `--checksum` to pin a checksum on the added plugin regardless:
+
+```sh
+dprint add --checksum typescript
+```
+
 Note: `dprint config add` also works and is equivalent.
 
 ### Updating Plugins via CLI


### PR DESCRIPTION
Adds a `--checksum` flag that forces a checksum onto the written plugin entry even for Wasm plugins (process plugins always carry one). Applies to bare URLs, named plugins, interactive selection, and `npm:` specifiers, and conflicts with `--no-version` / `--package-json` since an unversioned entry cannot carry a checksum.