### PR TITLE
fix(npm): resolve node_modules from config dir

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -3208,6 +3208,29 @@ mod test {
   }
 
   #[test]
+  fn should_resolve_unversioned_npm_plugin_from_config_dir_node_modules() {
+    // dprint.json lives below the workspace root and the dependency is
+    // installed beside it. The npm resolver must start at the config
+    // directory itself, not at the config directory's parent.
+    use crate::test_helpers::WASM_PLUGIN_BYTES;
+
+    let environment = TestEnvironmentBuilder::new()
+      .with_local_config("/repo/packages/web/dprint.json", |c| {
+        c.add_plugin("npm:test-plugin");
+      })
+      .write_file("/repo/packages/web/node_modules/test-plugin/plugin.wasm", WASM_PLUGIN_BYTES)
+      .write_file("/repo/packages/web/file.txt", "text")
+      .set_cwd("/repo/packages/web")
+      .build();
+
+    run_test_cli(vec!["fmt", "/repo/packages/web/file.txt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/repo/packages/web/file.txt").unwrap(), "text_formatted");
+
+    let _ = environment.take_stderr_messages();
+  }
+
+  #[test]
   fn should_walk_past_child_node_modules_lacking_plugin_to_reach_workspace_root() {
     // monorepo layout: dprint.json lives in a child workspace whose own
     // node_modules doesn't have the plugin (only a different package). The

--- a/crates/dprint/src/plugins/types.rs
+++ b/crates/dprint/src/plugins/types.rs
@@ -81,8 +81,9 @@ pub fn parse_plugin_source_reference(text: &str, base: &PathSource, environment:
     // also appear inside process plugin manifests pointing at `.zip` files.
     // For a top-level plugin reference, restrict to `.wasm` / `.json` here.
     validate_plugin_extension(&parsed.specifier, text)?;
-    // store the config file's directory for node_modules resolution
-    let base_dir = base.maybe_local_path().and_then(|p| p.parent());
+    // store the config directory for node_modules resolution. Callers pass the
+    // directory to resolve plugin references from, not the config file path.
+    let base_dir = base.maybe_local_path().cloned();
     return Ok(PluginSourceReference {
       path_source: PathSource::new_npm(parsed.specifier, base_dir),
       checksum: parsed.checksum,


### PR DESCRIPTION
## Summary

Fixes unversioned `npm:` plugin resolution so dprint looks for installed plugins from the config directory's `node_modules`.

Previously, a config such as this could fail even when the packages were installed:

```jsonc
{
  "plugins": [
    "npm:@dprint/markdown"
  ]
}
```

The error looked like:

```txt
Could not find @dprint/markdown in node_modules.
```

This PR also adds a regression test covering a nested project where `dprint.json` and `node_modules` live in the same directory.

## Related Issue

- Fixes #1193

## Testing

```sh
cargo test -p dprint should_resolve_unversioned_npm_plugin_from_config_dir_node_modules
cargo test -p dprint npm
```

Also verified against a pnpm project using unversioned `npm:` plugins.
