### PR TITLE
chore(website): rename sponsor-* classes so ad blockers don't hide the page

### DIFF
--- a/website/src/sponsor.njk
+++ b/website/src/sponsor.njk
@@ -4,9 +4,9 @@ description: Information on sponsoring dprint.
 layout: layouts/base.njk
 ---
 
-<section class="sponsor-hero">
-  <div class="sponsor-glow"></div>
-  <div class="sponsor-inner">
+<section class="support-hero">
+  <div class="support-glow"></div>
+  <div class="support-inner">
     <div class="eyebrow" style="text-align: center">// sponsor</div>
     <h1>Support dprint</h1>
     <p class="lead">
@@ -14,15 +14,15 @@ layout: layouts/base.njk
       forward.
     </p>
 
-    <div class="sponsor-actions">
+    <div class="support-actions">
       <a class="btn-primary" href="https://github.com/sponsors/dprint"><span>♥</span> Sponsor on GitHub</a>
       <a class="btn-secondary" href="https://github.com/dprint/dprint" rel="noopener noreferrer">View on GitHub</a>
     </div>
-    <div class="sponsor-note">github.com/sponsors/dprint</div>
+    <div class="support-note">github.com/sponsors/dprint</div>
 
-    <div class="sponsor-where">
-      <div class="sponsor-where-label">Where sponsorship goes</div>
-      <div class="sponsor-grid">
+    <div class="support-where">
+      <div class="support-where-label">Where sponsorship goes</div>
+      <div class="support-grid">
         <div class="card">
           <div class="num">01</div>
           <div class="name">Core development</div>

--- a/website/src/style.scss
+++ b/website/src/style.scss
@@ -980,11 +980,11 @@ a {
 
 /* ===================== sponsor ===================== */
 
-.sponsor-hero {
+.support-hero {
   position: relative;
   overflow: hidden;
 }
-.sponsor-glow {
+.support-glow {
   position: absolute;
   top: -120px;
   left: 50%;
@@ -994,14 +994,14 @@ a {
   background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0) 70%);
   pointer-events: none;
 }
-.sponsor-inner {
+.support-inner {
   position: relative;
   max-width: 720px;
   margin: 0 auto;
   padding: 92px 28px 80px;
   text-align: center;
 }
-.sponsor-inner h1 {
+.support-inner h1 {
   margin: 0;
   font-weight: 600;
   font-size: clamp(40px, 7vw, 68px);
@@ -1010,7 +1010,7 @@ a {
   color: #fff;
   filter: drop-shadow(0 0 26px rgba(255, 255, 255, 0.16));
 }
-.sponsor-inner .lead {
+.support-inner .lead {
   margin: 34px auto 0;
   max-width: 600px;
   font-size: 17px;
@@ -1018,28 +1018,28 @@ a {
   color: #c2c8d0;
   text-wrap: pretty;
 }
-.sponsor-actions {
+.support-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
   justify-content: center;
   margin-top: 38px;
 }
-.sponsor-actions .btn-primary {
+.support-actions .btn-primary {
   display: flex;
   align-items: center;
   gap: 10px;
 }
-.sponsor-note {
+.support-note {
   margin-top: 18px;
   font-size: 13px;
   color: #5b626d;
 }
-.sponsor-where {
+.support-where {
   margin-top: 64px;
   text-align: left;
 }
-.sponsor-where-label {
+.support-where-label {
   font-size: 11px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -1047,29 +1047,29 @@ a {
   margin-bottom: 18px;
   text-align: center;
 }
-.sponsor-grid {
+.support-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 200px), 1fr));
   gap: 14px;
 }
-.sponsor-grid .card {
+.support-grid .card {
   background: #23262d;
   border: 1px solid #2f333b;
   border-radius: 14px;
   padding: 24px;
 }
-.sponsor-grid .num {
+.support-grid .num {
   font-size: 13px;
   color: var(--accent);
   margin-bottom: 14px;
 }
-.sponsor-grid .name {
+.support-grid .name {
   font-size: 15.5px;
   font-weight: 600;
   color: #f0f1f3;
   margin-bottom: 8px;
 }
-.sponsor-grid p {
+.support-grid p {
   margin: 0;
   font-size: 13.5px;
   line-height: 1.6;


### PR DESCRIPTION
## Summary

The sponsor page rendered blank for anyone using an ad blocker. The cause was **not** a bug in the page's HTML or CSS — it was the CSS class name.

EasyList (the default filter list for uBlock Origin, AdBlock Plus, Brave Shields, etc.) ships a generic cosmetic filter `##.sponsor-inner` that hides **any** element with the class `sponsor-inner` on **every** website. The sponsor page wrapped all of its visible content in `.sponsor-inner`, so the blocker set it to `display: none` and the page looked empty (nav + footer still showed).

This was confirmed on the live site: injecting a fresh `<div class="sponsor-inner">` computed to `display: none`, while `sponsor-hero`, `sponsor-grid`, and a control class all rendered normally — so the page's own stylesheet was fine; an external cosmetic filter was hiding that specific class.

## Fix

Rename the `sponsor-*` classes on the sponsor page to `support-*`, which don't appear on any filter list (verified the same way against the live page). Only CSS class names change — the `/sponsor` route, the GitHub Sponsors links, and all copy are untouched.

## Testing

- `deno task build` succeeds; the built `_site/sponsor/index.html` uses `support-*` classes with no `sponsor-*` classes remaining.
- Verified candidate `support-*` names are not blocked by the live ad blocker before renaming.
