### PR TITLE
feat: add `--no-glob` to take args as path instead of glob

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -259,12 +259,13 @@ pub enum HiddenSubCommand {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct FilePatternArgs {
-  pub include_patterns: Vec<String>,
+  pub args: Vec<String>,
   pub include_pattern_overrides: Option<Vec<String>>,
   pub exclude_patterns: Vec<String>,
   pub exclude_pattern_overrides: Option<Vec<String>>,
   pub allow_node_modules: bool,
   pub no_gitignore: bool,
+  pub no_glob: bool,
   pub only_staged: bool,
   pub only_dirty: bool,
 }
@@ -474,13 +475,13 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
 
 fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_reader: &TStdInReader) -> Result<FilePatternArgs> {
   let plugins = maybe_values_to_vec(matches.get_many("plugins"));
-  let mut file_patterns = maybe_values_to_vec(matches.get_many("files"));
+  let mut file_args = maybe_values_to_vec(matches.get_many("files"));
 
   if matches.get_flag("stdin-files") {
-    file_patterns.extend(std_in_reader.read_non_empty_lines()?);
+    file_args.extend(std_in_reader.read_non_empty_lines()?);
   }
 
-  if !plugins.is_empty() && file_patterns.is_empty() {
+  if !plugins.is_empty() && file_args.is_empty() {
     validate_plugin_args_when_no_files(&plugins)?;
   }
 
@@ -489,7 +490,8 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
     only_dirty: matches.get_flag("dirty"),
     allow_node_modules: matches.get_flag("allow-node-modules"),
     no_gitignore: matches.get_flag("no-gitignore"),
-    include_patterns: file_patterns,
+    no_glob: matches.get_flag("no-glob"),
+    args: file_args,
     include_pattern_overrides: matches.get_many("includes-override").map(values_to_vec),
     exclude_patterns: maybe_values_to_vec(matches.get_many("excludes")),
     exclude_pattern_overrides: matches.get_many("excludes-override").map(values_to_vec),
@@ -1004,6 +1006,12 @@ impl ClapExtensions for clap::Command {
           .help("Disables respecting .gitignore files.")
           .num_args(0),
       )
+      .arg(
+        Arg::new("no-glob")
+          .long("no-glob")
+          .help("Treats the file arguments as literal file paths instead of glob patterns.")
+          .num_args(0),
+      )
   }
 
   fn add_incremental_arg(self) -> Self {
@@ -1170,7 +1178,7 @@ mod test {
     match args.sub_command {
       SubCommand::Fmt(cmd) => {
         // blank lines are skipped and paths with spaces are preserved
-        assert_eq!(cmd.patterns.include_patterns, vec!["/file1.txt".to_string(), "/sub dir/file 2.txt".to_string()]);
+        assert_eq!(cmd.patterns.args, vec!["/file1.txt".to_string(), "/sub dir/file 2.txt".to_string()]);
       }
       _ => unreachable!(),
     }
@@ -1186,6 +1194,14 @@ mod test {
     .err()
     .unwrap();
     assert!(err.to_string().contains("cannot be used with"));
+  }
+
+  #[test]
+  fn no_glob_arg() {
+    let fmt_cmd = parse_fmt_sub_command(vec!["fmt"]).unwrap();
+    assert!(!fmt_cmd.patterns.no_glob);
+    let fmt_cmd = parse_fmt_sub_command(vec!["fmt", "--no-glob", "[id].ts"]).unwrap();
+    assert!(fmt_cmd.patterns.no_glob);
   }
 
   #[test]

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -750,12 +750,13 @@ pub async fn update_plugins_config_file<TEnvironment: Environment>(
   }
 
   let file_pattern_args = FilePatternArgs {
-    include_patterns: Vec::new(),
+    args: Vec::new(),
     include_pattern_overrides: None,
     exclude_patterns: Vec::new(),
     exclude_pattern_overrides: None,
     allow_node_modules: false,
     no_gitignore: false,
+    no_glob: false,
     only_staged: false,
     only_dirty: false,
   };

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -358,6 +358,42 @@ mod test {
   }
 
   #[test]
+  fn should_treat_file_args_as_literal_paths_with_no_glob() {
+    let literal_paths = ["/[id].txt", "/{{file}}.txt", "/file?.txt", "/file*.txt", "/!important.txt"];
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(literal_paths[0], "text0")
+      .write_file(literal_paths[1], "text1")
+      .write_file(literal_paths[2], "text2")
+      .write_file(literal_paths[3], "text3")
+      .write_file(literal_paths[4], "text4")
+      .write_file("/id.txt", "not targeted")
+      .write_file("/file-other.txt", "not targeted")
+      .write_file("/.gitignore", "file*.txt")
+      .build();
+
+    run_test_cli(
+      vec![
+        "fmt",
+        "--no-glob",
+        literal_paths[0],
+        literal_paths[1],
+        literal_paths[2],
+        literal_paths[3],
+        literal_paths[4],
+      ],
+      &environment,
+    )
+    .unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(literal_paths.len())]);
+    for (index, file_path) in literal_paths.iter().enumerate() {
+      assert_eq!(environment.read_file(file_path).unwrap(), format!("text{index}_formatted"));
+    }
+    assert_eq!(environment.read_file("/id.txt").unwrap(), "not targeted");
+    assert_eq!(environment.read_file("/file-other.txt").unwrap(), "not targeted");
+  }
+
+  #[test]
   fn should_format_files() {
     let file_path1 = "/file.txt";
     let file_path2 = "/file.txt_ps";
@@ -421,6 +457,20 @@ mod test {
     assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
     assert_eq!(environment.read_file(&file_path1).unwrap(), "text_1_formatted");
     assert_eq!(environment.read_file(&file_path2).unwrap(), "text_2");
+  }
+
+  #[test]
+  fn should_treat_staged_files_as_literal_paths() {
+    let file_path = "/[id]/{{file}}?.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(file_path, "text")
+      .add_staged_file(file_path)
+      .build();
+
+    run_test_cli(vec!["fmt", "--staged"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file(file_path).unwrap(), "text_formatted");
   }
 
   #[test]

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -97,7 +97,7 @@ pub async fn resolve_config_from_args(args: &CliArgs, environment: &impl Environ
       if resolved_config_path.is_global_config
         && let SubCommand::Fmt(fmt) = &args.sub_command
         && !fmt.allow_no_files
-        && fmt.patterns.include_patterns.is_empty()
+        && fmt.patterns.args.is_empty()
         && fmt.patterns.include_pattern_overrides.is_none()
         && !(args.config_discovery_arg_set() && matches!(args.config_discovery(environment), ConfigDiscovery::Global))
       {

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -12,6 +12,7 @@ use crate::configuration::ResolvedConfig;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::patterns::get_all_file_patterns;
+use crate::patterns::get_cli_arg_patterns;
 use crate::patterns::process_config_patterns;
 use crate::plugins::PluginNameResolutionMaps;
 use crate::resolution::PluginWithConfig;
@@ -97,16 +98,12 @@ pub async fn get_and_resolve_file_paths<'a>(
 
   if args.only_staged {
     let staged_files = environment.get_staged_files().context("Failed running git staged.")?;
-    file_patterns.arg_includes = Some(GlobPattern::new_vec(
-      staged_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
-      cwd.clone(),
-    ));
+    let staged_files = staged_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect::<Vec<_>>();
+    file_patterns.arg_includes = Some(get_cli_arg_patterns(&staged_files, &cwd, true));
   } else if args.only_dirty {
     let dirty_files = environment.get_dirty_files().context("Failed running git status.")?;
-    file_patterns.arg_includes = Some(GlobPattern::new_vec(
-      dirty_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
-      cwd.clone(),
-    ));
+    let dirty_files = dirty_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect::<Vec<_>>();
+    file_patterns.arg_includes = Some(get_cli_arg_patterns(&dirty_files, &cwd, true));
   }
 
   if file_patterns.config_includes.is_none() {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -124,14 +124,11 @@ pub fn get_patterns_as_glob_matcher(patterns: &[String], config_base_path: &Cano
 pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> GlobPatterns {
   GlobPatterns {
     config_includes: get_config_includes_file_patterns(config, args, cwd),
-    arg_includes: if args.include_patterns.is_empty() {
+    arg_includes: if args.args.is_empty() {
       None
     } else {
       // resolve CLI patterns based on the current working directory
-      Some(GlobPattern::new_vec(
-        args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect(),
-        cwd.clone(),
-      ))
+      Some(get_cli_arg_patterns(&args.args, cwd, args.no_glob))
     },
     config_excludes: get_config_exclude_file_patterns(config, args, cwd),
     arg_excludes: if args.exclude_patterns.is_empty() {
@@ -144,6 +141,24 @@ pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cw
       ))
     },
   }
+}
+
+pub fn get_cli_arg_patterns(patterns: &[String], cwd: &CanonicalizedPathBuf, literal: bool) -> Vec<GlobPattern> {
+  patterns
+    .iter()
+    .map(|pattern| {
+      let pattern = if literal {
+        process_cli_path(pattern, cwd)
+      } else {
+        process_cli_pattern(pattern, cwd)
+      };
+      if literal {
+        GlobPattern::new_literal(pattern, cwd.clone())
+      } else {
+        GlobPattern::new(pattern, cwd.clone())
+      }
+    })
+    .collect()
 }
 
 fn get_config_includes_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Option<Vec<GlobPattern>> {
@@ -234,6 +249,25 @@ fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf) -> String
   }
 }
 
+fn process_cli_path(file_path: &str, cwd: &CanonicalizedPathBuf) -> String {
+  let file_path = process_file_pattern_slashes(file_path);
+  if is_absolute_pattern(&file_path) {
+    let cwd = process_file_pattern_slashes(&cwd.to_string_lossy());
+    format!(
+      "./{}",
+      if file_path.starts_with(&cwd) {
+        file_path[cwd.len()..].trim_start_matches('/')
+      } else {
+        file_path.as_str()
+      },
+    )
+  } else if file_path.starts_with("./") {
+    file_path
+  } else {
+    format!("./{file_path}")
+  }
+}
+
 pub fn process_config_patterns(file_patterns: &[String]) -> impl Iterator<Item = String> + '_ {
   file_patterns.iter().map(|p| process_config_pattern(p))
 }
@@ -269,6 +303,14 @@ mod test {
     assert_eq!(do_process_cli_pattern("!./test", "/"), "!./test");
     assert_eq!(do_process_cli_pattern("!test", "/"), "!./test");
     assert_eq!(do_process_cli_pattern("!**/test", "/"), "!./**/test");
+  }
+
+  #[test]
+  fn should_process_cli_paths() {
+    let cwd = CanonicalizedPathBuf::new_for_testing("/project");
+    assert_eq!(process_cli_path("[id].ts", &cwd), "./[id].ts");
+    assert_eq!(process_cli_path("!important.ts", &cwd), "./!important.ts");
+    assert_eq!(process_cli_path("/project/{{file}}.ts", &cwd), "./{{file}}.ts");
   }
 
   #[cfg(windows)]

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -501,9 +501,9 @@ impl<TEnvironment: Environment> PluginsScopeAndPathsCollection<TEnvironment> {
 
     // ensure we found some files
     if !cli_args.sub_command.allow_no_files() {
-      let has_cli_file_patterns = cli_args.sub_command.file_patterns().map(|p| !p.include_patterns.is_empty()).unwrap_or(false);
-      // when the user specifies a pattern on the command line, just ensure that one scope matched
-      if has_cli_file_patterns {
+      let has_cli_file_args = cli_args.sub_command.file_patterns().map(|p| !p.args.is_empty()).unwrap_or(false);
+      // when the user specifies file arguments on the command line, just ensure that one scope matched
+      if has_cli_file_args {
         let all_empty = self.iter().all(|s| s.file_paths_by_plugins.is_empty());
         if all_empty {
           return Err(

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -227,7 +227,9 @@ fn build_include_matcher(patterns: &[GlobPattern], opts: &GlobMatcherOptions, ba
   builder.case_insensitive(!opts.case_sensitive)?;
 
   for pattern in patterns {
-    if use_fast_path && let Some(path) = literal_relative_path(pattern) {
+    if (pattern.is_literal() || use_fast_path)
+      && let Some(path) = literal_relative_path(pattern)
+    {
       literal_paths.insert(path);
     } else {
       add_override_pattern(&mut builder, pattern, base_dir)?;
@@ -276,8 +278,9 @@ fn can_use_literal_fast_path(patterns: &[GlobPattern], opts: &GlobMatcherOptions
 /// depth and a directory-only pattern (trailing slash) depends on `is_dir`, so
 /// neither is equivalent to an exact path lookup.
 fn literal_relative_path(pattern: &GlobPattern) -> Option<PathBuf> {
+  let is_literal = pattern.is_literal();
   let pattern = &pattern.relative_pattern;
-  if is_pattern(pattern) {
+  if !is_literal && is_pattern(pattern) {
     return None; // glob (also excludes negated patterns, which start with `!`)
   }
   let (anchored, relative) = if let Some(rest) = pattern.strip_prefix("./") {

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -28,7 +28,7 @@ impl GlobPatterns {
       .flat_map(|i| i.iter())
       .chain(self.config_includes.iter().flat_map(|i| i.iter()))
       .filter_map(|pattern| {
-        if !is_pattern(&pattern.relative_pattern) {
+        if pattern.is_literal() || !is_pattern(&pattern.relative_pattern) {
           Some(pattern.base_dir.join(&pattern.relative_pattern))
         } else {
           None
@@ -42,11 +42,24 @@ impl GlobPatterns {
 pub struct GlobPattern {
   pub relative_pattern: String,
   pub base_dir: CanonicalizedPathBuf,
+  literal: bool,
 }
 
 impl GlobPattern {
   pub fn new(relative_pattern: String, base_dir: CanonicalizedPathBuf) -> Self {
-    GlobPattern { relative_pattern, base_dir }
+    GlobPattern {
+      relative_pattern,
+      base_dir,
+      literal: false,
+    }
+  }
+
+  pub fn new_literal(relative_path: String, base_dir: CanonicalizedPathBuf) -> Self {
+    GlobPattern {
+      relative_pattern: relative_path,
+      base_dir,
+      literal: true,
+    }
   }
 
   pub fn new_vec(relative_patterns: Vec<String>, base_dir: CanonicalizedPathBuf) -> Vec<Self> {
@@ -76,7 +89,7 @@ impl GlobPattern {
         let component = *component;
         if part == "**" {
           return true;
-        } else if !is_pattern(part) && !component.as_os_str().eq_ignore_ascii_case(part) {
+        } else if (self.literal || !is_pattern(part)) && !component.as_os_str().eq_ignore_ascii_case(part) {
           return false;
         }
         components.next();
@@ -89,7 +102,11 @@ impl GlobPattern {
   }
 
   pub fn is_negated(&self) -> bool {
-    is_negated_glob(&self.relative_pattern)
+    !self.literal && is_negated_glob(&self.relative_pattern)
+  }
+
+  pub fn is_literal(&self) -> bool {
+    self.literal
   }
 
   pub fn invert(self) -> Self {
@@ -97,11 +114,13 @@ impl GlobPattern {
       GlobPattern {
         base_dir: self.base_dir,
         relative_pattern: non_negated_glob(&self.relative_pattern).to_string(),
+        literal: self.literal,
       }
     } else {
       GlobPattern {
         base_dir: self.base_dir,
         relative_pattern: format!("!{}", self.relative_pattern),
+        literal: self.literal,
       }
     }
   }
@@ -121,7 +140,7 @@ impl GlobPattern {
     let mut found_glob = false;
 
     for part in &parts {
-      if !found_glob && !is_pattern(part) {
+      if !found_glob && (self.literal || !is_pattern(part)) {
         base_parts.push(*part);
       } else {
         found_glob = true;
@@ -147,10 +166,21 @@ impl GlobPattern {
     GlobPattern {
       base_dir: new_base_dir,
       relative_pattern: new_pattern,
+      literal: self.literal,
     }
   }
 
   pub fn into_new_base(self, new_base_dir: CanonicalizedPathBuf) -> Option<Self> {
+    if self.literal {
+      let relative_path = self.relative_pattern.strip_prefix("./").unwrap_or(&self.relative_pattern);
+      let absolute_path = self.base_dir.join(relative_path);
+      let relative_path = absolute_path.strip_prefix(&new_base_dir).ok()?;
+      return Some(GlobPattern::new_literal(
+        format!("./{}", relative_path.to_string_lossy().replace('\\', "/")),
+        new_base_dir,
+      ));
+    }
+
     if self.base_dir == new_base_dir {
       Some(self)
     } else if let Ok(prefix) = self.base_dir.strip_prefix(&new_base_dir) {
@@ -304,6 +334,17 @@ mod test {
     let pattern = GlobPattern::new("./**/*".to_string(), test_dir_dir);
     let pattern = pattern.into_new_base(root_dir.clone()).unwrap();
     assert_eq!(pattern.relative_pattern, "./test/dir/**/*");
+    assert_eq!(pattern.base_dir, root_dir);
+  }
+
+  #[test]
+  fn should_make_literal_path_with_new_base() {
+    let root_dir = CanonicalizedPathBuf::new_for_testing("/");
+    let project_dir = CanonicalizedPathBuf::new_for_testing("/project");
+    let pattern = GlobPattern::new_literal("./[id]/{{file}}?.ts".to_string(), project_dir);
+    let pattern = pattern.into_new_base(root_dir.clone()).unwrap();
+    assert!(pattern.is_literal());
+    assert_eq!(pattern.relative_pattern, "./project/[id]/{{file}}?.ts");
     assert_eq!(pattern.base_dir, root_dir);
   }
 

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -36,6 +36,12 @@ To format a subset of the files the configuration file matches, you may specify 
 dprint fmt **/*.js --excludes **/data
 ```
 
+To treat file arguments as literal paths instead of glob patterns, use `--no-glob`. This is useful for file names that contain glob characters such as brackets or braces:
+
+```sh
+dprint fmt --no-glob "./src/routes/[id].svelte"
+```
+
 A rare use case, but to override/ignore the patterns in the config file, use the `--includes-override` and `--excludes-override` flags:
 
 ```sh


### PR DESCRIPTION
add `--no-glob` to parse args as file path instead of glob

close https://github.com/dprint/dprint/issues/552 https://github.com/dprint/dprint/issues/920 https://github.com/dprint/dprint/issues/947