### PR TITLE
feat(playground): full-screen layout with resizable panes

### DIFF
--- a/website/playground/src/Playground.css
+++ b/website/playground/src/Playground.css
@@ -13,9 +13,10 @@ body,
 
 #App {
   --accent: #8b93a1;
-  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   background: #1e1e1e;
   color: #abb2bf;
 }
@@ -93,47 +94,20 @@ body,
 /* page shell */
 
 .page {
-  max-width: 1280px;
   width: 100%;
-  margin: 0 auto;
+  margin: 0;
   box-sizing: border-box;
-  padding: 0 28px 56px;
+  padding: 0 28px 20px;
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-}
-
-.pageHeader {
-  padding: 34px 0 18px;
-}
-
-.eyebrow {
-  font-size: 12px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: 12px;
-}
-
-.pageHeader h1 {
-  margin: 0 0 8px;
-  font-size: clamp(30px, 4.5vw, 44px);
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  color: #fff;
-  filter: drop-shadow(0 0 18px rgba(255, 255, 255, 0.12));
-}
-
-.pageHeader p {
-  margin: 0;
-  font-size: 15px;
-  color: #8b93a1;
 }
 
 /* toolbar */
 
 .toolbar {
-  padding: 14px 0;
+  padding: 16px 0;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -161,7 +135,7 @@ body,
   font-size: 13px;
   padding: 9px 12px;
   cursor: pointer;
-  max-width: 320px;
+  max-width: 560px;
   transition: border-color 0.15s, color 0.15s;
 }
 
@@ -214,21 +188,24 @@ body,
 /* panes */
 
 .panes {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  flex: 1;
+  min-height: 0;
+  display: flex;
   align-items: stretch;
 }
 
 .leftCol {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  flex: 0 0 calc(var(--left-frac, 0.5) * 100%);
+  min-width: 0;
+  min-height: 0;
 }
 
 .pane {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   background: #181a1e;
   border: 1px solid #33373f;
   border-radius: 14px;
@@ -236,15 +213,61 @@ body,
 }
 
 .inputPane {
-  height: 420px;
+  flex: 0 0 calc(var(--input-frac, 0.65) * 100%);
+  min-height: 0;
 }
 
 .configPane {
-  height: 224px;
+  flex: 1;
+  min-height: 0;
 }
 
 .outputPane {
-  height: 660px;
+  flex: 1;
+  min-height: 0;
+}
+
+/* draggable dividers — invisible gaps that highlight a line on hover/drag */
+
+.divider {
+  position: relative;
+  flex: 0 0 16px;
+  touch-action: none;
+}
+
+.divider::before {
+  content: "";
+  position: absolute;
+  background: transparent;
+  border-radius: 2px;
+  transition: background 0.15s;
+}
+
+.divider:hover::before,
+.divider:active::before {
+  background: var(--accent);
+}
+
+.dividerVertical {
+  cursor: col-resize;
+}
+
+.dividerVertical::before {
+  top: 0;
+  bottom: 0;
+  left: 7px;
+  width: 2px;
+}
+
+.dividerHorizontal {
+  cursor: row-resize;
+}
+
+.dividerHorizontal::before {
+  left: 0;
+  right: 0;
+  top: 7px;
+  height: 2px;
 }
 
 .paneHeader {
@@ -292,11 +315,41 @@ body,
 }
 
 @media (max-width: 860px) {
+  #App {
+    overflow: auto;
+  }
+
+  .page {
+    overflow: visible;
+  }
+
   .panes {
-    grid-template-columns: 1fr;
+    flex: none;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .leftCol {
+    flex: none;
+    gap: 16px;
+  }
+
+  .inputPane {
+    height: 360px;
+    flex: none;
+  }
+
+  .configPane {
+    height: 220px;
+    flex: none;
   }
 
   .outputPane {
     height: 420px;
+    flex: none;
+  }
+
+  .divider {
+    display: none;
   }
 }

--- a/website/playground/src/Playground.tsx
+++ b/website/playground/src/Playground.tsx
@@ -1,6 +1,6 @@
 import type { FileMatchingInfo, PluginInfo } from "@dprint/formatter";
 import JSON5 from "json5";
-import React, { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import React, { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CodeEditor } from "./components";
 import { Spinner } from "./components";
 import * as formatterWorker from "./FormatterWorker";
@@ -95,6 +95,16 @@ export function Playground({
   const editorLanguage = getLanguageFromPluginUrl(selectedPluginUrl) ?? "plaintext";
   const langLabel = getPluginShortNameFromPluginUrl(selectedPluginUrl) ?? "plugin";
 
+  // draggable dividers: leftFrac is the left column's width as a fraction of the
+  // panes row; inputFrac is the input pane's height as a fraction of the left column.
+  const panesRef = useRef<HTMLDivElement>(null);
+  const leftColRef = useRef<HTMLDivElement>(null);
+  const [leftFrac, setLeftFrac] = useState(0.5);
+  const [inputFrac, setInputFrac] = useState(0.65);
+
+  const startColumnResize = useDividerDrag(panesRef, "x", setLeftFrac);
+  const startRowResize = useDividerDrag(leftColRef, "y", setInputFrac);
+
   const onSelectPlugin = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     if (event.target.selectedIndex >= pluginUrls.length) {
       const url = prompt("Please provide a Wasm plugin url:", "");
@@ -125,19 +135,13 @@ export function Playground({
       </nav>
 
       <div className="page">
-        <header className="pageHeader">
-          <div className="eyebrow">// playground</div>
-          <h1>Try the formatter</h1>
-          <p>Paste code, pick a plugin, and format it live in the browser using the real Wasm formatter.</p>
-        </header>
-
         <div className="toolbar">
           <div className="toolbarGroup">
             <span className="toolbarLabel">plugin</span>
             <select className="control" value={selectedPluginUrl} onChange={onSelectPlugin}>
               {pluginUrls.map((pluginUrl, i) => (
                 <option key={i} value={pluginUrl}>
-                  {getPluginShortNameFromPluginUrl(pluginUrl) ?? pluginUrl}
+                  {pluginUrl}
                 </option>
               ))}
               <option key="custom">Custom…</option>
@@ -157,8 +161,8 @@ export function Playground({
           </div>
         </div>
 
-        <div className="panes">
-          <div className="leftCol">
+        <div className="panes" ref={panesRef} style={{ "--left-frac": leftFrac, "--input-frac": inputFrac } as React.CSSProperties}>
+          <div className="leftCol" ref={leftColRef}>
             <section className="pane inputPane">
               <div className="paneHeader">
                 <span className="paneLabel">Input</span>
@@ -176,6 +180,13 @@ export function Playground({
               </div>
             </section>
 
+            <div
+              className="divider dividerHorizontal"
+              role="separator"
+              aria-orientation="horizontal"
+              onPointerDown={startRowResize}
+            />
+
             <section className="pane configPane">
               <div className="paneHeader">
                 <span className="paneLabel">Config</span>
@@ -191,6 +202,13 @@ export function Playground({
               </div>
             </section>
           </div>
+
+          <div
+            className="divider dividerVertical"
+            role="separator"
+            aria-orientation="vertical"
+            onPointerDown={startColumnResize}
+          />
 
           <section className="pane outputPane">
             <div className="paneHeader">
@@ -213,9 +231,44 @@ export function Playground({
             </div>
           </section>
         </div>
-
-        <div className="tip">Tip: edit the code on the left and the formatted output updates live with your config.</div>
       </div>
     </div>
   );
+}
+
+// returns a pointer-down handler that resizes panes by dragging a divider,
+// updating `setFraction` with the pointer position as a fraction (0.15–0.85)
+// of the container along the given axis.
+function useDividerDrag(
+  containerRef: React.RefObject<HTMLElement | null>,
+  axis: "x" | "y",
+  setFraction: (fraction: number) => void,
+) {
+  return useCallback((event: React.PointerEvent) => {
+    event.preventDefault();
+    const container = containerRef.current;
+    if (container == null) {
+      return;
+    }
+
+    function onMove(moveEvent: PointerEvent) {
+      const rect = container!.getBoundingClientRect();
+      const fraction = axis === "x"
+        ? (moveEvent.clientX - rect.left) / rect.width
+        : (moveEvent.clientY - rect.top) / rect.height;
+      setFraction(Math.min(0.85, Math.max(0.15, fraction)));
+    }
+
+    function onUp() {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    }
+
+    document.body.style.cursor = axis === "x" ? "col-resize" : "row-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }, [containerRef, axis, setFraction]);
 }


### PR DESCRIPTION
## Summary

Restores the full-screen playground layout (like the pre-redesign version) and makes the panes resizable.

- **Full-screen layout** — the playground fills the viewport again. Removed the marketing header ("Try the formatter"), the bottom tip line, and the `max-width: 1280px` page container; the editor panes now flex to fill the available height instead of using fixed pixel heights.
- **Resizable panes** — added draggable dividers between the input/config panes and between the left column and the output pane. The dividers are invisible gaps that highlight a thin accent line on hover (and during drag) and show the appropriate resize cursor. Implemented with a small `useDividerDrag` hook (pointer events + CSS custom properties for the size fractions) — no new dependencies.
- **Plugin selector shows the URL** — the plugin dropdown now lists the full plugin URL (e.g. `https://plugins.dprint.dev/typescript-0.96.1.wasm`) instead of the short name like `typescript`. Widened the select so the URL isn't truncated.

On small screens (`≤860px`) the panes stack vertically with fixed heights and the dividers are hidden, so it scrolls as before.

Monaco reflows on resize via the existing 500ms layout poll in `CodeEditor`, so no editor changes were needed.

## Testing

Built locally (`deno task build`) and verified in `vite preview`: full-screen layout, dragging both dividers resizes the panes (editors reflow), hover highlight appears, and the plugin URL renders in the selector.
