### PR TITLE
feat: support formatting directory args

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -530,7 +530,7 @@ fn validate_plugin_args_when_no_files(plugins: &[String]) -> Result<()> {
         bail!("{}", start_message);
       } else {
         bail!(
-          "{}\n\nMaybe you meant to add two dashes after the plugins?\n  --plugins {} -- [file patterns]...",
+          "{}\n\nMaybe you meant to add two dashes after the plugins?\n  --plugins {} -- [files/directories/patterns]...",
           start_message,
           plugins[..i].join(" "),
         )
@@ -627,7 +627,7 @@ pub fn create_cli_parser(kind: CliArgParserKind) -> clap::Command {
     .version(env!("CARGO_PKG_VERSION"))
     .author("Copyright 2019 by David Sherret")
     .about("Auto-formats source code based on the specified plugins.")
-    .override_usage("dprint <SUBCOMMAND> [OPTIONS] [--] [file patterns]...")
+    .override_usage("dprint <SUBCOMMAND> [OPTIONS] [--] [files/directories/patterns]...")
     .help_template(r#"{bin} {version}
 {author}
 
@@ -693,7 +693,7 @@ EXAMPLES:
 
     dprint fmt --config path/to/config/dprint.json
 
-  Search for files using the specified file patterns:
+  Search for files using the specified paths or file patterns:
 
     dprint fmt "**/*.{ts,tsx,js,jsx,json}""#,
     )
@@ -958,7 +958,7 @@ impl ClapExtensions for clap::Command {
     self
       .arg(
         Arg::new("files")
-          .help("List of file patterns in quotes to format. This can be a subset of what is found in the config file.")
+          .help("List of files, directories, or file patterns to format. This can be a subset of what is found in the config file.")
           .num_args(1..),
       )
       .arg(
@@ -1108,7 +1108,7 @@ mod test {
       concat!(
         "other.ts was specified as a plugin, but it doesn't look like one. Plugins must have a .wasm or .json extension.\n\n",
         "Maybe you meant to add two dashes after the plugins?\n",
-        "  --plugins https://plugins.dprint.dev/test.wasm -- [file patterns]...",
+        "  --plugins https://plugins.dprint.dev/test.wasm -- [files/directories/patterns]...",
       )
     );
   }

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -373,6 +373,23 @@ mod test {
   }
 
   #[test]
+  fn should_format_directory_arg() {
+    let file_path1 = "/sub-dir/file.txt";
+    let file_path2 = "/sub-dir/nested/file.txt";
+    let file_path3 = "/other/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(file_path1, "text")
+      .write_file(file_path2, "text2")
+      .write_file(file_path3, "text3")
+      .build();
+    run_test_cli(vec!["fmt", "/sub-dir"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text_formatted");
+    assert_eq!(environment.read_file(&file_path2).unwrap(), "text2_formatted");
+    assert_eq!(environment.read_file(&file_path3).unwrap(), "text3");
+  }
+
+  #[test]
   fn should_format_files_from_stdin_files() {
     let file_path1 = "/file.txt";
     let file_path2 = "/sub dir/file with space.txt";

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::Split;
+use sys_traits::FsMetadata;
 use thiserror::Error;
 
 use crate::arg_parser::ConfigDiscovery;
@@ -21,6 +22,7 @@ use crate::utils::GlobPattern;
 use crate::utils::GlobPatterns;
 use crate::utils::glob;
 use crate::utils::is_negated_glob;
+use crate::utils::is_pattern;
 
 /// Struct that allows using plugin names as a key
 /// in a hash map.
@@ -93,7 +95,8 @@ pub async fn get_and_resolve_file_paths<'a>(
   environment: &impl Environment,
 ) -> Result<GlobOutput> {
   let cwd = environment.cwd();
-  let mut file_patterns = get_all_file_patterns(config, args, &cwd);
+  let args = expand_directory_include_patterns(args, environment);
+  let mut file_patterns = get_all_file_patterns(config, &args, &cwd);
 
   if args.only_staged {
     let staged_files = environment.get_staged_files().context("Failed running git staged.")?;
@@ -117,6 +120,42 @@ pub async fn get_and_resolve_file_paths<'a>(
   }
 
   get_and_resolve_file_patterns(config, file_patterns, args.no_gitignore, config_discovery, environment).await
+}
+
+fn expand_directory_include_patterns(args: &FilePatternArgs, environment: &impl Environment) -> FilePatternArgs {
+  FilePatternArgs {
+    include_patterns: args
+      .include_patterns
+      .iter()
+      .flat_map(|pattern| expand_directory_include_pattern(pattern, environment))
+      .collect(),
+    include_pattern_overrides: args.include_pattern_overrides.clone(),
+    exclude_patterns: args.exclude_patterns.clone(),
+    exclude_pattern_overrides: args.exclude_pattern_overrides.clone(),
+    allow_node_modules: args.allow_node_modules,
+    no_gitignore: args.no_gitignore,
+    only_staged: args.only_staged,
+    only_dirty: args.only_dirty,
+  }
+}
+
+fn expand_directory_include_pattern(pattern: &str, environment: &impl Environment) -> Vec<String> {
+  if pattern == "." || is_pattern(pattern) {
+    return vec![pattern.to_string()];
+  }
+
+  let normalized_pattern = pattern.replace('\\', "/");
+  let pattern_path = PathBuf::from(&normalized_pattern);
+  let path = if environment.is_absolute_path(&pattern_path) {
+    pattern_path
+  } else {
+    environment.cwd().join(pattern_path)
+  };
+  if environment.fs_is_dir_no_err(path) {
+    vec![normalized_pattern.clone(), format!("{}/**/*", normalized_pattern.trim_end_matches('/'))]
+  } else {
+    vec![pattern.to_string()]
+  }
 }
 
 async fn get_and_resolve_file_patterns(

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -333,7 +333,7 @@ Copyright 2019 by David Sherret
 Auto-formats source code based on the specified plugins.
 
 USAGE:
-    dprint <SUBCOMMAND> [OPTIONS] [--] [file patterns]...
+    dprint <SUBCOMMAND> [OPTIONS] [--] [files/directories/patterns]...
 
 SUBCOMMANDS:
   init               Initializes a configuration file in the current directory.
@@ -408,7 +408,7 @@ EXAMPLES:
 
     dprint fmt --config path/to/config/dprint.json
 
-  Search for files using the specified file patterns:
+  Search for files using the specified paths or file patterns:
 
     dprint fmt "**/*.{ts,tsx,js,jsx,json}"
 "#

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -30,9 +30,10 @@ After [setting up a configuration file](/setup), run the `fmt` command:
 dprint fmt
 ```
 
-To format a subset of the files the configuration file matches, you may specify the file paths to format or not format:
+To format a subset of the files the configuration file matches, you may specify the file paths, directories, or file patterns to format or not format:
 
 ```sh
+dprint fmt src
 dprint fmt **/*.js --excludes **/data
 ```
 


### PR DESCRIPTION
## Summary
- expand existing positional directory args like `dprint fmt src` into descendant file matching
- preserve existing literal file and missing-pattern behavior
- update CLI help and website docs to mention files, directories, and patterns

Fixes #1046.