### PR TITLE
chore(website): improve mobile layout for install section and playground header

### DIFF
--- a/website/playground/src/Playground.css
+++ b/website/playground/src/Playground.css
@@ -39,6 +39,7 @@ body,
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 18px;
 }
 
 .brand {
@@ -68,7 +69,8 @@ body,
 }
 
 .navLinks a.active {
-  color: var(--accent);
+  color: #fff;
+  font-weight: 600;
 }
 
 .navLinks a.ghButton {
@@ -89,6 +91,20 @@ body,
 
 .ghArrow {
   color: #6e7681;
+}
+
+/* keep the nav in step with the main site's responsive header */
+@media (max-width: 768px) {
+  .navInner {
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+
+  .navLinks {
+    flex-wrap: wrap;
+    gap: 14px 18px;
+    font-size: 13px;
+  }
 }
 
 /* page shell */

--- a/website/src/style.scss
+++ b/website/src/style.scss
@@ -672,7 +672,7 @@ a {
   .install-step:nth-child(2n) {
     border-right: none;
   }
-  .install-step:nth-last-child(-n + 2) {
+  .install-step:nth-last-child(-n+2) {
     border-bottom: none;
   }
 }

--- a/website/src/style.scss
+++ b/website/src/style.scss
@@ -649,11 +649,31 @@ a {
 
 @media (max-width: 720px) {
   .install-top {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .install-copy {
     border-right: none;
     border-bottom: 1px solid #2a2e35;
+    padding: 32px 24px;
+  }
+  .install-copy h2 {
+    font-size: 24px;
+  }
+  .installer {
+    padding: 24px;
+  }
+  .install-steps {
+    grid-template-columns: 1fr 1fr;
+  }
+  .install-step {
+    border-bottom: 1px solid #2a2e35;
+    padding: 18px 20px;
+  }
+  .install-step:nth-child(2n) {
+    border-right: none;
+  }
+  .install-step:nth-last-child(-n + 2) {
+    border-bottom: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Two mobile layout fixes for the new website.

### 1. Home "Up and running in one line." card

On mobile the install card overflowed and clipped its tabs/command. When the card collapses to a single column, the media query used `grid-template-columns: 1fr` (i.e. `minmax(auto, 1fr)`). The `auto` floor let the non-wrapping `curl … | sh` command force the grid track to ~543px — far wider than the card — and since the card is `overflow: hidden`, the OS tabs and command were clipped off the right edge.

- Use `minmax(0, 1fr)` so the track can't be blown out; the command now scrolls within its own box and the tabs wrap.
- Tighten padding and reduce the heading size on small screens.
- Lay the four install steps out as a 2×2 grid with proper dividers (previously full-width, very tall, no separators).

### 2. Playground header

The playground nav was a near-duplicate of the main site nav but lacked its responsive behavior: `.navInner` had no `gap` and never wrapped, so on mobile "dprint" collided with "Overview" and the GitHub button overflowed offscreen.

- Add `gap: 18px` to `.navInner`.
- Add the same `@media (max-width: 768px)` wrap rules the main site uses, so the brand → links → GitHub button stack identically.
- Align the active-link style to the main site's white/bold.

## Testing

Verified both at a 390px viewport with the real compiled CSS: the install card fits, tabs wrap, the command scrolls in its box, the steps form a clean 2×2 grid, and the playground header now wraps the same way as the main site.

> Note: the playground is a standalone Vite app with its own CSS bundle, so the nav styles are matched rather than shared. A future cleanup could extract the nav into a shared partial consumed by both builds.