### PR TITLE
feat(init): smart plugin defaults, scalable picker, and --yes

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -194,6 +194,8 @@ pub struct FmtSubCommand {
 pub enum ConfigSubCommand {
   Init {
     global: bool,
+    /// Skip the interactive plugin prompt and accept the smart defaults.
+    yes: bool,
   },
   Update {
     yes: bool,
@@ -279,6 +281,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
   fn parse_init(matches: &ArgMatches) -> ConfigSubCommand {
     ConfigSubCommand::Init {
       global: matches.get_flag("global"),
+      yes: matches.get_flag("yes"),
     }
   }
 
@@ -547,15 +550,25 @@ pub enum CliArgParserKind {
 
 pub fn create_cli_parser(kind: CliArgParserKind) -> clap::Command {
   fn init_command() -> Command {
-    Command::new("init").about("Initializes a configuration file in the current directory.").arg(
-      Arg::new("global")
-        .long("global")
-        .short('g')
-        .conflicts_with("config-discovery")
-        .help("Initialize the global dprint configuration file.")
-        .num_args(0)
-        .required(false),
-    )
+    Command::new("init")
+      .about("Initializes a configuration file in the current directory.")
+      .arg(
+        Arg::new("global")
+          .long("global")
+          .short('g')
+          .conflicts_with("config-discovery")
+          .help("Initialize the global dprint configuration file.")
+          .num_args(0)
+          .required(false),
+      )
+      .arg(
+        Arg::new("yes")
+          .long("yes")
+          .short('y')
+          .help("Skip the interactive plugin prompt and accept the plugins selected based on the files in the current directory.")
+          .num_args(0)
+          .required(false),
+      )
   }
 
   fn add_command() -> Command {

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -43,6 +43,8 @@ use crate::utils::pretty_print_json_text;
 pub struct InitConfigFileOptions<'a> {
   pub global: bool,
   pub config_arg: Option<&'a str>,
+  /// Skip the interactive plugin prompt and accept the smart defaults.
+  pub non_interactive: bool,
 }
 
 pub async fn init_config_file(environment: &impl Environment, options: InitConfigFileOptions<'_>) -> Result<()> {
@@ -70,7 +72,9 @@ pub async fn init_config_file(environment: &impl Environment, options: InitConfi
     }
   }
   let config_file_path = config_file_paths.remove(0);
-  let text = get_init_config_file_text(environment).await?;
+  // skip the interactive prompt when asked to or when there's no interactive terminal (ex. CI)
+  let non_interactive = options.non_interactive || !environment.is_terminal_interactive();
+  let text = get_init_config_file_text(environment, non_interactive).await?;
   if let Some(parent) = config_file_path.parent() {
     _ = environment.mk_dir_all(parent);
   }
@@ -1361,7 +1365,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1369,7 +1373,7 @@ mod test {
     run_test_cli(vec!["init"], &environment).unwrap();
     assert_eq!(
       environment.take_stderr_messages(),
-      vec!["Select plugins (use the spacebar to select/deselect and then press enter when finished):"]
+      vec!["Select plugins (space to toggle, type to filter, enter to finish):"]
     );
     assert_eq!(
       environment.take_stdout_messages(),
@@ -1382,12 +1386,54 @@ mod test {
   }
 
   #[test]
+  fn should_initialize_with_yes_flag_without_prompt() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        info
+          .add_plugin(TestInfoFilePlugin {
+            name: "dprint-plugin-typescript".to_string(),
+            version: "0.17.2".to_string(),
+            url: "https://plugins.dprint.dev/typescript-0.17.2.wasm".to_string(),
+            config_key: Some("typescript".to_string()),
+            file_extensions: vec!["ts".to_string()],
+            config_excludes: vec![],
+            ..Default::default()
+          })
+          .add_plugin(TestInfoFilePlugin {
+            name: "dprint-plugin-jsonc".to_string(),
+            version: "0.2.3".to_string(),
+            url: "https://plugins.dprint.dev/json-0.2.3.wasm".to_string(),
+            config_key: Some("json".to_string()),
+            file_extensions: vec!["json".to_string()],
+            config_excludes: vec![],
+            ..Default::default()
+          });
+      })
+      .write_file("./file.ts", "")
+      .build();
+    run_test_cli(vec!["init", "--yes"], &environment).unwrap();
+    // no plugin selection prompt should be shown
+    assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![
+        "\nCreated dprint.json",
+        "\nIf you are working in a commercial environment please consider sponsoring dprint: https://dprint.dev/sponsor"
+      ]
+    );
+    // only the typescript plugin should be selected based on the .ts file
+    let created = environment.read_file("./dprint.json").unwrap();
+    assert!(created.contains("typescript-0.17.2.wasm"));
+    assert!(!created.contains("json-0.2.3.wasm"));
+  }
+
+  #[test]
   fn should_use_dprint_config_init_as_alias() {
     let environment = TestEnvironment::new();
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1417,7 +1463,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1425,7 +1471,7 @@ mod test {
     run_test_cli(vec!["init", "--config", "./test.config.json"], &environment).unwrap();
     assert_eq!(
       environment.take_stderr_messages(),
-      vec!["Select plugins (use the spacebar to select/deselect and then press enter when finished):"]
+      vec!["Select plugins (space to toggle, type to filter, enter to finish):"]
     );
     assert_eq!(
       environment.take_stdout_messages(),
@@ -1476,7 +1522,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1484,7 +1530,7 @@ mod test {
     run_test_cli(vec!["init", "--global"], &environment).unwrap();
     assert_eq!(
       environment.take_stderr_messages(),
-      vec!["Select plugins (use the spacebar to select/deselect and then press enter when finished):"]
+      vec!["Select plugins (space to toggle, type to filter, enter to finish):"]
     );
     let config_path = if std::env::consts::OS == "macos" {
       Path::new("/home/.config/dprint")
@@ -1522,7 +1568,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1530,7 +1576,7 @@ mod test {
     run_test_cli(vec!["init", "--global"], &environment).unwrap();
     assert_eq!(
       environment.take_stderr_messages(),
-      vec!["Select plugins (use the spacebar to select/deselect and then press enter when finished):"]
+      vec!["Select plugins (space to toggle, type to filter, enter to finish):"]
     );
     assert_eq!(
       environment.take_stdout_messages(),

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -17,6 +17,7 @@ use url::Url;
 use crate::arg_parser::CliArgs;
 use crate::arg_parser::FilePatternArgs;
 use crate::arg_parser::OutputResolvedConfigSubCommand;
+use crate::configuration::GetInitConfigFileTextOptions;
 use crate::configuration::get_init_config_file_text;
 use crate::configuration::*;
 use crate::environment::CanonicalizedPathBuf;
@@ -74,7 +75,7 @@ pub async fn init_config_file(environment: &impl Environment, options: InitConfi
   let config_file_path = config_file_paths.remove(0);
   // skip the interactive prompt when asked to or when there's no interactive terminal (ex. CI)
   let non_interactive = options.non_interactive || !environment.is_terminal_interactive();
-  let text = get_init_config_file_text(environment, non_interactive).await?;
+  let text = get_init_config_file_text(environment, GetInitConfigFileTextOptions { non_interactive }).await?;
   if let Some(parent) = config_file_path.parent() {
     _ = environment.mk_dir_all(parent);
   }
@@ -1365,7 +1366,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1433,7 +1434,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1463,7 +1464,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1522,7 +1523,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
         environment.clear_logs();
         expected_text
       }
@@ -1568,7 +1569,7 @@ mod test {
     let expected_text = environment.clone().run_in_runtime({
       let environment = environment.clone();
       async move {
-        let expected_text = get_init_config_file_text(&environment, false).await.unwrap();
+        let expected_text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
         environment.clear_logs();
         expected_text
       }

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -152,7 +152,8 @@ struct ProjectFiles {
 }
 
 /// Whether the plugin should be pre-selected based on the files in the current
-/// directory.
+/// directory. Extensions are matched case-insensitively, while file names are
+/// matched exactly because their casing is significant (ex. `Cargo.toml`).
 fn is_default_selected(plugin: &InfoFilePluginInfo, project_files: &ProjectFiles) -> bool {
   plugin.file_extensions.iter().any(|ext| project_files.extensions.contains(&ext.to_lowercase()))
     || plugin.file_names.iter().any(|name| project_files.file_names.contains(name))
@@ -360,6 +361,69 @@ mod test {
 "#
       );
 
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_scan_files_in_nested_directories() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/src/nested/app.ts", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
+      // the typescript plugin is selected from the nested file
+      assert!(text.contains("https://plugins.dprint.dev/typescript-0.17.2.wasm"), "{text}");
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_not_scan_ignored_directories() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      // matching files only exist within ignored directories
+      .write_file("/node_modules/dep/app.ts", "")
+      .write_file("/.git/hooks/config.json", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "excludes": [],
+  "plugins": [
+    // specify plugin urls here
+  ]
+}
+"#
+      );
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_match_extensions_case_insensitively() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/MAIN.TS", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
+      assert!(text.contains("https://plugins.dprint.dev/typescript-0.17.2.wasm"), "{text}");
       assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
     });
   }

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -145,12 +145,8 @@ struct ProjectFiles {
 }
 
 /// Whether the plugin should be pre-selected based on the files in the current
-/// directory. Process plugins are never pre-selected because they're heavier to
-/// set up (they require a checksum) and are better chosen explicitly.
+/// directory.
 fn is_default_selected(plugin: &InfoFilePluginInfo, project_files: &ProjectFiles) -> bool {
-  if plugin.is_process_plugin() {
-    return false;
-  }
   plugin.file_extensions.iter().any(|ext| project_files.extensions.contains(&ext.to_lowercase()))
     || plugin.file_names.iter().any(|name| project_files.file_names.contains(name))
 }
@@ -324,6 +320,34 @@ mod test {
   ],
   "plugins": [
     "https://plugins.dprint.dev/final-0.1.2.wasm"
+  ]
+}
+"#
+      );
+
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_pre_select_process_plugin_by_extension() {
+    // the process plugin is matched via its ".ps" file extension
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/file.ps", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "excludes": [],
+  "plugins": [
+    "https://plugins.dprint.dev/process-0.1.0.json@test-checksum"
   ]
 }
 "#

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -16,7 +16,14 @@ const MAX_SCAN_FILES: usize = 1000;
 /// files can't make the scan walk forever.
 const MAX_SCAN_DIRS: usize = 1000;
 
-pub async fn get_init_config_file_text(environment: &impl Environment, non_interactive: bool) -> Result<String> {
+#[derive(Default)]
+pub struct GetInitConfigFileTextOptions {
+  /// Skip the interactive plugin prompt and accept the plugins selected based
+  /// on the files in the current directory.
+  pub non_interactive: bool,
+}
+
+pub async fn get_init_config_file_text(environment: &impl Environment, options: GetInitConfigFileTextOptions) -> Result<String> {
   let info = match read_info_file(environment).await {
     Ok(info) => {
       // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
@@ -59,7 +66,7 @@ pub async fn get_init_config_file_text(environment: &impl Environment, non_inter
       .map(|plugin| is_default_selected(plugin, &project_files))
       .collect::<Vec<_>>();
 
-    let selected_indexes = if non_interactive {
+    let selected_indexes = if options.non_interactive {
       defaults.iter().enumerate().filter_map(|(i, on)| on.then_some(i)).collect::<Vec<_>>()
     } else {
       let prompt_message = "Select plugins (space to toggle, type to filter, enter to finish):";
@@ -247,7 +254,7 @@ mod test {
       .write_file("/file.json", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -282,7 +289,7 @@ mod test {
       .write_file("/readme.md", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -310,7 +317,7 @@ mod test {
       .write_file("/Cargo.toml", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -341,7 +348,7 @@ mod test {
       .write_file("/file.ps", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -368,7 +375,9 @@ mod test {
       .write_file("/file.ts", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, true).await.unwrap();
+      let text = get_init_config_file_text(&environment, GetInitConfigFileTextOptions { non_interactive: true })
+        .await
+        .unwrap();
       assert_eq!(
         text,
         r#"{
@@ -400,7 +409,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![0, 1, 2]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -437,7 +446,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![1]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -468,7 +477,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -495,7 +504,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![3]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -515,7 +524,7 @@ mod test {
   fn should_get_initialization_text_when_cannot_access_url() {
     let environment = TestEnvironment::new();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -556,7 +565,7 @@ mod test {
     environment.set_selection_result(1);
     environment.set_multi_selection_result(vec![0]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -593,7 +602,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![0]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
       assert_eq!(
         text,
         r#"{

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -1,10 +1,22 @@
+use std::collections::HashSet;
+use std::collections::VecDeque;
+
 use anyhow::Result;
 use dprint_core::plugins::wasm::{self};
 
+use crate::environment::DirEntry;
 use crate::environment::Environment;
+use crate::plugins::InfoFilePluginInfo;
 use crate::plugins::read_info_file;
 
-pub async fn get_init_config_file_text(environment: &impl Environment) -> Result<String> {
+/// Maximum number of files to look at when scanning the current directory to
+/// decide which plugins to pre-select. Keeps `dprint init` fast in large repos.
+const MAX_SCAN_FILES: usize = 1000;
+/// Upper bound on directories visited during the scan so a deep tree with few
+/// files can't make the scan walk forever.
+const MAX_SCAN_DIRS: usize = 1000;
+
+pub async fn get_init_config_file_text(environment: &impl Environment, non_interactive: bool) -> Result<String> {
   let info = match read_info_file(environment).await {
     Ok(info) => {
       // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
@@ -40,17 +52,27 @@ pub async fn get_init_config_file_text(environment: &impl Environment) -> Result
 
   let selected_plugins = if let Some(info) = info {
     let latest_plugins = info.latest_plugins;
-    let prompt_message = "Select plugins (use the spacebar to select/deselect and then press enter when finished):";
-    let plugin_indexes = environment.get_multi_selection(
-      prompt_message,
-      0,
-      &latest_plugins
+    // pre-select the plugins that match files found in the current directory
+    let project_files = scan_project_files(environment);
+    let defaults = latest_plugins
+      .iter()
+      .map(|plugin| is_default_selected(plugin, &project_files))
+      .collect::<Vec<_>>();
+
+    let selected_indexes = if non_interactive {
+      defaults.iter().enumerate().filter_map(|(i, on)| on.then_some(i)).collect::<Vec<_>>()
+    } else {
+      let prompt_message = "Select plugins (space to toggle, type to filter, enter to finish):";
+      let items = latest_plugins
         .iter()
-        .map(|x| (x.selected && !x.is_process_plugin(), String::from(&x.name)))
-        .collect::<Vec<_>>(),
-    )?;
+        .zip(defaults.iter())
+        .map(|(plugin, default)| (*default, plugin_display_text(plugin)))
+        .collect::<Vec<_>>();
+      environment.get_multi_selection(prompt_message, 0, &items)?
+    };
+
     let mut selected_plugins = Vec::new();
-    for index in plugin_indexes {
+    for index in selected_indexes {
       selected_plugins.push(latest_plugins[index].clone());
     }
     Some(selected_plugins)
@@ -114,6 +136,84 @@ pub async fn get_init_config_file_text(environment: &impl Environment) -> Result
   Ok(json_text)
 }
 
+/// The files found while scanning the current directory, used to decide which
+/// plugins to pre-select.
+struct ProjectFiles {
+  /// Lowercased file extensions without the leading dot (ex. `ts`, `json`).
+  extensions: HashSet<String>,
+  file_names: HashSet<String>,
+}
+
+/// Whether the plugin should be pre-selected based on the files in the current
+/// directory. Process plugins are never pre-selected because they're heavier to
+/// set up (they require a checksum) and are better chosen explicitly.
+fn is_default_selected(plugin: &InfoFilePluginInfo, project_files: &ProjectFiles) -> bool {
+  if plugin.is_process_plugin() {
+    return false;
+  }
+  plugin.file_extensions.iter().any(|ext| project_files.extensions.contains(&ext.to_lowercase()))
+    || plugin.file_names.iter().any(|name| project_files.file_names.contains(name))
+}
+
+/// The text shown for a plugin in the selection list. The supported file
+/// extensions are appended so unfamiliar plugins are easier to tell apart.
+fn plugin_display_text(plugin: &InfoFilePluginInfo) -> String {
+  if plugin.file_extensions.is_empty() {
+    plugin.name.clone()
+  } else {
+    let extensions = plugin.file_extensions.iter().map(|ext| format!(".{}", ext)).collect::<Vec<_>>().join(", ");
+    format!("{} ({})", plugin.name, extensions)
+  }
+}
+
+/// Scans the current directory for files in order to decide which plugins to
+/// pre-select. The scan is bounded by [`MAX_SCAN_FILES`] and [`MAX_SCAN_DIRS`]
+/// to stay fast in large repositories and best-effort ignores errors.
+fn scan_project_files(environment: &impl Environment) -> ProjectFiles {
+  let mut extensions = HashSet::new();
+  let mut file_names = HashSet::new();
+  let mut files_remaining = MAX_SCAN_FILES;
+  let mut dirs_remaining = MAX_SCAN_DIRS;
+  let mut pending_dirs = VecDeque::from([environment.cwd().into_path_buf()]);
+
+  'outer: while let Some(dir) = pending_dirs.pop_front() {
+    if dirs_remaining == 0 {
+      break;
+    }
+    dirs_remaining -= 1;
+    let Ok(entries) = environment.dir_info(&dir) else {
+      continue; // best-effort: skip directories we can't read
+    };
+    for entry in entries {
+      match entry {
+        DirEntry::Directory(path) => {
+          if path.file_name().and_then(|name| name.to_str()).is_some_and(|name| !is_ignored_dir(name)) {
+            pending_dirs.push_back(path);
+          }
+        }
+        DirEntry::File { name, path } => {
+          if files_remaining == 0 {
+            break 'outer;
+          }
+          files_remaining -= 1;
+          file_names.insert(name.to_string_lossy().into_owned());
+          if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
+            extensions.insert(ext.to_lowercase());
+          }
+        }
+      }
+    }
+  }
+
+  ProjectFiles { extensions, file_names }
+}
+
+/// Directories that are skipped while scanning. Hidden directories (those
+/// starting with a dot) are always skipped.
+fn is_ignored_dir(name: &str) -> bool {
+  name.starts_with('.') || matches!(name, "node_modules" | "target" | "vendor" | "dist" | "build" | "out" | "bin" | "obj")
+}
+
 /// Gets the unique items in the vector in the same order
 fn get_unique_items<T>(vec: Vec<T>) -> Vec<T>
 where
@@ -140,15 +240,18 @@ mod test {
 
   #[test]
   fn should_get_default_initialization_text() {
+    // the typescript and json plugins are pre-selected because of these files
     let environment = TestEnvironmentBuilder::new()
       .with_info_file(|info| {
         for plugin in get_multi_plugins_config() {
           info.add_plugin(plugin);
         }
       })
+      .write_file("/file.ts", "")
+      .write_file("/file.json", "")
       .build();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -173,6 +276,96 @@ mod test {
   }
 
   #[test]
+  fn should_select_no_plugins_when_no_files_match() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/readme.md", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "excludes": [],
+  "plugins": [
+    // specify plugin urls here
+  ]
+}
+"#
+      );
+
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_pre_select_plugin_by_file_name() {
+    // the "final" plugin is matched via the Cargo.toml file name
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/Cargo.toml", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "excludes": [
+    "**/something",
+    "**other"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/final-0.1.2.wasm"
+  ]
+}
+"#
+      );
+
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_skip_prompt_when_non_interactive() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/file.ts", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, true).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "typescript": {
+  },
+  "excludes": [
+    "**/something"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.17.2.wasm"
+  ]
+}
+"#
+      );
+
+      // no prompt should be shown when non-interactive
+      assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+    });
+  }
+
+  #[test]
   fn should_get_initialization_text_when_can_access_url() {
     let environment = TestEnvironmentBuilder::new()
       .with_info_file(|info| {
@@ -183,7 +376,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![0, 1, 2]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -220,7 +413,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![1]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -251,7 +444,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -278,7 +471,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![3]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -298,7 +491,7 @@ mod test {
   fn should_get_initialization_text_when_cannot_access_url() {
     let environment = TestEnvironment::new();
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -339,7 +532,7 @@ mod test {
     environment.set_selection_result(1);
     environment.set_multi_selection_result(vec![0]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -376,7 +569,7 @@ mod test {
       .build();
     environment.set_multi_selection_result(vec![0]);
     environment.clone().run_in_runtime(async move {
-      let text = get_init_config_file_text(&environment).await.unwrap();
+      let text = get_init_config_file_text(&environment, false).await.unwrap();
       assert_eq!(
         text,
         r#"{
@@ -404,7 +597,7 @@ mod test {
   }
 
   fn get_standard_logged_messages() -> Vec<&'static str> {
-    vec!["Select plugins (use the spacebar to select/deselect and then press enter when finished):"]
+    vec!["Select plugins (space to toggle, type to filter, enter to finish):"]
   }
 
   fn get_multi_plugins_config() -> Vec<TestInfoFilePlugin> {
@@ -412,7 +605,6 @@ mod test {
       TestInfoFilePlugin {
         name: "dprint-plugin-typescript".to_string(),
         version: "0.17.2".to_string(),
-        selected: Some(true),
         url: "https://plugins.dprint.dev/typescript-0.17.2.wasm".to_string(),
         config_key: Some("typescript".to_string()),
         file_extensions: vec!["ts".to_string(), "tsx".to_string()],
@@ -422,7 +614,6 @@ mod test {
       TestInfoFilePlugin {
         name: "dprint-plugin-jsonc".to_string(),
         version: "0.2.3".to_string(),
-        selected: Some(true),
         url: "https://plugins.dprint.dev/json-0.2.3.wasm".to_string(),
         config_key: Some("json".to_string()),
         file_extensions: vec!["json".to_string()],
@@ -432,7 +623,6 @@ mod test {
       TestInfoFilePlugin {
         name: "dprint-plugin-final".to_string(),
         version: "0.1.2".to_string(),
-        selected: Some(false),
         url: "https://plugins.dprint.dev/final-0.1.2.wasm".to_string(),
         file_names: Some(vec!["Cargo.toml".to_string()]),
         file_extensions: vec!["tsx".to_string(), "rs".to_string()],
@@ -442,7 +632,6 @@ mod test {
       TestInfoFilePlugin {
         name: "dprint-process-plugin".to_string(),
         version: "0.1.0".to_string(),
-        selected: Some(true), // should ignore this even though it's selected
         url: "https://plugins.dprint.dev/process-0.1.0.json".to_string(),
         file_extensions: vec!["ps".to_string()],
         config_excludes: vec![],

--- a/crates/dprint/src/environment/test_environment_builder.rs
+++ b/crates/dprint/src/environment/test_environment_builder.rs
@@ -169,8 +169,6 @@ pub struct TestInfoFilePlugin {
   pub version: String,
   pub url: String,
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub selected: Option<bool>,
-  #[serde(skip_serializing_if = "Option::is_none")]
   pub file_names: Option<Vec<String>>,
   pub file_extensions: Vec<String>,
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dprint/src/plugins/repo/read_info_file.rs
+++ b/crates/dprint/src/plugins/repo/read_info_file.rs
@@ -18,7 +18,6 @@ pub struct InfoFile {
 pub struct InfoFilePluginInfo {
   pub name: String,
   pub version: String,
-  pub selected: bool,
   pub url: String,
   pub config_key: Option<String>,
   pub file_extensions: Vec<String>,
@@ -104,7 +103,6 @@ fn get_latest_plugin(value: JsonValue) -> Result<InfoFilePluginInfo> {
   let name = get_string(&mut obj, "name")?;
   let version = get_string(&mut obj, "version")?;
   let url = get_string(&mut obj, "url")?;
-  let selected = obj.get_boolean("selected").unwrap_or(false);
   let config_key = obj.take_string("configKey").map(|k| k.into_owned());
   let file_extensions = get_string_array(&mut obj, "fileExtensions")?;
   let file_names = get_string_array(&mut obj, "fileNames").unwrap_or_default(); // compatible with old configuration
@@ -115,7 +113,6 @@ fn get_latest_plugin(value: JsonValue) -> Result<InfoFilePluginInfo> {
     name,
     version,
     url,
-    selected,
     config_key,
     file_extensions,
     file_names,
@@ -165,7 +162,6 @@ mod test {
           .add_plugin(TestInfoFilePlugin {
             name: "dprint-plugin-typescript".to_string(),
             version: "0.17.2".to_string(),
-            selected: Some(true),
             url: "https://plugins.dprint.dev/typescript-0.17.2.wasm".to_string(),
             config_key: Some("typescript".to_string()),
             file_extensions: vec!["ts".to_string(), "tsx".to_string()],
@@ -195,7 +191,6 @@ mod test {
             InfoFilePluginInfo {
               name: "dprint-plugin-typescript".to_string(),
               version: "0.17.2".to_string(),
-              selected: true,
               url: "https://plugins.dprint.dev/typescript-0.17.2.wasm".to_string(),
               config_key: Some("typescript".to_string()),
               file_extensions: vec!["ts".to_string(), "tsx".to_string()],
@@ -206,7 +201,6 @@ mod test {
             InfoFilePluginInfo {
               name: "dprint-plugin-jsonc".to_string(),
               version: "0.2.3".to_string(),
-              selected: false,
               url: "https://plugins.dprint.dev/json-0.2.3.wasm".to_string(),
               config_key: None,
               file_extensions: vec!["json".to_string()],

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -117,12 +117,13 @@ pub async fn run_cli<TEnvironment: Environment>(args: &CliArgs, environment: &TE
     SubCommand::Lsp => commands::run_language_server(args, environment, plugin_resolver).await,
     SubCommand::ClearCache => commands::clear_cache(environment),
     SubCommand::Config(cmd) => match cmd {
-      ConfigSubCommand::Init { global } => {
+      ConfigSubCommand::Init { global, yes } => {
         commands::init_config_file(
           environment,
           InitConfigFileOptions {
             global: *global,
             config_arg: args.config.as_deref(),
+            non_interactive: *yes,
           },
         )
         .await

--- a/crates/dprint/src/utils/logging/multi_select.rs
+++ b/crates/dprint/src/utils/logging/multi_select.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use anyhow::bail;
 use crossterm::event::Event;
 use crossterm::event::KeyCode;
+use crossterm::event::KeyModifiers;
 
+use crate::utils::terminal::get_terminal_size;
 use crate::utils::terminal::read_terminal_key_press;
 
 use super::Logger;
@@ -13,7 +15,12 @@ struct MultiSelectData<'a> {
   prompt: &'a str,
   item_hanging_indent: u16,
   items: Vec<(bool, &'a String)>,
+  /// Text typed by the user to narrow down the visible items.
+  filter: String,
+  /// Index into the currently visible (filtered) items.
   active_index: usize,
+  /// First visible (filtered) item, used to scroll long lists.
+  scroll_offset: usize,
 }
 
 pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item_hanging_indent: u16, items: Vec<(bool, &String)>) -> Result<Vec<usize>> {
@@ -21,34 +28,64 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
     prompt,
     items,
     item_hanging_indent,
+    filter: String::new(),
     active_index: 0,
+    scroll_offset: 0,
   };
 
   loop {
-    let text_items = render_multi_select(&data);
+    let visible = visible_indexes(&data);
+    // keep the active index and scrolling within the visible items
+    if data.active_index >= visible.len() {
+      data.active_index = visible.len().saturating_sub(1);
+    }
+    let max_visible_rows = max_visible_rows(&data);
+    update_scroll_offset(&mut data, visible.len(), max_visible_rows);
+
+    let text_items = render_multi_select(&data, &visible, max_visible_rows);
     logger.set_refresh_item(LoggerRefreshItemKind::Selection, text_items);
 
     if let Event::Key(key_event) = read_terminal_key_press()? {
+      // ctrl+c cancels
+      if key_event.modifiers.contains(KeyModifiers::CONTROL) && matches!(key_event.code, KeyCode::Char('c')) {
+        logger.remove_refresh_item(LoggerRefreshItemKind::Selection);
+        bail!("Selection cancelled.");
+      }
       match &key_event.code {
-        KeyCode::Up | KeyCode::Char('k') => {
-          if data.active_index == 0 {
-            data.active_index = data.items.len() - 1;
-          } else {
-            data.active_index -= 1;
+        KeyCode::Up => {
+          if !visible.is_empty() {
+            data.active_index = (data.active_index + visible.len() - 1) % visible.len();
           }
         }
-        KeyCode::Down | KeyCode::Char('j') => {
-          data.active_index = (data.active_index + 1) % data.items.len();
+        KeyCode::Down => {
+          if !visible.is_empty() {
+            data.active_index = (data.active_index + 1) % visible.len();
+          }
         }
         KeyCode::Char(' ') => {
-          // select an item
-          let current_item = data.items.get_mut(data.active_index).unwrap();
-          current_item.0 = !current_item.0;
+          // toggle the active item's selection
+          if let Some(&item_index) = visible.get(data.active_index) {
+            data.items[item_index].0 = !data.items[item_index].0;
+          }
+        }
+        KeyCode::Backspace => {
+          if data.filter.pop().is_some() {
+            data.active_index = 0;
+            data.scroll_offset = 0;
+          }
+        }
+        KeyCode::Char(c) => {
+          // any other printable character narrows down the list
+          if !key_event.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+            data.filter.push(*c);
+            data.active_index = 0;
+            data.scroll_offset = 0;
+          }
         }
         KeyCode::Enter => {
           break;
         }
-        KeyCode::Esc | KeyCode::Char('q') => {
+        KeyCode::Esc => {
           logger.remove_refresh_item(LoggerRefreshItemKind::Selection);
           bail!("Selection cancelled.");
         }
@@ -72,12 +109,69 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
   Ok(result)
 }
 
-fn render_multi_select(data: &MultiSelectData) -> Vec<LoggerTextItem> {
+/// The indexes into `data.items` that match the current filter, in order.
+fn visible_indexes(data: &MultiSelectData) -> Vec<usize> {
+  if data.filter.is_empty() {
+    return (0..data.items.len()).collect();
+  }
+  let filter = data.filter.to_lowercase();
+  data
+    .items
+    .iter()
+    .enumerate()
+    .filter(|(_, (_, text))| text.to_lowercase().contains(&filter))
+    .map(|(i, _)| i)
+    .collect()
+}
+
+/// The maximum number of items to show at once, based on the terminal height.
+/// When the terminal size is unknown (ex. not a tty) everything is shown.
+fn max_visible_rows(data: &MultiSelectData) -> usize {
+  match get_terminal_size() {
+    Some(size) => {
+      // reserve rows for: the prompt, the filter line, both scroll indicators,
+      // and a little breathing room so the list doesn't fill the entire screen
+      let reserved = 1 + usize::from(!data.filter.is_empty()) + 2 + 1;
+      (size.rows as usize).saturating_sub(reserved).max(1)
+    }
+    None => data.items.len().max(1),
+  }
+}
+
+/// Adjusts the scroll offset so the active item stays within the visible window.
+fn update_scroll_offset(data: &mut MultiSelectData, visible_len: usize, max_visible_rows: usize) {
+  if data.active_index < data.scroll_offset {
+    data.scroll_offset = data.active_index;
+  } else if data.active_index >= data.scroll_offset + max_visible_rows {
+    data.scroll_offset = data.active_index + 1 - max_visible_rows;
+  }
+  let max_scroll = visible_len.saturating_sub(max_visible_rows);
+  if data.scroll_offset > max_scroll {
+    data.scroll_offset = max_scroll;
+  }
+}
+
+fn render_multi_select(data: &MultiSelectData, visible: &[usize], max_visible_rows: usize) -> Vec<LoggerTextItem> {
   let mut result = vec![LoggerTextItem::Text(data.prompt.to_string())];
 
-  for (i, (is_selected, item_text)) in data.items.iter().enumerate() {
+  if !data.filter.is_empty() {
+    result.push(LoggerTextItem::Text(format!("  filter: {}", data.filter)));
+  }
+
+  if visible.is_empty() {
+    result.push(LoggerTextItem::Text("  (no matching plugins)".to_string()));
+    return result;
+  }
+
+  let end = (data.scroll_offset + max_visible_rows).min(visible.len());
+  if data.scroll_offset > 0 {
+    result.push(LoggerTextItem::Text(format!("  ...{} more above", data.scroll_offset)));
+  }
+
+  for (visible_pos, &item_index) in visible.iter().enumerate().take(end).skip(data.scroll_offset) {
+    let (is_selected, item_text) = &data.items[item_index];
     let mut text = String::new();
-    text.push_str(if i == data.active_index { ">" } else { " " });
+    text.push_str(if visible_pos == data.active_index { ">" } else { " " });
     text.push_str(" [");
     text.push_str(if *is_selected { "x" } else { " " });
     text.push_str("] ");
@@ -87,6 +181,10 @@ fn render_multi_select(data: &MultiSelectData) -> Vec<LoggerTextItem> {
       text,
       indent: 7 + data.item_hanging_indent,
     });
+  }
+
+  if end < visible.len() {
+    result.push(LoggerTextItem::Text(format!("  ...{} more below", visible.len() - end)));
   }
 
   result

--- a/crates/dprint/src/utils/logging/multi_select.rs
+++ b/crates/dprint/src/utils/logging/multi_select.rs
@@ -205,3 +205,127 @@ fn render_complete(data: &MultiSelectData) -> Vec<LoggerTextItem> {
   }
   result
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use pretty_assertions::assert_eq;
+
+  fn build_data(items: &[(bool, String)]) -> MultiSelectData<'_> {
+    MultiSelectData {
+      prompt: "Select:",
+      item_hanging_indent: 0,
+      items: items.iter().map(|(selected, text)| (*selected, text)).collect(),
+      filter: String::new(),
+      active_index: 0,
+      scroll_offset: 0,
+    }
+  }
+
+  fn rendered_lines(items: &[LoggerTextItem]) -> Vec<String> {
+    items
+      .iter()
+      .map(|item| match item {
+        LoggerTextItem::Text(text) => text.clone(),
+        LoggerTextItem::HangingText { text, .. } => text.clone(),
+      })
+      .collect()
+  }
+
+  #[test]
+  fn visible_indexes_returns_all_when_no_filter() {
+    let items = vec![(false, "alpha".to_string()), (false, "beta".to_string())];
+    let data = build_data(&items);
+    assert_eq!(visible_indexes(&data), vec![0, 1]);
+  }
+
+  #[test]
+  fn visible_indexes_filters_case_insensitively() {
+    let items = vec![(false, "TypeScript".to_string()), (false, "JSON".to_string()), (false, "Markdown".to_string())];
+    let mut data = build_data(&items);
+    data.filter = "json".to_string();
+    assert_eq!(visible_indexes(&data), vec![1]);
+    data.filter = "s".to_string(); // matches "TypeScript" and "JSON"
+    assert_eq!(visible_indexes(&data), vec![0, 1]);
+    data.filter = "nope".to_string();
+    assert_eq!(visible_indexes(&data), Vec::<usize>::new());
+  }
+
+  #[test]
+  fn update_scroll_offset_scrolls_to_keep_active_visible() {
+    let items = (0..10).map(|i| (false, format!("item{i}"))).collect::<Vec<_>>();
+    let mut data = build_data(&items);
+
+    // active below the window scrolls down so it's the last visible row
+    data.active_index = 7;
+    update_scroll_offset(&mut data, 10, 3);
+    assert_eq!(data.scroll_offset, 5);
+
+    // active above the window scrolls up to the active row
+    data.active_index = 2;
+    update_scroll_offset(&mut data, 10, 3);
+    assert_eq!(data.scroll_offset, 2);
+
+    // active already visible doesn't move the window
+    data.active_index = 3;
+    update_scroll_offset(&mut data, 10, 3);
+    assert_eq!(data.scroll_offset, 2);
+  }
+
+  #[test]
+  fn update_scroll_offset_clamps_to_end() {
+    let items = (0..5).map(|i| (false, format!("item{i}"))).collect::<Vec<_>>();
+    let mut data = build_data(&items);
+    data.scroll_offset = 4;
+    data.active_index = 4;
+    update_scroll_offset(&mut data, 5, 3);
+    // max scroll is 5 - 3 = 2
+    assert_eq!(data.scroll_offset, 2);
+  }
+
+  #[test]
+  fn render_marks_active_and_selected() {
+    let items = vec![(true, "alpha".to_string()), (false, "beta".to_string())];
+    let mut data = build_data(&items);
+    data.active_index = 1;
+    let visible = visible_indexes(&data);
+    assert_eq!(
+      rendered_lines(&render_multi_select(&data, &visible, 10)),
+      vec!["Select:", "  [x] alpha", "> [ ] beta"]
+    );
+  }
+
+  #[test]
+  fn render_shows_filter_and_scroll_indicators() {
+    let items = (0..10).map(|i| (false, format!("item{i}"))).collect::<Vec<_>>();
+    let mut data = build_data(&items);
+    data.filter = "item".to_string();
+    data.active_index = 5;
+    data.scroll_offset = 4;
+    let visible = visible_indexes(&data);
+    assert_eq!(
+      rendered_lines(&render_multi_select(&data, &visible, 3)),
+      vec![
+        "Select:",
+        "  filter: item",
+        "  ...4 more above",
+        "  [ ] item4",
+        "> [ ] item5",
+        "  [ ] item6",
+        "  ...3 more below",
+      ]
+    );
+  }
+
+  #[test]
+  fn render_shows_message_when_no_matches() {
+    let items = vec![(false, "alpha".to_string())];
+    let mut data = build_data(&items);
+    data.filter = "nope".to_string();
+    let visible = visible_indexes(&data);
+    assert_eq!(
+      rendered_lines(&render_multi_select(&data, &visible, 10)),
+      vec!["Select:", "  filter: nope", "  (no matching plugins)"]
+    );
+  }
+}

--- a/website/src/setup.md
+++ b/website/src/setup.md
@@ -24,7 +24,17 @@ Open a terminal in the root directory of your project and run the following comm
 dprint init
 ```
 
-This will create a _dprint.json_ file in the current working directory. If you are connected to the internet, it will initialize the file according to the latest plugins.
+This will create a _dprint.json_ file in the current working directory. If you are connected to the internet, it will prompt you to select from the latest plugins, pre-selecting the ones that match the files found in the current directory. Use the spacebar to toggle a plugin, type to filter the list, and press enter when finished.
+
+### Non-interactive init
+
+Pass the `--yes` or `-y` flag to skip the prompt and accept the plugins selected based on the files in the current directory. This is useful in scripts or CI:
+
+```sh
+dprint init --yes
+```
+
+The prompt is also skipped automatically when there is no interactive terminal.
 
 ## Manual Setup
 

--- a/website/src/setup.md
+++ b/website/src/setup.md
@@ -28,7 +28,7 @@ This will create a _dprint.json_ file in the current working directory. If you a
 
 ### Non-interactive init
 
-Pass the `--yes` or `-y` flag to skip the prompt and accept the plugins selected based on the files in the current directory. This is useful in scripts or CI:
+Pass the `--yes` or `-y` flag to skip the prompt and accept the plugins selected based on the files in the current directory. This is useful in scripts:
 
 ```sh
 dprint init --yes


### PR DESCRIPTION
Improves `dprint init` so it picks sensible defaults automatically and stays usable when `info.json` lists many plugins.

## Smart default selection
- Scans the current directory for files and pre-selects each plugin (Wasm or process) whose `fileExtensions` / `fileNames` match something in the project.
- The scan is bounded (1000 files / 1000 dirs) to stay fast in large repos, skips hidden dirs and common build/dep dirs (`node_modules`, `target`, `vendor`, `dist`, `build`, `out`, `bin`, `obj`), and is best-effort (ignores unreadable dirs).
- Selection follows `info.json` order.
- The now-unused `selected` property is dropped from `info.json` parsing.

## Scalable picker
- The multi-select now scrolls to fit the terminal height, with `...N more above` / `...N more below` indicators, so long lists no longer overflow the screen.
- Type-to-filter: any printable key narrows the list (case-insensitive); Backspace edits. Space still toggles, arrows navigate, Enter confirms. Cancel is now Esc / Ctrl+C (the old `q`/`j`/`k` bindings conflicted with typing).
- Each plugin shows its file extensions beside the name, e.g. `dprint-plugin-typescript (.ts, .tsx)`.

## `--yes` / non-interactive
- `dprint init --yes` (`-y`) skips the prompt and accepts the scanned defaults.
- The prompt is also auto-skipped when there's no interactive terminal (ex. CI), avoiding a hang.

## Tests
- Reworked existing init tests for scan-based defaults; added coverage for no-match, file-name matching (`Cargo.toml`), process-plugin matching by extension, non-interactive skip, and the `init --yes` CLI path.

> Note: the scroll/filter rendering only engages with a real TTY (the test environment bypasses the renderer), so that part was verified by hand rather than unit tests.
