### PR TITLE
feat(core): convert Utf8Error to FormatError

### DIFF
--- a/crates/core/src/plugins/plugin_handler.rs
+++ b/crates/core/src/plugins/plugin_handler.rs
@@ -108,9 +108,24 @@ impl_format_error_from!(
   &str,
   Box<dyn std::error::Error + Send + Sync + 'static>,
   std::io::Error,
+  std::str::Utf8Error,
   std::string::FromUtf8Error,
   CriticalFormatError,
 );
+
+#[cfg(test)]
+mod tests {
+  use super::FormatError;
+
+  #[test]
+  fn should_convert_utf8_error_to_format_error() {
+    let bytes = [u8::MAX];
+    let utf8_error = std::str::from_utf8(&bytes).unwrap_err();
+    let format_error: FormatError = utf8_error.into();
+
+    assert!(format_error.downcast_ref::<std::str::Utf8Error>().is_some());
+  }
+}
 
 #[cfg(feature = "serde_json")]
 impl_format_error_from!(serde_json::Error);


### PR DESCRIPTION
## Summary

- add the requested `From<std::str::Utf8Error>` implementation for `FormatError`
- verify that the original UTF-8 error remains available through `downcast_ref`

Closes #1201.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dprint-core --features process should_convert_utf8_error_to_format_error`
- `git diff --check`

The focused test was run under Ubuntu because this Windows environment does not
have the MSVC linker installed.

## AI usage

I used an AI coding assistant to help inspect the issue, implement the small
conversion, and run the checks. I reviewed the patch and verified the focused
test locally.
