### PR TITLE
fix: format explicit paths outside the working directory

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -1481,6 +1481,28 @@ mod test {
     assert_eq!(environment.read_file(&file_path).unwrap(), "text1_formatted");
   }
 
+  #[cfg(unix)]
+  #[test]
+  fn should_format_parent_paths_from_subdirectory() {
+    for (cwd, file_arg) in [("/sub", "../file.txt"), ("/sub", "/file.txt"), ("/sub/nested", "../../file.txt")] {
+      let file_path = "/file.txt";
+      let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+        .with_local_config("/dprint.json", |c| {
+          c.add_remote_wasm_plugin();
+        })
+        .write_file(file_path, "text")
+        .write_file(format!("{cwd}/other.txt"), "other")
+        .set_cwd(cwd)
+        .initialize()
+        .build();
+
+      run_test_cli(vec!["fmt", "--", file_arg], &environment).unwrap();
+
+      assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+      assert_eq!(environment.read_file(file_path).unwrap(), "text_formatted");
+    }
+  }
+
   #[test]
   fn should_format_files_with_specific_config_includes() {
     let file_path1 = "/file1.txt";

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -113,7 +113,8 @@ pub async fn get_and_resolve_file_paths<'a>(
     // If no includes patterns were specified, derive one from the list of plugins
     // as this is a massive performance improvement, because it collects less file
     // paths to examine and match to plugins later.
-    file_patterns.config_includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), cwd.clone()));
+    let search_base = get_cli_search_base(&cwd, &file_patterns);
+    file_patterns.config_includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), search_base));
   }
 
   get_and_resolve_file_patterns(config, file_patterns, args.no_gitignore, config_discovery, environment).await
@@ -129,7 +130,11 @@ async fn get_and_resolve_file_patterns(
   let cwd = environment.cwd();
   let is_cwd_in_base = cwd.starts_with(&config.base_path);
   let is_in_sub_dir = cwd != config.base_path && is_cwd_in_base;
-  let start_dir = if is_in_sub_dir { cwd } else { config.base_path.clone() };
+  let start_dir = if is_in_sub_dir {
+    get_cli_search_base(&cwd, &file_patterns)
+  } else {
+    config.base_path.clone()
+  };
   let environment = environment.clone();
   let pattern_base = config.base_path.clone();
 
@@ -148,6 +153,21 @@ async fn get_and_resolve_file_patterns(
   })
   .await
   .unwrap()
+}
+
+fn get_cli_search_base(cwd: &CanonicalizedPathBuf, file_patterns: &GlobPatterns) -> CanonicalizedPathBuf {
+  file_patterns
+    .arg_includes
+    .iter()
+    .flat_map(|patterns| patterns.iter())
+    .filter(|pattern| !pattern.is_negated() && cwd.starts_with(&pattern.base_dir))
+    .fold(cwd.clone(), |base_dir, pattern| {
+      if base_dir.starts_with(&pattern.base_dir) {
+        pattern.base_dir.clone()
+      } else {
+        base_dir
+      }
+    })
 }
 
 fn get_plugin_patterns<'a>(plugins: impl Iterator<Item = &'a PluginWithConfig>) -> Vec<String> {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -1,4 +1,6 @@
+use std::path::Component;
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Result;
 
@@ -16,6 +18,7 @@ use crate::utils::GlobPattern;
 use crate::utils::GlobPatterns;
 use crate::utils::is_absolute_pattern;
 use crate::utils::is_negated_glob;
+use crate::utils::non_negated_glob;
 use crate::utils::resolve_global_gitignore_lines;
 
 pub struct FileMatcher<TEnvironment: Environment> {
@@ -128,20 +131,14 @@ pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cw
       None
     } else {
       // resolve CLI patterns based on the current working directory
-      Some(GlobPattern::new_vec(
-        args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(),
-        cwd.clone(),
-      ))
+      Some(args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect())
     },
     config_excludes: get_config_exclude_file_patterns(config, args, cwd),
     arg_excludes: if args.exclude_patterns.is_empty() {
       None
     } else {
       // resolve CLI patterns based on the current working directory
-      Some(GlobPattern::new_vec(
-        args.exclude_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(),
-        cwd.clone(),
-      ))
+      Some(args.exclude_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect())
     },
   }
 }
@@ -152,7 +149,7 @@ fn get_config_includes_file_patterns(config: &ResolvedConfig, args: &FilePattern
   file_patterns.extend(match &args.include_pattern_overrides {
     Some(includes_overrides) => {
       // resolve CLI patterns based on the current working directory
-      GlobPattern::new_vec(includes_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
+      includes_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect()
     }
     None => GlobPattern::new_vec(process_config_patterns(config.includes.as_ref()?).collect(), config.base_path.clone()),
   });
@@ -166,7 +163,7 @@ fn get_config_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternA
   file_patterns.extend(match &args.exclude_pattern_overrides {
     Some(exclude_overrides) => {
       // resolve CLI patterns based on the current working directory
-      GlobPattern::new_vec(exclude_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect(), cwd.clone())
+      exclude_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect()
     }
     None => config
       .excludes
@@ -204,34 +201,47 @@ fn process_file_pattern_slashes(file_pattern: &str) -> String {
   file_pattern.replace('\\', "/")
 }
 
-fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf) -> String {
+fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf) -> GlobPattern {
   let file_pattern = process_file_pattern_slashes(file_pattern);
-  if is_absolute_pattern(&file_pattern) {
-    let is_negated = is_negated_glob(&file_pattern);
-    let cwd = process_file_pattern_slashes(&cwd.to_string_lossy());
-    let file_pattern = if is_negated { &file_pattern[1..] } else { &file_pattern };
-    format!(
-      "{}./{}",
-      if is_negated { "!" } else { "" },
-      if file_pattern.starts_with(&cwd) {
-        file_pattern[cwd.len()..].trim_start_matches('/')
-      } else {
-        file_pattern
-      },
-    )
-  } else if file_pattern.starts_with("./") || file_pattern.starts_with("!./") {
-    file_pattern
-  } else if file_pattern == "." {
-    // format everything in the current directory
-    "**".to_string()
+  let is_negated = is_negated_glob(&file_pattern);
+  let pattern = non_negated_glob(&file_pattern);
+  if pattern == "." {
+    return GlobPattern::new(if is_negated { "!./." } else { "**" }.to_string(), cwd.clone());
+  }
+
+  let absolute_pattern = if is_absolute_pattern(&file_pattern) {
+    normalize_path(PathBuf::from(pattern))
   } else {
-    // make all cli specified patterns relative
-    if is_negated_glob(&file_pattern) {
-      format!("!./{}", &file_pattern[1..])
-    } else {
-      format!("./{}", file_pattern)
+    normalize_path(cwd.join(pattern))
+  };
+
+  let mut base_dir = cwd.clone();
+  loop {
+    if let Ok(relative_pattern) = absolute_pattern.strip_prefix(base_dir.as_ref()) {
+      let relative_pattern = process_file_pattern_slashes(&relative_pattern.to_string_lossy());
+      let relative_pattern = format!("{}./{}", if is_negated { "!" } else { "" }, relative_pattern);
+      return GlobPattern::new(relative_pattern, base_dir);
+    }
+
+    let Some(parent) = base_dir.parent() else {
+      return GlobPattern::new(file_pattern, cwd.clone());
+    };
+    base_dir = parent;
+  }
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+  let mut result = PathBuf::new();
+  for component in path.components() {
+    match component {
+      Component::CurDir => {}
+      Component::ParentDir => {
+        result.pop();
+      }
+      component => result.push(component.as_os_str()),
     }
   }
+  result
 }
 
 pub fn process_config_patterns(file_patterns: &[String]) -> impl Iterator<Item = String> + '_ {
@@ -260,30 +270,36 @@ mod test {
 
   #[test]
   fn should_process_cli_patterns() {
-    assert_eq!(do_process_cli_pattern("/test", "/"), "./test");
-    assert_eq!(do_process_cli_pattern("./test", "/"), "./test");
-    assert_eq!(do_process_cli_pattern("test", "/"), "./test");
-    assert_eq!(do_process_cli_pattern("**/test", "/"), "./**/test");
+    assert_cli_pattern("/test", "/", "./test", "/");
+    assert_cli_pattern("./test", "/", "./test", "/");
+    assert_cli_pattern("test", "/", "./test", "/");
+    assert_cli_pattern("**/test", "/", "./**/test", "/");
 
-    assert_eq!(do_process_cli_pattern("!/test", "/"), "!./test");
-    assert_eq!(do_process_cli_pattern("!./test", "/"), "!./test");
-    assert_eq!(do_process_cli_pattern("!test", "/"), "!./test");
-    assert_eq!(do_process_cli_pattern("!**/test", "/"), "!./**/test");
+    assert_cli_pattern("!/test", "/", "!./test", "/");
+    assert_cli_pattern("!./test", "/", "!./test", "/");
+    assert_cli_pattern("!test", "/", "!./test", "/");
+    assert_cli_pattern("!**/test", "/", "!./**/test", "/");
+    assert_cli_pattern("!.", "/", "!./.", "/");
+    assert_cli_pattern("../test", "/sub", "./test", "/");
+    assert_cli_pattern("/test", "/sub", "./test", "/");
   }
 
   #[cfg(windows)]
   #[test]
   fn should_process_cli_patterns_windows() {
-    assert_eq!(do_process_cli_pattern("C:/test", "C:\\"), "./test");
-    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test\\"), "./other");
-    assert_eq!(do_process_cli_pattern("C:/test/other", "C:\\test"), "./other");
+    assert_cli_pattern("C:/test", "C:\\", "./test", "C:\\");
+    assert_cli_pattern("C:/test/other", "C:\\test\\", "./other", "C:\\test\\");
+    assert_cli_pattern("C:/test/other", "C:\\test", "./other", "C:\\test");
+    assert_cli_pattern("../test", "C:\\sub", "./test", "C:\\");
 
-    assert_eq!(do_process_cli_pattern("!C:/test", "C:\\"), "!./test");
-    assert_eq!(do_process_cli_pattern("!C:/test/other", "C:\\test\\"), "!./other");
+    assert_cli_pattern("!C:/test", "C:\\", "!./test", "C:\\");
+    assert_cli_pattern("!C:/test/other", "C:\\test\\", "!./other", "C:\\test\\");
   }
 
-  fn do_process_cli_pattern(file_pattern: &str, cwd: &str) -> String {
-    process_cli_pattern(file_pattern, &CanonicalizedPathBuf::new_for_testing(cwd))
+  fn assert_cli_pattern(file_pattern: &str, cwd: &str, expected_pattern: &str, expected_base_dir: &str) {
+    let pattern = process_cli_pattern(file_pattern, &CanonicalizedPathBuf::new_for_testing(cwd));
+    assert_eq!(pattern.relative_pattern, expected_pattern);
+    assert_eq!(pattern.base_dir, CanonicalizedPathBuf::new_for_testing(expected_base_dir));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- resolve relative and absolute CLI paths against their nearest ancestor search base
- cover one- and two-level parent paths plus absolute paths

## Why

From a project subdirectory, explicit paths such as `../dprint.json`, `../../dprint.json`, and an absolute project path either reported no files or panicked before traversal. The resolved pattern base now expands only for positive CLI includes, while config include filtering remains intact.

Closes #1199.

## Validation

- `cargo test -p dprint should_format_parent_paths_from_subdirectory -- --nocapture` — passed
- `cargo test -p dprint patterns::test -- --nocapture` — passed
- `cargo check -p dprint` — passed
- `cargo clippy -p dprint --bin dprint` — passed
- `cargo fmt --all -- --check` — passed