### PR TITLE
chore(website): content-hash CSS/JS filenames for cache busting

### DIFF
--- a/website/_config.ts
+++ b/website/_config.ts
@@ -41,7 +41,41 @@ site
   .add("style.scss")
   .copy("assets", ".");
 
+// cache busting: give the built CSS/JS content-hashed filenames (like Vite)
+// so each deploy invalidates stale browser caches, then rewrite the references
+// in the generated HTML to point at the hashed names.
+const hashedAssets = new Map<string, string>();
+
+site.process([".css", ".js"], async (pages) => {
+  for (const page of pages) {
+    const url = page.data.url;
+    const dot = url.lastIndexOf(".");
+    const hashedUrl = `${url.slice(0, dot)}.${await shortHash(page.content!)}${url.slice(dot)}`;
+    hashedAssets.set(url, hashedUrl);
+    page.data.url = hashedUrl;
+  }
+});
+
+site.process([".html"], (pages) => {
+  for (const page of pages) {
+    let html = page.content as string;
+    for (const [from, to] of hashedAssets) {
+      html = html.replaceAll(`"${from}"`, `"${to}"`);
+    }
+    page.content = html;
+  }
+});
+
 export default site;
+
+async function shortHash(content: string | Uint8Array): Promise<string> {
+  const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 10);
+}
 
 async function copyConfigSchema() {
   // the dprint CLI crate is the source of truth for the config schema (it


### PR DESCRIPTION
## Summary

Adds Vite-style content-hashed filenames for the website's built CSS/JS so that deploys reliably bust stale browser caches.

A post-process step in `website/_config.ts`:

1. Hashes the built `style.css` and `scripts.js` by content (SHA-256, first 10 hex chars) and renames them — e.g. `style.31c6535258.css`, `scripts.f1699439c8.js`.
2. Rewrites the `<link>`/`<script>` references in every generated HTML page to point at the hashed names.

Because the hash is content-based, changing an asset changes its filename (forcing a fresh fetch), while unchanged assets keep the same URL and stay cached.

## Why

Browsers were serving stale cached CSS/JS after website updates. Lume has no built-in cache-busting plugin, so this adds a small processor to do it.

## Testing

- `deno task build` emits only hashed names; the old unhashed files are gone, and no stale `/style.css` / `/scripts.js` references remain in any HTML output.
- Verified the hash is content-based: editing the CSS output changes the hash (`31c6535258` → `f022d9212f`) and the HTML reference follows; restoring the source restores the original hash.
- Works in both `deno task build` and `deno task serve` (processors run in both).
