### PR TITLE
fix: resolve literal file and directory args without directory traversal

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -257,7 +257,7 @@ pub enum HiddenSubCommand {
   WindowsUninstall(String),
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FilePatternArgs {
   pub include_patterns: Vec<String>,
   pub include_pattern_overrides: Option<Vec<String>>,

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -142,6 +142,17 @@ impl SubCommand {
     }
   }
 
+  /// Whether a specified path that can't be resolved should be skipped with a
+  /// warning instead of erroring (ex. a path outside the config's directory
+  /// that has no config file of its own).
+  ///
+  /// `output-file-paths` always allows this because it's the command users are
+  /// pointed at to diagnose which files dprint is finding, so it should show
+  /// what it did resolve rather than fail.
+  pub fn allow_skipping_paths(&self) -> bool {
+    self.allow_no_files() || matches!(self, SubCommand::OutputFilePaths(_))
+  }
+
   pub fn file_patterns(&self) -> Option<&FilePatternArgs> {
     match self {
       SubCommand::Check(a) => Some(&a.patterns),

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -43,11 +43,19 @@ pub async fn stdin_fmt<TEnvironment: Environment>(
 
   // if the path is absolute, then apply exclusion rules
   if environment.is_absolute_path(&cmd.file_name_or_path) {
-    let file_matcher = FileMatcher::new(environment.clone(), plugins_scope.config.as_ref().unwrap(), &cmd.patterns, &environment.cwd())?;
     // canonicalize the file path, then check if it's in the list of file paths.
     let resolved_file_path = environment.canonicalize(&cmd.file_name_or_path)?;
+    let mut file_matcher = FileMatcher::new(
+      environment.clone(),
+      plugins_scope.config.as_ref().unwrap(),
+      &cmd.patterns,
+      &environment.cwd(),
+      Some(resolved_file_path.as_ref()),
+    )?;
     // log the file text as-is since it's not in the list of files to format
-    if !file_matcher.matches(resolved_file_path) {
+    // (checking the ancestor directories too so exclusions apply the same
+    // way as a normal `fmt`, ex. a file in an excluded directory)
+    if !file_matcher.matches_and_dir_not_ignored(resolved_file_path.as_ref()) {
       environment.log_machine_readable(&cmd.file_bytes);
       return Ok(());
     }
@@ -712,6 +720,21 @@ mod test {
     assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
     assert_eq!(environment.read_file(&file_path).unwrap(), "text_formatted");
     assert_eq!(environment.read_file(&file_path2).unwrap(), "text");
+  }
+
+  #[test]
+  fn should_format_dot_slash_dir_arg() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/file.txt", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "./"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text_formatted");
   }
 
   #[test]
@@ -1498,17 +1521,285 @@ mod test {
     assert_eq!(environment.read_file(&file_path).unwrap(), "text1_formatted");
   }
 
-  #[cfg(unix)]
+  #[test]
+  fn should_format_files_in_specified_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/sub/file1.txt", "text1")
+      .write_file("/sub/nested/file2.txt", "text2")
+      .write_file("/other/file3.txt", "text3")
+      .build();
+
+    run_test_cli(vec!["fmt", "sub"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/sub/file1.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/sub/nested/file2.txt").unwrap(), "text2_formatted");
+    assert_eq!(environment.read_file("/other/file3.txt").unwrap(), "text3");
+  }
+
+  #[test]
+  fn should_format_files_matching_character_class_glob_arg() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/file1.txt", "text1")
+      .write_file("/file_a.txt", "other")
+      .build();
+
+    run_test_cli(vec!["fmt", "file[0-9].txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/file1.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/file_a.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_format_file_with_glob_chars_when_path_exists() {
+    // https://github.com/dprint/dprint/issues/552
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/routes/[id].txt", "text1")
+      // a character class interpretation would match this file instead
+      .write_file("/routes/i.txt", "other")
+      .build();
+
+    run_test_cli(vec!["fmt", "routes/[id].txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/routes/[id].txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/routes/i.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_format_file_with_curly_braces_when_path_exists() {
+    // https://github.com/dprint/dprint/issues/947 -- this pattern isn't
+    // even a valid glob (nested alternate groups), so it previously errored
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/{{myfile}}.txt", "text1")
+      .build();
+
+    run_test_cli(vec!["fmt", "{{myfile}}.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/{{myfile}}.txt").unwrap(), "text1_formatted");
+  }
+
+  #[test]
+  fn should_format_dir_with_glob_chars_when_path_exists() {
+    // https://github.com/dprint/dprint/issues/920
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/[a]/file.txt", "text1")
+      .write_file("/[a]/nested/file.txt", "text2")
+      // a character class interpretation would match this directory instead
+      .write_file("/a/file.txt", "other")
+      .build();
+
+    run_test_cli(vec!["fmt", "[a]"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/[a]/file.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/[a]/nested/file.txt").unwrap(), "text2_formatted");
+    assert_eq!(environment.read_file("/a/file.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_format_file_specified_inside_dir_with_glob_chars() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/[a]/file.txt", "text1")
+      .build();
+
+    run_test_cli(vec!["fmt", "[a]/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/[a]/file.txt").unwrap(), "text1_formatted");
+  }
+
+  #[test]
+  fn should_format_file_when_cwd_has_glob_chars() {
+    // formatting should work the same regardless of the arg spelling
+    for args in [
+      vec!["fmt", "file.txt"],
+      vec!["fmt", "."],
+      vec!["fmt", "*.txt"],
+      vec!["fmt", "/[a]/file.txt"],
+      vec!["fmt"],
+    ] {
+      let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+        .with_default_config(|config| {
+          config.add_remote_wasm_plugin();
+        })
+        .write_file("/[a]/file.txt", "text1")
+        .set_cwd("/[a]")
+        .build();
+
+      run_test_cli(args.clone(), &environment).unwrap();
+
+      assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()], "args: {:?}", args);
+      assert_eq!(environment.read_file("/[a]/file.txt").unwrap(), "text1_formatted", "args: {:?}", args);
+    }
+  }
+
+  #[test]
+  fn should_format_parent_path_with_glob_chars_from_subdirectory() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/[a].txt", "text1")
+      .write_file("/sub/other.txt", "other")
+      .set_cwd("/sub")
+      .build();
+
+    run_test_cli(vec!["fmt", "../[a].txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/[a].txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/sub/other.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_exclude_dir_with_glob_chars_when_path_exists() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/[a]/file.txt", "text1")
+      .write_file("/other.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "**/*.txt", "--excludes", "[a]"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/[a]/file.txt").unwrap(), "text1");
+    assert_eq!(environment.read_file("/other.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_not_format_file_negated_by_arg_with_glob_chars() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/routes/[id].txt", "text1")
+      // a character class interpretation would negate this file instead
+      .write_file("/routes/i.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "**/*.txt", "!routes/[id].txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/routes/[id].txt").unwrap(), "text1");
+    assert_eq!(environment.read_file("/routes/i.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_format_specified_gitignored_file_with_glob_chars() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      // the escaped entry targets the literal file name in git semantics
+      .write_file("/.gitignore", "\\[id\\].txt")
+      .write_file("/routes/[id].txt", "text1")
+      .write_file("/a.txt", "text2")
+      .build();
+
+    // explicitly specifying the file overrides the gitignore entry, and the
+    // result is the same when another glob arg triggers a traversal
+    run_test_cli(vec!["fmt", "routes/[id].txt", "a*.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/routes/[id].txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/a.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_format_file_with_glob_chars_in_includes_override() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/routes/[id].txt", "text1")
+      // a character class interpretation would match this file instead
+      .write_file("/routes/i.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "--includes-override", "routes/[id].txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/routes/[id].txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/routes/i.txt").unwrap(), "text2");
+  }
+
+  #[test]
+  fn should_exclude_dir_with_glob_chars_in_excludes_override() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/[a]/file.txt", "text1")
+      .write_file("/other.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "--excludes-override", "[a]"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/[a]/file.txt").unwrap(), "text1");
+    assert_eq!(environment.read_file("/other.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_not_double_format_config_dir_with_glob_chars_when_formatting_ancestor() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/[app]/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "app-config" }"#);
+      })
+      .write_file("/root.txt", "r")
+      .write_file("/[app]/file.txt", "a")
+      .set_cwd("/[app]")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", ".."], &environment).unwrap();
+
+    // each file formats exactly once with the config in its directory tree
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/[app]/file.txt").unwrap(), "a_app-config");
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "r_formatted");
+  }
+
   #[test]
   fn should_format_parent_paths_from_subdirectory() {
+    // https://github.com/dprint/dprint/issues/1199
     for (cwd, file_arg) in [("/sub", "../file.txt"), ("/sub", "/file.txt"), ("/sub/nested", "../../file.txt")] {
       let file_path = "/file.txt";
+      let other_file_path = format!("{cwd}/other.txt");
       let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
         .with_local_config("/dprint.json", |c| {
           c.add_remote_wasm_plugin();
         })
         .write_file(file_path, "text")
-        .write_file(format!("{cwd}/other.txt"), "other")
+        .write_file(&other_file_path, "other")
         .set_cwd(cwd)
         .initialize()
         .build();
@@ -1517,7 +1808,556 @@ mod test {
 
       assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
       assert_eq!(environment.read_file(file_path).unwrap(), "text_formatted");
+      // the file in the cwd was not specified, so it should not be formatted
+      assert_eq!(environment.read_file(&other_file_path).unwrap(), "other");
     }
+  }
+
+  #[test]
+  fn should_format_glob_and_parent_path_args_together() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/dprint.json", |c| {
+        c.add_remote_wasm_plugin();
+      })
+      .write_file("/parent.txt", "parent")
+      .write_file("/sub/file1.txt", "text1")
+      .write_file("/sub/file2.txt", "text2")
+      .set_cwd("/sub")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "*.txt", "../parent.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    assert_eq!(environment.read_file("/parent.txt").unwrap(), "parent_formatted");
+    assert_eq!(environment.read_file("/sub/file1.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/sub/file2.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_format_parent_dir_arg_from_subdirectory() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/file.txt", "text1")
+      .write_file("/sub/other.txt", "text2")
+      .set_cwd("/sub")
+      .build();
+
+    run_test_cli(vec!["fmt", ".."], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/sub/other.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_format_sibling_dir_arg_from_subdirectory() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/dprint.json", |c| {
+        c.add_remote_wasm_plugin();
+      })
+      .write_file("/other_dir/file1.txt", "text1")
+      .write_file("/other_dir/nested/file2.txt", "text2")
+      .write_file("/sub/file3.txt", "text3")
+      .set_cwd("/sub")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "../other_dir"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/other_dir/file1.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/other_dir/nested/file2.txt").unwrap(), "text2_formatted");
+    assert_eq!(environment.read_file("/sub/file3.txt").unwrap(), "text3");
+  }
+
+  #[test]
+  fn should_format_specified_gitignored_file() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/.gitignore", "file.txt")
+      .write_file("/file.txt", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text_formatted");
+  }
+
+  #[test]
+  fn should_not_format_specified_file_in_gitignored_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/.gitignore", "sub")
+      .write_file("/sub/file.txt", "text")
+      .write_file("/a.txt", "other")
+      .build();
+
+    // a gitignored ancestor directory hides the file even when it's
+    // explicitly specified (only file-level gitignore entries are overridden
+    // by specifying the file), and the result is the same whether or not a
+    // glob arg triggers a traversal
+    let error = run_test_cli(vec!["fmt", "sub/file.txt"], &environment).err().unwrap();
+    assert_no_files_found(&error, &environment);
+    assert_eq!(environment.read_file("/sub/file.txt").unwrap(), "text");
+
+    run_test_cli(vec!["fmt", "sub/file.txt", "a*.txt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/sub/file.txt").unwrap(), "text");
+    assert_eq!(environment.read_file("/a.txt").unwrap(), "other_formatted");
+  }
+
+  #[test]
+  fn should_discover_sibling_configs_when_formatting_ancestor_dir() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .write_file("/root.txt", "r")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", ".."], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    // formatting from an ancestor directory works like running dprint from
+    // that directory: each file uses the config in its own directory tree
+    // and ungoverned files use the global config
+    assert_eq!(environment.read_file("/project/a.txt").unwrap(), "a_formatted");
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b_other-config");
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "r_global-config");
+  }
+
+  #[test]
+  fn should_discover_sibling_configs_when_formatting_ancestor_glob() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .write_file("/root.txt", "r")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "../**/*.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    assert_eq!(environment.read_file("/project/a.txt").unwrap(), "a_formatted");
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b_other-config");
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "r_global-config");
+  }
+
+  #[test]
+  fn should_format_ancestor_dir_with_explicitly_specified_config() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      // ignored because a config was explicitly specified
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .write_file("/root.txt", "r")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "--config", "/project/dprint.json", ".."], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(3)]);
+    assert_eq!(environment.read_file("/project/a.txt").unwrap(), "a_formatted");
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b_formatted");
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "r_formatted");
+  }
+
+  #[test]
+  fn should_error_formatting_ancestor_dir_without_global_config() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/root.txt", "r")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    // the area above the config's directory has no governing config, the
+    // same as running dprint from that directory
+    let error = run_test_cli(vec!["fmt", ".."], &environment).err().unwrap();
+
+    assert!(error.to_string().starts_with("No dprint config file found for '"), "{}", error);
+    assert_eq!(environment.read_file("/project/a.txt").unwrap(), "a");
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "r");
+  }
+
+  #[test]
+  fn should_format_path_outside_config_dir_using_its_tree_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    // formatted with the config file found in the path's own directory tree
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text_other-config");
+  }
+
+  #[test]
+  fn should_error_formatting_path_outside_config_dir_without_config() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    let error = run_test_cli(vec!["fmt", "../other/file.txt"], &environment).err().unwrap();
+
+    assert!(error.to_string().starts_with("No dprint config file found for '"), "{}", error);
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_error_formatting_outside_path_with_global_config_when_config_discovery_disabled() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/project/other.txt", "other")
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    let error = run_test_cli(
+      vec![
+        "fmt",
+        "--config-discovery=false",
+        "--plugins",
+        "https://plugins.dprint.dev/test-plugin.wasm",
+        "--",
+        "../other/file.txt",
+      ],
+      &environment,
+    )
+    .err()
+    .unwrap();
+
+    // the global config file should not be consulted when config discovery is disabled
+    assert!(error.to_string().starts_with("No dprint config file found for '"), "{}", error);
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_format_path_outside_config_dir_with_global_config() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    // no config file exists in the path's directory tree, so the global config is used
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text_global-config");
+  }
+
+  #[test]
+  fn should_format_path_outside_cwd_when_global_config_in_use() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/project/other.txt", "other")
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    // no config file in the cwd's or the path's directory tree, so the
+    // global config in use governs the explicitly specified path
+    run_test_cli(vec!["fmt", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text_global-config");
+    assert_eq!(environment.read_file("/project/other.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_format_path_outside_config_dir_with_explicitly_specified_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      // this config would win if it wasn't for the explicitly specified config
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "--config", "/project/dprint.json", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text_formatted");
+  }
+
+  #[test]
+  fn should_not_format_outside_path_excluded_by_arg_with_explicit_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/other/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(
+      vec![
+        "fmt",
+        "--config",
+        "/project/dprint.json",
+        "../other/a.txt",
+        "../other/b.txt",
+        "--excludes",
+        "../other/b.txt",
+      ],
+      &environment,
+    )
+    .unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/a.txt").unwrap(), "a_formatted");
+    // the exclude must apply to outside paths too
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b");
+  }
+
+  #[test]
+  fn should_not_format_outside_path_excluded_by_arg_with_global_config_in_use() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/project/other.txt", "other")
+      .write_file("/other/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "../other/a.txt", "../other/b.txt", "--excludes", "../other/b.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/a.txt").unwrap(), "a_global-config");
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b");
+  }
+
+  #[test]
+  fn should_not_format_outside_path_negated_by_arg() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .write_file("/other/a.txt", "a")
+      .write_file("/other/b.txt", "b")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "../other/a.txt", "../other/b.txt", "!../other/b.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/a.txt").unwrap(), "a_other-config");
+    assert_eq!(environment.read_file("/other/b.txt").unwrap(), "b");
+  }
+
+  #[test]
+  fn should_not_format_outside_path_excluded_by_dir_arg() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/project/file.txt", "text")
+      .write_file("/other/file.txt", "other")
+      .set_cwd("/project")
+      .build();
+
+    // an exclude naming the directory an outside path is in
+    run_test_cli(vec!["fmt", "file.txt", "../other/file.txt", "--excludes", "../other"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/project/file.txt").unwrap(), "text_formatted");
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "other");
+
+    // an exclude naming the same directory as an outside dir arg
+    environment.write_file("/project/file.txt", "text").unwrap();
+    run_test_cli(vec!["fmt", "file.txt", "../other", "--excludes", "../other"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/project/file.txt").unwrap(), "text_formatted");
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "other");
+  }
+
+  #[test]
+  fn should_format_outside_dir_with_config_inside_it() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/standalone/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "standalone" }"#);
+      })
+      .write_file("/standalone/file.txt", "text")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "../standalone"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    // the config directly inside the specified directory governs it
+    assert_eq!(environment.read_file("/standalone/file.txt").unwrap(), "text_standalone");
+  }
+
+  #[test]
+  fn should_format_outside_dir_with_explicitly_specified_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/other/file1.txt", "text1")
+      .write_file("/other/nested/file2.txt", "text2")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "--config", "/project/dprint.json", "../other"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/other/file1.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/other/nested/file2.txt").unwrap(), "text2_formatted");
+  }
+
+  #[test]
+  fn should_format_outside_glob_pattern_using_its_tree_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/other/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "other-config" }"#);
+      })
+      .write_file("/other/a.txt", "a")
+      .write_file("/other/nested/b.txt", "b")
+      .write_file("/other/c.json", "c")
+      .set_cwd("/project")
+      .build();
+
+    run_test_cli(vec!["fmt", "../other/**/*.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/other/a.txt").unwrap(), "a_other-config");
+    assert_eq!(environment.read_file("/other/nested/b.txt").unwrap(), "b_other-config");
+    assert_eq!(environment.read_file("/other/c.json").unwrap(), "c");
+  }
+
+  #[test]
+  fn should_skip_outside_path_without_config_when_allow_no_files() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    run_test_cli(vec!["fmt", "--allow-no-files", "a.txt", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["WARNING: Skipping '/other/file.txt' because no dprint config file was found for it."]
+    );
+    assert_eq!(environment.read_file("/project/a.txt").unwrap(), "a_formatted");
+    // skipped with a warning instead of erroring
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text");
   }
 
   #[test]
@@ -1669,6 +2509,31 @@ mod test {
   }
 
   #[test]
+  fn should_format_with_includes_override_when_cwd_deep_below_config_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_remote_wasm_plugin();
+      })
+      .write_file("/sub/dir/file.txt", "text")
+      .write_file("/other.txt", "other")
+      .set_cwd("/sub/dir")
+      .build();
+
+    // the override patterns resolve relative to the cwd, which is multiple
+    // directories below the config directory here
+    for args in [
+      vec!["fmt", "--includes-override", "**/*.txt"],
+      vec!["fmt", "--includes-override", "**/*.txt", "file.txt"],
+    ] {
+      environment.write_file("/sub/dir/file.txt", "text").unwrap();
+      run_test_cli(args, &environment).unwrap();
+      assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+      assert_eq!(environment.read_file("/sub/dir/file.txt").unwrap(), "text_formatted");
+      assert_eq!(environment.read_file("/other.txt").unwrap(), "other");
+    }
+  }
+
+  #[test]
   fn should_not_format_explicitly_specified_file_when_excluded() {
     let file_path1 = "/file1.txt";
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
@@ -1682,6 +2547,58 @@ mod test {
     // this is done for tools like lint staged
     let error = run_test_cli(vec!["fmt", "file1.txt"], &environment).err().unwrap();
     assert_no_files_found(&error, &environment);
+  }
+
+  #[test]
+  fn should_not_format_specified_file_excluded_by_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin().add_excludes("ignored/**");
+      })
+      .write_file("/ignored/file.txt", "text")
+      .build();
+
+    let error = run_test_cli(vec!["fmt", "ignored/file.txt"], &environment).err().unwrap();
+
+    assert_no_files_found(&error, &environment);
+    assert_eq!(environment.read_file("/ignored/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_not_format_specified_file_in_excluded_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        // excludes the directory itself rather than the files within it
+        config.add_remote_wasm_plugin().add_excludes("./ignored");
+      })
+      .write_file("/ignored/file.txt", "text")
+      .build();
+
+    let error = run_test_cli(vec!["fmt", "ignored/file.txt"], &environment).err().unwrap();
+
+    assert_no_files_found(&error, &environment);
+    assert_eq!(environment.read_file("/ignored/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_not_format_when_cwd_inside_config_excluded_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin().add_excludes("**/node_modules");
+      })
+      .write_file("/node_modules/pkg/file.txt", "text")
+      .set_cwd("/node_modules/pkg")
+      .build();
+
+    // matching works the same regardless of the cwd, so running from inside
+    // an excluded directory matches nothing whether the file is specified
+    // directly, matched by a glob, or found by traversing the cwd
+    for args in [vec!["fmt", "file.txt"], vec!["fmt", "file.txt", "*.nomatch"], vec!["fmt"]] {
+      let error = run_test_cli(args, &environment).err().unwrap();
+      assert!(error.to_string().starts_with("No files found to format"), "{}", error);
+      error.assert_exit_code(14);
+      assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text");
+    }
   }
 
   #[test]
@@ -2461,6 +3378,22 @@ mod test {
   }
 
   #[test]
+  fn should_not_format_stdin_file_excluded_by_arg_with_glob_chars() {
+    // stdin matching must agree with a normal `fmt` about an exclude arg
+    // naming an existing directory with glob characters
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_remote_wasm_plugin();
+      })
+      .write_file("/[a]/file.txt", "")
+      .build();
+
+    let test_std_in = TestStdInReader::from("text");
+    run_test_cli_with_stdin(vec!["fmt", "--stdin", "/[a]/file.txt", "--excludes", "[a]"], &environment, test_std_in).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec!["text"]);
+  }
+
+  #[test]
   fn should_not_format_stdin_resolving_config_file_from_provided_path_when_relative() {
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
       .with_default_config(|c| {
@@ -2885,6 +3818,72 @@ mod test {
     // now try with a pattern that doesn't match any file in any scope and it should error
     let err = run_test_cli(vec!["fmt", "**/*.no_matching"], &environment).unwrap_err();
     assert_no_files_found(&err, &environment);
+  }
+
+  #[test]
+  fn should_format_specified_file_using_sub_dir_config() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/sub_dir/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "custom-formatted" }"#);
+      })
+      .write_file("/sub_dir/file.txt", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "sub_dir/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    // formatted with the sub directory config's settings
+    assert_eq!(environment.read_file("/sub_dir/file.txt").unwrap(), "text_custom-formatted");
+  }
+
+  #[test]
+  fn should_format_files_under_nested_config_when_dir_arg_specified() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/dir/sub/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "custom-formatted" }"#);
+      })
+      .write_file("/dir/file1.txt", "text1")
+      .write_file("/dir/sub/file2.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "dir"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/dir/file1.txt").unwrap(), "text1_formatted");
+    // must not be silently skipped by the nested config's scope
+    assert_eq!(environment.read_file("/dir/sub/file2.txt").unwrap(), "text2_custom-formatted");
+  }
+
+  #[test]
+  fn should_format_files_under_nested_config_when_dot_arg_specified() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_local_config("/sub/dprint.json", |config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "custom-formatted" }"#);
+      })
+      .write_file("/root.txt", "text1")
+      .write_file("/sub/file.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "."], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/root.txt").unwrap(), "text1_formatted");
+    assert_eq!(environment.read_file("/sub/file.txt").unwrap(), "text2_custom-formatted");
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -22,6 +22,7 @@ use crate::format::RunForFilePathError;
 use crate::format::run_parallelized;
 use crate::incremental::get_incremental_file;
 use crate::patterns::FileMatcher;
+use crate::patterns::FileMatcherOptions;
 use crate::plugins::PluginResolver;
 use crate::resolution::PluginsScope;
 use crate::resolution::ResolvePluginsScopeAndPathsOptions;
@@ -47,10 +48,12 @@ pub async fn stdin_fmt<TEnvironment: Environment>(
     let resolved_file_path = environment.canonicalize(&cmd.file_name_or_path)?;
     let mut file_matcher = FileMatcher::new(
       environment.clone(),
-      plugins_scope.config.as_ref().unwrap(),
-      &cmd.patterns,
-      &environment.cwd(),
-      Some(resolved_file_path.as_ref()),
+      FileMatcherOptions {
+        config: plugins_scope.config.as_ref().unwrap(),
+        args: &cmd.patterns,
+        root_dir: &environment.cwd(),
+        specified_file_path: Some(resolved_file_path.as_ref()),
+      },
     )?;
     // log the file text as-is since it's not in the list of files to format
     // (checking the ancestor directories too so exclusions apply the same

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -1952,6 +1952,33 @@ mod test {
   }
 
   #[test]
+  fn should_format_file_in_global_config_dir_with_global_config_in_use() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/global-config/file.txt", "text")
+      .set_cwd("/")
+      .initialize()
+      .build();
+
+    // a file in the global config's own directory is formatted by the
+    // global config's scope instead of being dropped because the config
+    // file in use was rediscovered as a descendant config (issue #1111)
+    run_test_cli(vec!["fmt", "global-config/file.txt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/global-config/file.txt").unwrap(), "text_global-config");
+
+    // same when found via traversal
+    environment.write_file("/global-config/file.txt", "text").unwrap();
+    run_test_cli(vec!["fmt", "."], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/global-config/file.txt").unwrap(), "text_global-config");
+  }
+
+  #[test]
   fn should_discover_sibling_configs_when_formatting_ancestor_glob() {
     let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
       .with_local_config("/project/dprint.json", |config| {

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -2391,6 +2391,29 @@ mod test {
   }
 
   #[test]
+  fn should_skip_outside_path_without_config_when_outputting_file_paths() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/project/a.txt", "a")
+      .write_file("/other/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    // this is the command users are told to run to see what dprint is finding,
+    // so it should show what it resolved rather than error out
+    run_test_cli(vec!["output-file-paths", "a.txt", "../other/file.txt"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec!["/project/a.txt"]);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["WARNING: Skipping '/other/file.txt' because no dprint config file was found for it."]
+    );
+  }
+
+  #[test]
   fn should_format_files_with_specific_config_includes() {
     let file_path1 = "/file1.txt";
     let file_path2 = "/file2.txt";

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -35,6 +35,8 @@ pub struct ResolvedConfig {
   pub source: PathSource,
   /// The folder that should be considered the "root".
   pub base_path: CanonicalizedPathBuf,
+  /// Whether this is the user's global configuration file.
+  pub is_global: bool,
   pub includes: Option<Vec<String>>,
   pub excludes: Option<Vec<String>>,
   pub plugins: Vec<PluginSourceReference>,
@@ -120,6 +122,7 @@ pub async fn resolve_config_from_args(args: &CliArgs, environment: &impl Environ
           config_map: ConfigMap::new(),
           base_path: environment.cwd().clone(),
           source: PathSource::new_local(environment.cwd().join_panic_relative("dprint.json")),
+          is_global: false,
           excludes: None,
           includes: None,
           incremental: None,
@@ -196,6 +199,7 @@ pub async fn resolve_config_from_path_with_bytes<TEnvironment: Environment>(
   let resolved_config = ResolvedConfig {
     source: config_path_and_text.source.clone(),
     base_path: config_path_and_text.base_path.clone(),
+    is_global: config_path_and_text.is_global_config,
     config_map,
     includes,
     excludes,
@@ -1852,6 +1856,7 @@ mod tests {
     let parent = ResolvedConfig {
       source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/dprint.json")),
       base_path: CanonicalizedPathBuf::new_for_testing("/"),
+      is_global: false,
       includes: Some(vec!["**/*.txt".to_string()]),
       // "**/node_modules" rebases into the nested directory, but the anchored
       // "dist" points outside it and is dropped
@@ -1881,6 +1886,7 @@ mod tests {
     let child = ResolvedConfig {
       source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/sub/dprint.json")),
       base_path: CanonicalizedPathBuf::new_for_testing("/sub"),
+      is_global: false,
       includes: None,
       excludes: Some(vec!["sub-excludes".to_string()]),
       // a plugin specified in the child has precedence over the ancestor's
@@ -1969,6 +1975,7 @@ mod tests {
     let parent = ResolvedConfig {
       source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/dprint.json")),
       base_path: CanonicalizedPathBuf::new_for_testing("/"),
+      is_global: false,
       includes: None,
       excludes: None,
       plugins: Vec::new(),
@@ -1987,6 +1994,7 @@ mod tests {
     let child = ResolvedConfig {
       source: PathSource::new_local(CanonicalizedPathBuf::new_for_testing("/sub/dprint.json")),
       base_path: CanonicalizedPathBuf::new_for_testing("/sub"),
+      is_global: false,
       includes: None,
       excludes: None,
       plugins: Vec::new(),

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -20,6 +20,7 @@ use crate::environment::Environment;
 use crate::plugins::PluginSourceReference;
 use crate::plugins::parse_plugin_source_reference;
 use crate::utils::GlobPattern;
+use crate::utils::GlobPatternKind;
 use crate::utils::PathSource;
 use crate::utils::PluginKind;
 use crate::utils::ResolvedFilePathWithText;
@@ -259,7 +260,7 @@ fn inherit_excludes(
     .iter()
     .filter_map(|pattern| {
       GlobPattern::new(pattern.clone(), ancestor_base.clone())
-        .into_new_base(new_base.clone())
+        .into_new_base(new_base.clone(), GlobPatternKind::Exclude)
         .map(|p| p.relative_pattern)
     })
     .collect::<Vec<_>>();

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -261,7 +261,11 @@ pub trait Environment:
   /// (e.g. on Windows a running executable can't be removed). This is best-effort
   /// and never fails.
   fn kill_processes_using_dir(&self, dir_path: impl AsRef<Path>) -> usize;
-  fn path_exists(&self, path: impl AsRef<Path>) -> bool;
+  /// Gets whether anything exists at the path (a broken symlink counts as
+  /// existing).
+  fn path_exists(&self, path: impl AsRef<Path>) -> bool {
+    self.path_kind(path).is_some()
+  }
   /// Gets whether the path exists and is a file (follows symlinks).
   fn path_is_file(&self, path: impl AsRef<Path>) -> bool;
   /// Stats the path in a single call, saying whether it's a file, directory,

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -38,6 +38,14 @@ pub enum DirEntry {
   File { name: std::ffi::OsString, path: PathBuf },
 }
 
+/// The kind of entry at a path on the file system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathKind {
+  File,
+  Dir,
+  Symlink,
+}
+
 #[derive(Debug, Clone)]
 pub enum FilePermissions {
   Std(std::fs::Permissions),
@@ -256,6 +264,10 @@ pub trait Environment:
   fn path_exists(&self, path: impl AsRef<Path>) -> bool;
   /// Gets whether the path exists and is a file (follows symlinks).
   fn path_is_file(&self, path: impl AsRef<Path>) -> bool;
+  /// Stats the path in a single call, saying whether it's a file, directory,
+  /// or symlink (`None` when the path doesn't exist). Symlinks are not
+  /// followed—canonicalize and stat again to see what a symlink points at.
+  fn path_kind(&self, path: impl AsRef<Path>) -> Option<PathKind>;
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf>;
   fn is_absolute_path(&self, path: impl AsRef<Path>) -> bool;
   fn file_permissions(&self, path: impl AsRef<Path>) -> io::Result<FilePermissions>;

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -254,6 +254,8 @@ pub trait Environment:
   /// and never fails.
   fn kill_processes_using_dir(&self, dir_path: impl AsRef<Path>) -> usize;
   fn path_exists(&self, path: impl AsRef<Path>) -> bool;
+  /// Gets whether the path exists and is a file (follows symlinks).
+  fn path_is_file(&self, path: impl AsRef<Path>) -> bool;
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf>;
   fn is_absolute_path(&self, path: impl AsRef<Path>) -> bool;
   fn file_permissions(&self, path: impl AsRef<Path>) -> io::Result<FilePermissions>;

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -261,11 +261,9 @@ pub trait Environment:
   /// (e.g. on Windows a running executable can't be removed). This is best-effort
   /// and never fails.
   fn kill_processes_using_dir(&self, dir_path: impl AsRef<Path>) -> usize;
-  /// Gets whether anything exists at the path (a broken symlink counts as
-  /// existing).
-  fn path_exists(&self, path: impl AsRef<Path>) -> bool {
-    self.path_kind(path).is_some()
-  }
+  /// Gets whether anything exists at the path (follows symlinks, so a broken
+  /// symlink does not count as existing).
+  fn path_exists(&self, path: impl AsRef<Path>) -> bool;
   /// Gets whether the path exists and is a file (follows symlinks).
   fn path_is_file(&self, path: impl AsRef<Path>) -> bool;
   /// Stats the path in a single call, saying whether it's a file, directory,

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -450,12 +450,6 @@ impl Environment for RealEnvironment {
     Ok(entries)
   }
 
-  fn path_exists(&self, file_path: impl AsRef<Path>) -> bool {
-    log_debug!(self, "Checking path exists: {}", file_path.as_ref().display());
-    #[allow(clippy::disallowed_methods)]
-    file_path.as_ref().exists()
-  }
-
   fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
     log_debug!(self, "Checking path is file: {}", file_path.as_ref().display());
     #[allow(clippy::disallowed_methods)]

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -450,6 +450,12 @@ impl Environment for RealEnvironment {
     Ok(entries)
   }
 
+  fn path_exists(&self, file_path: impl AsRef<Path>) -> bool {
+    log_debug!(self, "Checking path exists: {}", file_path.as_ref().display());
+    #[allow(clippy::disallowed_methods)]
+    file_path.as_ref().exists()
+  }
+
   fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
     log_debug!(self, "Checking path is file: {}", file_path.as_ref().display());
     #[allow(clippy::disallowed_methods)]

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -39,6 +39,7 @@ use super::DirEntry;
 use super::DownloadedFile;
 use super::Environment;
 use super::FilePermissions;
+use super::PathKind;
 use super::UrlDownloader;
 use crate::plugins::CompilationResult;
 use crate::utils::FastInsecureHasher;
@@ -459,6 +460,19 @@ impl Environment for RealEnvironment {
     log_debug!(self, "Checking path is file: {}", file_path.as_ref().display());
     #[allow(clippy::disallowed_methods)]
     file_path.as_ref().is_file()
+  }
+
+  fn path_kind(&self, file_path: impl AsRef<Path>) -> Option<PathKind> {
+    log_debug!(self, "Statting path: {}", file_path.as_ref().display());
+    #[allow(clippy::disallowed_methods)]
+    let file_type = file_path.as_ref().symlink_metadata().ok()?.file_type();
+    Some(if file_type.is_symlink() {
+      PathKind::Symlink
+    } else if file_type.is_dir() {
+      PathKind::Dir
+    } else {
+      PathKind::File
+    })
   }
 
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf> {

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -455,6 +455,12 @@ impl Environment for RealEnvironment {
     file_path.as_ref().exists()
   }
 
+  fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
+    log_debug!(self, "Checking path is file: {}", file_path.as_ref().display());
+    #[allow(clippy::disallowed_methods)]
+    file_path.as_ref().is_file()
+  }
+
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf> {
     canonicalize_path(path)
   }

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -631,6 +631,11 @@ impl Environment for TestEnvironment {
     Ok(entries)
   }
 
+  fn path_exists(&self, file_path: impl AsRef<Path>) -> bool {
+    let path = self.clean_path(file_path);
+    self.sys.fs_exists_no_err(path)
+  }
+
   fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
     let path = self.clean_path(file_path);
     self.sys.fs_is_file_no_err(path)

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -54,6 +54,7 @@ use super::DirEntry;
 use super::DownloadedFile;
 use super::Environment;
 use super::FilePermissions;
+use super::PathKind;
 use super::UrlDownloader;
 use crate::plugins::CompilationResult;
 use crate::utils::LogLevel;
@@ -638,6 +639,16 @@ impl Environment for TestEnvironment {
   fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
     let path = self.clean_path(file_path);
     self.sys.fs_is_file_no_err(path)
+  }
+
+  fn path_kind(&self, file_path: impl AsRef<Path>) -> Option<PathKind> {
+    let path = self.clean_path(file_path);
+    let metadata = self.sys.fs_symlink_metadata(path).ok()?;
+    Some(match metadata.file_type() {
+      sys_traits::FileType::Dir => PathKind::Dir,
+      sys_traits::FileType::Symlink => PathKind::Symlink,
+      sys_traits::FileType::File | sys_traits::FileType::Unknown => PathKind::File,
+    })
   }
 
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf> {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -635,6 +635,11 @@ impl Environment for TestEnvironment {
     self.sys.fs_exists_no_err(path)
   }
 
+  fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
+    let path = self.clean_path(file_path);
+    self.sys.fs_is_file_no_err(path)
+  }
+
   fn canonicalize(&self, path: impl AsRef<Path>) -> io::Result<CanonicalizedPathBuf> {
     let path = self.clean_path(path);
     // todo: use sys_traits to implement this properly

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -631,11 +631,6 @@ impl Environment for TestEnvironment {
     Ok(entries)
   }
 
-  fn path_exists(&self, file_path: impl AsRef<Path>) -> bool {
-    let path = self.clean_path(file_path);
-    self.sys.fs_exists_no_err(path)
-  }
-
   fn path_is_file(&self, file_path: impl AsRef<Path>) -> bool {
     let path = self.clean_path(file_path);
     self.sys.fs_is_file_no_err(path)

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -130,6 +130,7 @@ async fn get_and_resolve_file_patterns(
   let start_dir = if is_in_sub_dir { cwd } else { config.base_path.clone() };
   let environment = environment.clone();
   let pattern_base = config.base_path.clone();
+  let current_config_path = config.source.maybe_local_path().map(|p| p.as_ref().to_path_buf());
 
   // This is intensive so do it in a blocking task
   dprint_core::async_runtime::spawn_blocking(move || {
@@ -140,6 +141,7 @@ async fn get_and_resolve_file_patterns(
         file_patterns,
         pattern_base,
         config_discovery,
+        current_config_path,
         no_gitignore,
       },
     )

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::Split;
-use sys_traits::FsMetadata;
 use thiserror::Error;
 
 use crate::arg_parser::ConfigDiscovery;
@@ -13,6 +12,7 @@ use crate::configuration::ResolvedConfig;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::patterns::get_all_file_patterns;
+use crate::patterns::process_cli_path_args;
 use crate::patterns::process_config_patterns;
 use crate::plugins::PluginNameResolutionMaps;
 use crate::resolution::PluginWithConfig;
@@ -22,7 +22,6 @@ use crate::utils::GlobPattern;
 use crate::utils::GlobPatterns;
 use crate::utils::glob;
 use crate::utils::is_negated_glob;
-use crate::utils::is_pattern;
 
 /// Struct that allows using plugin names as a key
 /// in a hash map.
@@ -95,68 +94,27 @@ pub async fn get_and_resolve_file_paths<'a>(
   environment: &impl Environment,
 ) -> Result<GlobOutput> {
   let cwd = environment.cwd();
-  let args = expand_directory_include_patterns(args, environment);
-  let mut file_patterns = get_all_file_patterns(config, &args, &cwd);
+  let mut file_patterns = get_all_file_patterns(config, args, &cwd, environment);
 
   if args.only_staged {
     let staged_files = environment.get_staged_files().context("Failed running git staged.")?;
-    file_patterns.arg_includes = Some(GlobPattern::new_vec(
-      staged_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
-      cwd.clone(),
-    ));
+    file_patterns.arg_includes = Some(process_cli_path_args(&staged_files, &cwd, environment));
   } else if args.only_dirty {
     let dirty_files = environment.get_dirty_files().context("Failed running git status.")?;
-    file_patterns.arg_includes = Some(GlobPattern::new_vec(
-      dirty_files.into_iter().map(|path| path.to_string_lossy().into_owned()).collect(),
-      cwd.clone(),
-    ));
+    file_patterns.arg_includes = Some(process_cli_path_args(&dirty_files, &cwd, environment));
   }
 
   if file_patterns.config_includes.is_none() {
     // If no includes patterns were specified, derive one from the list of plugins
     // as this is a massive performance improvement, because it collects less file
     // paths to examine and match to plugins later.
-    let search_base = get_cli_search_base(&cwd, &file_patterns);
-    file_patterns.config_includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), search_base));
+    //
+    // These are based at the config dir rather than the cwd so that explicitly
+    // specified paths outside the cwd (ex. ../file.txt) can still match them.
+    file_patterns.config_includes = Some(GlobPattern::new_vec(get_plugin_patterns(plugins), config.base_path.clone()));
   }
 
   get_and_resolve_file_patterns(config, file_patterns, args.no_gitignore, config_discovery, environment).await
-}
-
-fn expand_directory_include_patterns(args: &FilePatternArgs, environment: &impl Environment) -> FilePatternArgs {
-  FilePatternArgs {
-    include_patterns: args
-      .include_patterns
-      .iter()
-      .flat_map(|pattern| expand_directory_include_pattern(pattern, environment))
-      .collect(),
-    include_pattern_overrides: args.include_pattern_overrides.clone(),
-    exclude_patterns: args.exclude_patterns.clone(),
-    exclude_pattern_overrides: args.exclude_pattern_overrides.clone(),
-    allow_node_modules: args.allow_node_modules,
-    no_gitignore: args.no_gitignore,
-    only_staged: args.only_staged,
-    only_dirty: args.only_dirty,
-  }
-}
-
-fn expand_directory_include_pattern(pattern: &str, environment: &impl Environment) -> Vec<String> {
-  if pattern == "." || is_pattern(pattern) {
-    return vec![pattern.to_string()];
-  }
-
-  let normalized_pattern = pattern.replace('\\', "/");
-  let pattern_path = PathBuf::from(&normalized_pattern);
-  let path = if environment.is_absolute_path(&pattern_path) {
-    pattern_path
-  } else {
-    environment.cwd().join(pattern_path)
-  };
-  if environment.fs_is_dir_no_err(path) {
-    vec![normalized_pattern.clone(), format!("{}/**/*", normalized_pattern.trim_end_matches('/'))]
-  } else {
-    vec![pattern.to_string()]
-  }
 }
 
 async fn get_and_resolve_file_patterns(
@@ -169,11 +127,7 @@ async fn get_and_resolve_file_patterns(
   let cwd = environment.cwd();
   let is_cwd_in_base = cwd.starts_with(&config.base_path);
   let is_in_sub_dir = cwd != config.base_path && is_cwd_in_base;
-  let start_dir = if is_in_sub_dir {
-    get_cli_search_base(&cwd, &file_patterns)
-  } else {
-    config.base_path.clone()
-  };
+  let start_dir = if is_in_sub_dir { cwd } else { config.base_path.clone() };
   let environment = environment.clone();
   let pattern_base = config.base_path.clone();
 
@@ -192,21 +146,6 @@ async fn get_and_resolve_file_patterns(
   })
   .await
   .unwrap()
-}
-
-fn get_cli_search_base(cwd: &CanonicalizedPathBuf, file_patterns: &GlobPatterns) -> CanonicalizedPathBuf {
-  file_patterns
-    .arg_includes
-    .iter()
-    .flat_map(|patterns| patterns.iter())
-    .filter(|pattern| !pattern.is_negated() && cwd.starts_with(&pattern.base_dir))
-    .fold(cwd.clone(), |base_dir, pattern| {
-      if base_dir.starts_with(&pattern.base_dir) {
-        pattern.base_dir.clone()
-      } else {
-        base_dir
-      }
-    })
 }
 
 fn get_plugin_patterns<'a>(plugins: impl Iterator<Item = &'a PluginWithConfig>) -> Vec<String> {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -91,12 +91,17 @@ impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
       GlobMatchesDetail::MatchedOptedOutExclude => {}
       GlobMatchesDetail::Excluded | GlobMatchesDetail::NotMatched => return false,
     };
-    // ensure the parents aren't ignored (skipping the file itself, which
-    // was checked above with file semantics instead of dir semantics)
+    // ensure the parents aren't ignored (skipping the file itself, which was
+    // checked above with file semantics instead of dir semantics, and stopping
+    // at the base directory, which a traversal starts within rather than
+    // descends into)
     if !file_path.starts_with(self.glob_matcher.base_dir()) {
       return false;
     }
     for ancestor in file_path.ancestors().skip(1) {
+      if ancestor == self.glob_matcher.base_dir().as_ref() {
+        break;
+      }
       if let Ok(path) = ancestor.strip_prefix(self.glob_matcher.base_dir()) {
         match self.glob_matcher.check_exclude(path, true) {
           ExcludeMatchDetail::Excluded => return false,
@@ -489,6 +494,36 @@ mod test {
     // a directory-only gitignore pattern (`sub.ts/`) doesn't apply to a
     // file with that name
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/sub.ts", true);
+  }
+
+  #[test]
+  fn ignores_gitignored_base_dir_itself() {
+    let environment = TestEnvironment::new();
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/testing/dir");
+    environment.mk_dir_all(base_dir.as_ref()).unwrap();
+    // the base dir is gitignored by its parent
+    environment.write_file("/testing/.gitignore", "dir/\n").unwrap();
+    let glob_matcher = GlobMatcher::new(
+      GlobPatterns {
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), base_dir.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![],
+      },
+      &GlobMatcherOptions {
+        case_sensitive: true,
+        base_dir: base_dir.clone(),
+      },
+    )
+    .unwrap();
+    let mut file_matcher = FileMatcher {
+      glob_matcher,
+      gitignores: Some(GitIgnoreTree::new(environment, GitIgnoreTreeOptions::default())),
+    };
+    // a traversal starts within the base dir rather than descending into it,
+    // so the base dir being gitignored doesn't exclude everything
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/match.ts", true);
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/sub/match.ts", true);
   }
 
   #[track_caller]

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -91,17 +91,20 @@ impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
       GlobMatchesDetail::MatchedOptedOutExclude => {}
       GlobMatchesDetail::Excluded | GlobMatchesDetail::NotMatched => return false,
     };
-    // ensure the parents aren't ignored
+    // ensure the parents aren't ignored (skipping the file itself, which
+    // was checked above with file semantics instead of dir semantics)
     if !file_path.starts_with(self.glob_matcher.base_dir()) {
       return false;
     }
-    for ancestor in file_path.ancestors() {
+    for ancestor in file_path.ancestors().skip(1) {
       if let Ok(path) = ancestor.strip_prefix(self.glob_matcher.base_dir()) {
         match self.glob_matcher.check_exclude(path, true) {
           ExcludeMatchDetail::Excluded => return false,
           ExcludeMatchDetail::OptedOutExclude => {}
           ExcludeMatchDetail::NotExcluded => {
-            if self.is_gitignored(path, /* is dir */ true) {
+            // the gitignore tree resolves gitignore files by walking the
+            // path's ancestor directories, so pass the absolute path
+            if self.is_gitignored(ancestor, /* is dir */ true) {
               return false;
             }
           }
@@ -452,6 +455,40 @@ mod test {
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/sub-dir/dir/match.ts", true);
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/sub-dir/dir/other/match.ts", true);
     assert_matches_dir_and_not_ignored(&mut file_matcher, "/sub-dir/dist/no-match.ts", false);
+  }
+
+  #[test]
+  fn handles_gitignored_ancestor_dir() {
+    let environment = TestEnvironment::new();
+    // note the cwd differs from the base dir, so gitignore resolution
+    // must not depend on relative paths
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/testing/dir");
+    environment.mk_dir_all(base_dir.as_ref()).unwrap();
+    environment.write_file("/testing/dir/.gitignore", "ignored-dir/\nsub.ts/\n").unwrap();
+    let glob_matcher = GlobMatcher::new(
+      GlobPatterns {
+        arg_includes: None,
+        config_includes: Some(vec![GlobPattern::new("**/*.ts".to_string(), base_dir.clone())]),
+        arg_excludes: None,
+        config_excludes: vec![],
+      },
+      &GlobMatcherOptions {
+        case_sensitive: true,
+        base_dir: base_dir.clone(),
+      },
+    )
+    .unwrap();
+    let mut file_matcher = FileMatcher {
+      glob_matcher,
+      gitignores: Some(GitIgnoreTree::new(environment, GitIgnoreTreeOptions::default())),
+    };
+    // a file within a gitignored ancestor dir doesn't match
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/ignored-dir/no-match.ts", false);
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/ignored-dir/nested/no-match.ts", false);
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/other/match.ts", true);
+    // a directory-only gitignore pattern (`sub.ts/`) doesn't apply to a
+    // file with that name
+    assert_matches_dir_and_not_ignored(&mut file_matcher, "/testing/dir/sub.ts", true);
   }
 
   #[track_caller]

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -20,6 +20,8 @@ use crate::utils::is_absolute_pattern;
 use crate::utils::is_negated_glob;
 use crate::utils::non_negated_glob;
 use crate::utils::resolve_global_gitignore_lines;
+use crate::utils::rewrite_literal_arg_pattern;
+use crate::utils::rewrite_literal_arg_patterns;
 
 pub struct FileMatcher<TEnvironment: Environment> {
   glob_matcher: GlobMatcher,
@@ -27,17 +29,30 @@ pub struct FileMatcher<TEnvironment: Environment> {
 }
 
 impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
-  pub fn new(environment: TEnvironment, config: &ResolvedConfig, args: &FilePatternArgs, root_dir: &CanonicalizedPathBuf) -> Result<Self> {
-    let patterns = get_all_file_patterns(config, args, root_dir);
+  pub fn new(
+    environment: TEnvironment,
+    config: &ResolvedConfig,
+    args: &FilePatternArgs,
+    root_dir: &CanonicalizedPathBuf,
+    specified_file_path: Option<&Path>,
+  ) -> Result<Self> {
+    let mut patterns = get_all_file_patterns(config, args, root_dir, &environment);
+    // resolve args with an existing literal name the same way `glob()` does
+    // (ex. `--stdin` matching must agree with a normal `fmt`)
+    rewrite_literal_arg_patterns(&environment, &mut patterns, &config.base_path);
     let gitignores = if args.no_gitignore {
       None
     } else {
       let global_gitignore_lines = resolve_global_gitignore_lines(&environment);
+      // explicitly specified paths should override what's in the gitignore
+      let mut include_paths = patterns.include_paths();
+      if let Some(path) = specified_file_path {
+        include_paths.push(path.to_path_buf());
+      }
       Some(GitIgnoreTree::new(
         environment,
         GitIgnoreTreeOptions {
-          // explicitly specified paths should override what's in the gitignore
-          include_paths: patterns.include_paths(),
+          include_paths,
           global_gitignore_lines,
         },
       ))
@@ -53,13 +68,9 @@ impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
     Ok(FileMatcher { glob_matcher, gitignores })
   }
 
-  pub fn matches(&self, file_path: impl AsRef<Path>) -> bool {
-    self.glob_matcher.matches(&file_path)
-  }
-
-  /// More expensive check for if the directory is already ignored.
-  /// Prefer using `matches` if you already know the parent directory
-  /// isn't ignored.
+  /// Gets whether the file matches, also checking that none of its
+  /// ancestor directories are excluded or gitignored so exclusions apply
+  /// the same way they do during a directory traversal.
   pub fn matches_and_dir_not_ignored(&mut self, file_path: &Path) -> bool {
     let match_result = self.glob_matcher.matches_detail(file_path);
     match match_result {
@@ -124,32 +135,40 @@ pub fn get_patterns_as_glob_matcher(patterns: &[String], config_base_path: &Cano
   )
 }
 
-pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> GlobPatterns {
+pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf, environment: &impl Environment) -> GlobPatterns {
   GlobPatterns {
-    config_includes: get_config_includes_file_patterns(config, args, cwd),
+    config_includes: get_config_includes_file_patterns(config, args, cwd, environment),
     arg_includes: if args.include_patterns.is_empty() {
       None
     } else {
       // resolve CLI patterns based on the current working directory
-      Some(args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect())
+      Some(args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd, environment)).collect())
     },
-    config_excludes: get_config_exclude_file_patterns(config, args, cwd),
+    config_excludes: get_config_exclude_file_patterns(config, args, cwd, environment),
     arg_excludes: if args.exclude_patterns.is_empty() {
       None
     } else {
       // resolve CLI patterns based on the current working directory
-      Some(args.exclude_patterns.iter().map(|p| process_cli_pattern(p, cwd)).collect())
+      Some(args.exclude_patterns.iter().map(|p| process_cli_pattern(p, cwd, environment)).collect())
     },
   }
 }
 
-fn get_config_includes_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Option<Vec<GlobPattern>> {
+fn get_config_includes_file_patterns(
+  config: &ResolvedConfig,
+  args: &FilePatternArgs,
+  cwd: &CanonicalizedPathBuf,
+  environment: &impl Environment,
+) -> Option<Vec<GlobPattern>> {
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(match &args.include_pattern_overrides {
     Some(includes_overrides) => {
       // resolve CLI patterns based on the current working directory
-      includes_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect()
+      includes_overrides
+        .iter()
+        .map(|p| process_cli_override_pattern(p, cwd, config, environment))
+        .collect()
     }
     None => GlobPattern::new_vec(process_config_patterns(config.includes.as_ref()?).collect(), config.base_path.clone()),
   });
@@ -157,13 +176,21 @@ fn get_config_includes_file_patterns(config: &ResolvedConfig, args: &FilePattern
   Some(file_patterns)
 }
 
-fn get_config_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf) -> Vec<GlobPattern> {
+fn get_config_exclude_file_patterns(
+  config: &ResolvedConfig,
+  args: &FilePatternArgs,
+  cwd: &CanonicalizedPathBuf,
+  environment: &impl Environment,
+) -> Vec<GlobPattern> {
   let mut file_patterns = Vec::new();
 
   file_patterns.extend(match &args.exclude_pattern_overrides {
     Some(exclude_overrides) => {
       // resolve CLI patterns based on the current working directory
-      exclude_overrides.iter().map(|p| process_cli_pattern(p, cwd)).collect()
+      exclude_overrides
+        .iter()
+        .map(|p| process_cli_override_pattern(p, cwd, config, environment))
+        .collect::<Vec<_>>()
     }
     None => config
       .excludes
@@ -191,6 +218,15 @@ fn get_config_exclude_file_patterns(config: &ResolvedConfig, args: &FilePatternA
   file_patterns
 }
 
+/// Processes CLI-provided file paths (ex. git staged files) the same way
+/// as CLI patterns so they resolve to a base directory that contains them.
+pub fn process_cli_path_args(paths: &[PathBuf], cwd: &CanonicalizedPathBuf, environment: &impl Environment) -> Vec<GlobPattern> {
+  paths
+    .iter()
+    .map(|path| process_cli_pattern(&path.to_string_lossy(), cwd, environment))
+    .collect()
+}
+
 fn process_file_pattern_slashes(file_pattern: &str) -> String {
   // Convert all backslashes to forward slashes.
   // It is true that this means someone cannot specify patterns that
@@ -201,7 +237,16 @@ fn process_file_pattern_slashes(file_pattern: &str) -> String {
   file_pattern.replace('\\', "/")
 }
 
-fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf) -> GlobPattern {
+/// Processes an `--includes-override`/`--excludes-override` pattern, resolving
+/// an existing literal name the same way normal CLI args are resolved (ex.
+/// `--includes-override "routes/[id].svelte"` when that file exists).
+fn process_cli_override_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf, config: &ResolvedConfig, environment: &impl Environment) -> GlobPattern {
+  let mut pattern = process_cli_pattern(file_pattern, cwd, environment);
+  rewrite_literal_arg_pattern(environment, &mut pattern, &config.base_path);
+  pattern
+}
+
+fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf, environment: &impl Environment) -> GlobPattern {
   let file_pattern = process_file_pattern_slashes(file_pattern);
   let is_negated = is_negated_glob(&file_pattern);
   let pattern = non_negated_glob(&file_pattern);
@@ -209,25 +254,43 @@ fn process_cli_pattern(file_pattern: &str, cwd: &CanonicalizedPathBuf) -> GlobPa
     return GlobPattern::new(if is_negated { "!./." } else { "**" }.to_string(), cwd.clone());
   }
 
-  let absolute_pattern = if is_absolute_pattern(&file_pattern) {
-    normalize_path(PathBuf::from(pattern))
+  let absolute_pattern = normalize_path(if is_absolute_pattern(&file_pattern) {
+    PathBuf::from(pattern)
   } else {
-    normalize_path(cwd.join(pattern))
-  };
+    cwd.join(pattern)
+  });
 
+  // resolve the pattern against the nearest ancestor directory it's within
+  // so that patterns like ../file.txt or absolute paths outside the current
+  // working directory get a base directory that contains them
   let mut base_dir = cwd.clone();
   loop {
     if let Ok(relative_pattern) = absolute_pattern.strip_prefix(base_dir.as_ref()) {
-      let relative_pattern = process_file_pattern_slashes(&relative_pattern.to_string_lossy());
-      let relative_pattern = format!("{}./{}", if is_negated { "!" } else { "" }, relative_pattern);
-      return GlobPattern::new(relative_pattern, base_dir);
+      return build_cli_pattern(relative_pattern, is_negated, base_dir);
     }
 
     let Some(parent) = base_dir.parent() else {
-      return GlobPattern::new(file_pattern, cwd.clone());
+      break;
     };
     base_dir = parent;
   }
+
+  // the pattern is on a different root than the cwd (ex. another drive
+  // on Windows), so resolve it against its own root directory
+  if let Some(root_dir) = absolute_pattern.ancestors().last().filter(|p| !p.as_os_str().is_empty())
+    && let Ok(relative_pattern) = absolute_pattern.strip_prefix(root_dir)
+    && let Ok(root_dir) = environment.canonicalize(root_dir)
+  {
+    return build_cli_pattern(relative_pattern, is_negated, root_dir);
+  }
+
+  GlobPattern::new(file_pattern, cwd.clone())
+}
+
+fn build_cli_pattern(relative_pattern: &Path, is_negated: bool, base_dir: CanonicalizedPathBuf) -> GlobPattern {
+  let relative_pattern = process_file_pattern_slashes(&relative_pattern.to_string_lossy());
+  let relative_pattern = format!("{}./{}", if is_negated { "!" } else { "" }, relative_pattern);
+  GlobPattern::new(relative_pattern, base_dir)
 }
 
 fn normalize_path(path: PathBuf) -> PathBuf {
@@ -292,12 +355,22 @@ mod test {
     assert_cli_pattern("C:/test/other", "C:\\test", "./other", "C:\\test");
     assert_cli_pattern("../test", "C:\\sub", "./test", "C:\\");
 
+    // a path on a different drive resolves against its own root
+    {
+      let environment = TestEnvironment::new();
+      let pattern = process_cli_pattern("V:/test/file.txt", &CanonicalizedPathBuf::new_for_testing("C:\\sub"), &environment);
+      assert_eq!(pattern.relative_pattern, "./test/file.txt");
+      assert_eq!(pattern.base_dir, environment.canonicalize("V:/").unwrap());
+    }
+
     assert_cli_pattern("!C:/test", "C:\\", "!./test", "C:\\");
     assert_cli_pattern("!C:/test/other", "C:\\test\\", "!./other", "C:\\test\\");
   }
 
+  #[track_caller]
   fn assert_cli_pattern(file_pattern: &str, cwd: &str, expected_pattern: &str, expected_base_dir: &str) {
-    let pattern = process_cli_pattern(file_pattern, &CanonicalizedPathBuf::new_for_testing(cwd));
+    let environment = TestEnvironment::new();
+    let pattern = process_cli_pattern(file_pattern, &CanonicalizedPathBuf::new_for_testing(cwd), &environment);
     assert_eq!(pattern.relative_pattern, expected_pattern);
     assert_eq!(pattern.base_dir, CanonicalizedPathBuf::new_for_testing(expected_base_dir));
   }

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -23,19 +23,28 @@ use crate::utils::resolve_global_gitignore_lines;
 use crate::utils::rewrite_literal_arg_pattern;
 use crate::utils::rewrite_literal_arg_patterns;
 
+pub struct FileMatcherOptions<'a> {
+  pub config: &'a ResolvedConfig,
+  pub args: &'a FilePatternArgs,
+  pub root_dir: &'a CanonicalizedPathBuf,
+  /// An explicitly specified file path (ex. the `--stdin` path) that should
+  /// override what's in the gitignore the same way an explicit fmt arg does.
+  pub specified_file_path: Option<&'a Path>,
+}
+
 pub struct FileMatcher<TEnvironment: Environment> {
   glob_matcher: GlobMatcher,
   gitignores: Option<GitIgnoreTree<TEnvironment>>,
 }
 
 impl<TEnvironment: Environment> FileMatcher<TEnvironment> {
-  pub fn new(
-    environment: TEnvironment,
-    config: &ResolvedConfig,
-    args: &FilePatternArgs,
-    root_dir: &CanonicalizedPathBuf,
-    specified_file_path: Option<&Path>,
-  ) -> Result<Self> {
+  pub fn new(environment: TEnvironment, opts: FileMatcherOptions) -> Result<Self> {
+    let FileMatcherOptions {
+      config,
+      args,
+      root_dir,
+      specified_file_path,
+    } = opts;
     let mut patterns = get_all_file_patterns(config, args, root_dir, &environment);
     // resolve args with an existing literal name the same way `glob()` does
     // (ex. `--stdin` matching must agree with a normal `fmt`)

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -704,7 +704,7 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
       return Ok(Some(OutsideScopeConfig::ConfigFile(config_path)));
     }
 
-    if self.args.sub_command.allow_no_files() {
+    if self.args.sub_command.allow_skipping_paths() {
       log_warn!(
         self.environment,
         "WARNING: Skipping '{}' because no dprint config file was found for it.",

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -48,6 +48,7 @@ use crate::paths::NoFilesFoundError;
 use crate::paths::get_and_resolve_file_paths;
 use crate::paths::get_file_paths_by_plugins;
 use crate::patterns::FileMatcher;
+use crate::patterns::FileMatcherOptions;
 use crate::patterns::get_patterns_as_glob_matcher;
 use crate::plugins::FormatConfig;
 use crate::plugins::InitializedPlugin;
@@ -435,7 +436,15 @@ impl<TEnvironment: Environment> PluginsScope<TEnvironment> {
       let Some(config) = &self.config else {
         return false;
       };
-      let matcher = match FileMatcher::new(self.environment.clone(), config, &FilePatternArgs::default(), &config.base_path, None) {
+      let matcher = match FileMatcher::new(
+        self.environment.clone(),
+        FileMatcherOptions {
+          config,
+          args: &FilePatternArgs::default(),
+          root_dir: &config.base_path,
+          specified_file_path: None,
+        },
+      ) {
         Ok(matcher) => matcher,
         Err(err) => {
           log_warn!(self.environment, "Error creating file matcher: {}", err);

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Result;
+use anyhow::bail;
 use dprint_core::async_runtime::FutureExt;
 use dprint_core::async_runtime::LocalBoxFuture;
 use dprint_core::configuration::ConfigKeyMap;
@@ -33,11 +34,13 @@ use crate::configuration::RawPluginConfigOverride;
 use crate::configuration::ResolveConfigError;
 use crate::configuration::ResolvedConfig;
 use crate::configuration::ResolvedConfigPathWithText;
+use crate::configuration::get_default_config_file_in_ancestor_directories;
 use crate::configuration::get_global_config;
 use crate::configuration::get_plugin_config_map;
 use crate::configuration::inherit_config;
 use crate::configuration::resolve_config_from_args;
 use crate::configuration::resolve_config_from_path_with_bytes;
+use crate::configuration::resolve_global_config_path_and_text;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
 use crate::paths::FilesPathsByPlugins;
@@ -57,7 +60,10 @@ use crate::plugins::output_plugin_config_diagnostics;
 use crate::utils::FastInsecureHasher;
 use crate::utils::GlobMatcher;
 use crate::utils::GlobOutput;
+use crate::utils::OutsideBasePath;
 use crate::utils::PathSource;
+use crate::utils::escape_glob_text_for_cli;
+use crate::utils::is_negated_glob;
 
 pub enum GetPluginResult {
   HadDiagnostics(usize),
@@ -429,7 +435,7 @@ impl<TEnvironment: Environment> PluginsScope<TEnvironment> {
       let Some(config) = &self.config else {
         return false;
       };
-      let matcher = match FileMatcher::new(self.environment.clone(), config, &FilePatternArgs::default(), &config.base_path) {
+      let matcher = match FileMatcher::new(self.environment.clone(), config, &FilePatternArgs::default(), &config.base_path, None) {
         Ok(matcher) => matcher,
         Err(err) => {
           log_warn!(self.environment, "Error creating file matcher: {}", err);
@@ -575,11 +581,11 @@ struct PluginsAndPathsResolver<'a, TEnvironment: Environment> {
 }
 
 impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
-  pub async fn resolve_for_config(&self) -> Result<PluginsScopeAndPathsCollection<TEnvironment>> {
+  pub async fn resolve_for_config(&'a self) -> Result<PluginsScopeAndPathsCollection<TEnvironment>> {
     let config = Rc::new(resolve_config_from_args(self.args, self.environment).await?);
     let scope = resolve_plugins_scope(config.clone(), self.environment, self.plugin_resolver).await?;
     let config_discovery = self.args.config_discovery(self.environment);
-    let glob_output = if self.skip_traversal {
+    let mut glob_output = if self.skip_traversal {
       GlobOutput::default()
     } else {
       get_and_resolve_file_paths(
@@ -591,18 +597,28 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
       )
       .await?
     };
+    let root_config_path = config.source.maybe_local_path().cloned();
+
+    // resolve specified paths that are outside the config's directory
+    // against the config file found in their own directory tree or the
+    // user's global config file
+    let outside_scopes = self
+      .resolve_outside_base_paths(&mut glob_output, &config, config_discovery, root_config_path.clone())
+      .await?;
+
     let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths)?;
 
     let mut result = vec![PluginsScopeAndPaths { scope, file_paths_by_plugins }];
-    let root_config_path = config.source.maybe_local_path();
     // todo: parallelize?
+    let patterns = Rc::new(self.patterns.clone());
     for config_file_path in glob_output.config_files {
       result.extend(
         self
-          .resolve_for_sub_config(config_file_path, &config, config_discovery, root_config_path)
+          .resolve_for_sub_config(config_file_path, config.clone(), config_discovery, root_config_path.clone(), patterns.clone())
           .await?,
       );
     }
+    result.extend(outside_scopes);
 
     Ok(PluginsScopeAndPathsCollection {
       environment: self.environment.clone(),
@@ -610,60 +626,299 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
     })
   }
 
-  fn resolve_for_sub_config(
+  /// Resolves the scopes for specified paths and patterns that are outside
+  /// the config's directory. Each one uses the config file found in its own
+  /// directory tree when one exists, otherwise the explicitly specified or
+  /// global config file, and it's an error when there's no config file to use.
+  async fn resolve_outside_base_paths(
+    &'a self,
+    glob_output: &mut GlobOutput,
+    config: &Rc<ResolvedConfig>,
+    config_discovery: ConfigDiscovery,
+    root_config_path: Option<CanonicalizedPathBuf>,
+  ) -> Result<Vec<PluginsScopeAndPaths<TEnvironment>>> {
+    let outside_base_paths = std::mem::take(&mut glob_output.outside_base_paths);
+    if outside_base_paths.is_empty() {
+      return Ok(Vec::new());
+    }
+
+    // group the paths by the config that governs them (keyed by the config's
+    // base directory)
+    let mut path_groups: IndexMap<CanonicalizedPathBuf, (OutsideScopeConfig, Vec<String>)> = IndexMap::new();
+    for outside_path in outside_base_paths {
+      let Some(scope_config) = self.resolve_outside_scope_config(&outside_path, config, config_discovery)? else {
+        continue; // skipped with a warning
+      };
+      path_groups
+        .entry(scope_config.base_path().clone())
+        .or_insert_with(|| (scope_config, Vec::new()))
+        .1
+        .push(outside_path.include_pattern);
+    }
+
+    let mut result = Vec::new();
+    for (_, (scope_config, include_patterns)) in path_groups {
+      result.extend(
+        self
+          .resolve_outside_scope(scope_config, include_patterns, config, config_discovery, root_config_path.clone())
+          .await?,
+      );
+    }
+    Ok(result)
+  }
+
+  /// Resolves the config that governs the provided outside path. Returns
+  /// `None` when the path should be skipped (a warning was logged).
+  fn resolve_outside_scope_config(
+    &self,
+    outside_path: &OutsideBasePath,
+    config: &ResolvedConfig,
+    config_discovery: ConfigDiscovery,
+  ) -> Result<Option<OutsideScopeConfig>> {
+    let discover_tree_configs = self.args.config.is_none() && config_discovery.traverse_ancestors();
+    if discover_tree_configs && let Some(config_path) = get_default_config_file_in_ancestor_directories(self.environment, &outside_path.config_search_dir)? {
+      return Ok(Some(OutsideScopeConfig::ConfigFile(config_path)));
+    }
+
+    if self.args.config.is_some() || config.is_global {
+      // an explicitly specified config file or the global config file
+      // governs explicitly specified paths anywhere
+      let root_dir = self.canonical_path_root_dir(&outside_path.config_search_dir)?;
+      return Ok(Some(OutsideScopeConfig::RebasedCurrentConfig(root_dir)));
+    }
+
+    // only fall back to the global config file when config discovery is in
+    // its default mode to match main config file resolution
+    if matches!(config_discovery, ConfigDiscovery::Default)
+      && let Some(config_path) = self.global_config_path_based_at_path_root(&outside_path.config_search_dir)?
+    {
+      return Ok(Some(OutsideScopeConfig::ConfigFile(config_path)));
+    }
+
+    if self.args.sub_command.allow_no_files() {
+      log_warn!(
+        self.environment,
+        "WARNING: Skipping '{}' because no dprint config file was found for it.",
+        outside_path.include_pattern,
+      );
+      Ok(None)
+    } else {
+      bail!(
+        concat!(
+          "No dprint config file found for '{}'. The path is outside the config file's directory ",
+          "and no dprint config file was found in the path's ancestor directories. Create one there ",
+          "or set up a global config file by running `dprint init --global`."
+        ),
+        outside_path.include_pattern,
+      );
+    }
+  }
+
+  /// Resolves the scope and file paths for a group of outside paths that
+  /// share a governing config.
+  async fn resolve_outside_scope(
+    &'a self,
+    scope_config: OutsideScopeConfig,
+    mut include_patterns: Vec<String>,
+    config: &Rc<ResolvedConfig>,
+    config_discovery: ConfigDiscovery,
+    root_config_path: Option<CanonicalizedPathBuf>,
+  ) -> Result<Vec<PluginsScopeAndPaths<TEnvironment>>> {
+    // carry the negated patterns along so exclusions specified on the
+    // command line keep applying in the new scope, but only resolve the
+    // grouped paths so files matched by the other args don't get formatted
+    // a second time
+    include_patterns.extend(self.patterns.include_patterns.iter().filter(|p| is_negated_glob(p)).cloned());
+    // the current scope already handles everything in the config's
+    // directory (ex. a `dprint fmt ..` arg covers it with `**`), escaping
+    // in case the directory path contains glob characters (ex. `[app]`)
+    include_patterns.push(format!("!{}/**", escape_glob_text_for_cli(&config.base_path.to_string_lossy())));
+    let patterns = Rc::new(FilePatternArgs {
+      include_patterns,
+      only_staged: false,
+      only_dirty: false,
+      ..self.patterns.clone()
+    });
+    match scope_config {
+      OutsideScopeConfig::ConfigFile(config_path) => {
+        self
+          .resolve_for_config_path(
+            config_path,
+            config.clone(),
+            /* is descendant config */ false,
+            config_discovery,
+            root_config_path,
+            patterns,
+          )
+          .await
+      }
+      OutsideScopeConfig::RebasedCurrentConfig(base_path) => {
+        // with an explicitly specified config file, don't let other config
+        // files take over parts of the scope
+        let config_discovery = if self.args.config.is_some() {
+          ConfigDiscovery::IgnoreDescendants
+        } else {
+          config_discovery
+        };
+        self
+          .resolve_for_rebased_config(config, base_path, config_discovery, root_config_path, patterns)
+          .await
+      }
+    }
+  }
+
+  /// Resolves the scope and file paths for the provided config with its base
+  /// directory changed to the provided path (ex. resolving paths on another
+  /// drive against the in-use config file).
+  async fn resolve_for_rebased_config(
+    &'a self,
+    config: &Rc<ResolvedConfig>,
+    base_path: CanonicalizedPathBuf,
+    config_discovery: ConfigDiscovery,
+    root_config_path: Option<CanonicalizedPathBuf>,
+    patterns: Rc<FilePatternArgs>,
+  ) -> Result<Vec<PluginsScopeAndPaths<TEnvironment>>> {
+    let mut rebased_config = (**config).clone();
+    rebased_config.base_path = base_path;
+    self
+      .resolve_scope_and_descendants(Rc::new(rebased_config), config_discovery, root_config_path, patterns)
+      .await
+  }
+
+  /// Gets the global config file based at the root directory of the provided
+  /// path so the path is within the resulting config's directory.
+  fn global_config_path_based_at_path_root(&self, path: &Path) -> Result<Option<ResolvedConfigPathWithText>> {
+    let Some(global_config_path) = resolve_global_config_path_and_text(self.environment)? else {
+      return Ok(None);
+    };
+    Ok(Some(ResolvedConfigPathWithText {
+      base_path: self.canonical_path_root_dir(path)?,
+      ..global_config_path
+    }))
+  }
+
+  /// Gets the canonicalized root directory of the provided path (ex. the
+  /// drive root on Windows).
+  fn canonical_path_root_dir(&self, path: &Path) -> Result<CanonicalizedPathBuf> {
+    let root_dir = path.ancestors().last().unwrap();
+    Ok(self.environment.canonicalize(root_dir)?)
+  }
+
+  async fn resolve_for_sub_config(
     &'a self,
     config_file_path: PathBuf,
-    parent_config: &'a ResolvedConfig,
+    parent_config: Rc<ResolvedConfig>,
     config_discovery: ConfigDiscovery,
-    root_config_path: Option<&'a CanonicalizedPathBuf>,
+    root_config_path: Option<CanonicalizedPathBuf>,
+    patterns: Rc<FilePatternArgs>,
+  ) -> Result<Vec<PluginsScopeAndPaths<TEnvironment>>> {
+    log_debug!(self.environment, "Analyzing config file {}", config_file_path.display());
+    let config_file_path = self.environment.canonicalize(&config_file_path)?;
+    if Some(&config_file_path) == root_config_path.as_ref() {
+      // config file specified via `--config` so ignore it
+      return Ok(Vec::new());
+    }
+    let config_path = ResolvedConfigPathWithText {
+      content: self.environment.read_file(&config_file_path)?,
+      base_path: config_file_path.parent().unwrap(),
+      source: PathSource::new_local(config_file_path),
+      is_global_config: false,
+      is_first_download: false,
+    };
+    self
+      .resolve_for_config_path(
+        config_path,
+        parent_config,
+        /* is descendant config */ true,
+        config_discovery,
+        root_config_path,
+        patterns,
+      )
+      .await
+  }
+
+  /// Resolves the scope and file paths for a config file, recursively
+  /// resolving any descendant config files found within its directory.
+  fn resolve_for_config_path(
+    &'a self,
+    config_path: ResolvedConfigPathWithText,
+    parent_config: Rc<ResolvedConfig>,
+    is_descendant_config: bool,
+    config_discovery: ConfigDiscovery,
+    root_config_path: Option<CanonicalizedPathBuf>,
+    patterns: Rc<FilePatternArgs>,
   ) -> LocalBoxFuture<'a, Result<Vec<PluginsScopeAndPaths<TEnvironment>>>> {
     async move {
-      log_debug!(self.environment, "Analyzing config file {}", config_file_path.display());
-      let config_file_path = self.environment.canonicalize(&config_file_path)?;
-      if Some(&config_file_path) == root_config_path {
-        // config file specified via `--config` so ignore it
-        return Ok(Vec::new());
-      }
-      let config_path = ResolvedConfigPathWithText {
-        content: self.environment.read_file(&config_file_path)?,
-        base_path: config_file_path.parent().unwrap(),
-        source: PathSource::new_local(config_file_path),
-        is_global_config: false,
-        is_first_download: false,
-      };
       let mut config = resolve_config_from_path_with_bytes(&config_path, self.environment).await?;
-      // when the nested config opts into inheriting, merge in the ancestor config
-      if config.inherit == Some(true) {
-        config = inherit_config(config, parent_config)?;
+      // when a nested config opts into inheriting, merge in the ancestor config
+      if is_descendant_config && config.inherit == Some(true) {
+        config = inherit_config(config, &parent_config)?;
       }
       if !self.args.plugins.is_empty() {
         config.plugins.clone_from(&parent_config.plugins);
       }
-      let config = Rc::new(config);
-      let scope = resolve_plugins_scope(config.clone(), self.environment, self.plugin_resolver).await?;
-      let glob_output = get_and_resolve_file_paths(
-        &config,
-        self.patterns,
-        config_discovery,
-        scope.plugins.values().map(|p| p.as_ref()),
-        self.environment,
-      )
-      .await?;
-      let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths)?;
-
-      let mut result = vec![PluginsScopeAndPaths { scope, file_paths_by_plugins }];
-      // todo: parallelize?
-      for config_file_path in glob_output.config_files {
-        result.extend(
-          self
-            .resolve_for_sub_config(config_file_path, &config, config_discovery, root_config_path)
-            .await?,
-        );
-      }
-
-      Ok(result)
+      self
+        .resolve_scope_and_descendants(Rc::new(config), config_discovery, root_config_path, patterns)
+        .await
     }
     .boxed_local()
+  }
+
+  /// Resolves the plugins scope and file paths for the provided config,
+  /// recursively resolving any descendant config files found within its
+  /// directory.
+  async fn resolve_scope_and_descendants(
+    &'a self,
+    config: Rc<ResolvedConfig>,
+    config_discovery: ConfigDiscovery,
+    root_config_path: Option<CanonicalizedPathBuf>,
+    patterns: Rc<FilePatternArgs>,
+  ) -> Result<Vec<PluginsScopeAndPaths<TEnvironment>>> {
+    let scope = resolve_plugins_scope(config.clone(), self.environment, self.plugin_resolver).await?;
+    let mut glob_output = get_and_resolve_file_paths(
+      &config,
+      &patterns,
+      config_discovery,
+      scope.plugins.values().map(|p| p.as_ref()),
+      self.environment,
+    )
+    .await?;
+    // paths outside this config's directory were already handled when
+    // resolving the root scope
+    glob_output.outside_base_paths.clear();
+    let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths)?;
+
+    let mut result = vec![PluginsScopeAndPaths { scope, file_paths_by_plugins }];
+    // todo: parallelize?
+    for config_file_path in glob_output.config_files {
+      result.extend(
+        self
+          .resolve_for_sub_config(config_file_path, config.clone(), config_discovery, root_config_path.clone(), patterns.clone())
+          .await?,
+      );
+    }
+    Ok(result)
+  }
+}
+
+/// The config governing paths that are outside the main config's directory.
+enum OutsideScopeConfig {
+  /// A config file found for the outside path (in its directory tree or
+  /// the user's global config file).
+  ConfigFile(ResolvedConfigPathWithText),
+  /// The config file already in use (an explicitly specified `--config`
+  /// or the global config file), rebased at the outside path's root
+  /// directory so the path is within the scope and the config's
+  /// unanchored patterns still apply.
+  RebasedCurrentConfig(CanonicalizedPathBuf),
+}
+
+impl OutsideScopeConfig {
+  fn base_path(&self) -> &CanonicalizedPathBuf {
+    match self {
+      Self::ConfigFile(config_path) => &config_path.base_path,
+      Self::RebasedCurrentConfig(base_path) => base_path,
+    }
   }
 }
 

--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::environment::Environment;
+use crate::utils::escape_glob_text;
 
 /// Lifted from the Deno code.
 /// Copyright 2018-2024 the Deno authors. MIT license.
@@ -182,10 +183,11 @@ impl<TEnvironment: Environment> GitIgnoreTree<TEnvironment> {
         builder.add_line(None, line).ok()?;
       }
     }
-    // override the gitignore contents to include these paths
+    // override the gitignore contents to include these paths (escaping so a
+    // path with glob characters in its name matches literally)
     for path in &self.options.include_paths {
       if let Ok(suffix) = path.strip_prefix(dir_path) {
-        let suffix = suffix.to_string_lossy().replace('\\', "/");
+        let suffix = escape_glob_text(&suffix.to_string_lossy().replace('\\', "/"));
         let _ignore = builder.add_line(None, &format!("!/{}", suffix));
         if !suffix.ends_with('/') {
           let _ignore = builder.add_line(None, &format!("!/{}/", suffix));

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -55,6 +55,10 @@ pub struct GlobOptions {
   pub start_dir: PathBuf,
   /// Whether to enable configuration discovery.
   pub config_discovery: ConfigDiscovery,
+  /// The config file already in use, so it isn't rediscovered as a
+  /// descendant config file (ex. the global config file when its directory
+  /// is within the directory being formatted).
+  pub current_config_path: Option<PathBuf>,
   /// The file patterns to use for globbing.
   pub file_patterns: GlobPatterns,
   /// The directory to use as the base for the patterns.
@@ -119,7 +123,7 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
   };
 
   let discover_configs = opts.config_discovery.traverse_descendants();
-  let mut config_file_finder = DirConfigFileFinder::new(environment);
+  let mut config_file_finder = DirConfigFileFinder::new(environment, opts.current_config_path.clone());
 
   // check the directories between the pattern base and the start directory the
   // same way a traversal descending from the pattern base would so matching
@@ -197,6 +201,7 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
       ReadDirRunnerOptions {
         start_dir: opts.start_dir,
         config_discovery: opts.config_discovery,
+        current_config_path: opts.current_config_path,
         thread_count: read_dir_thread_count,
       },
     ));
@@ -551,13 +556,15 @@ fn push_dedup_config_file(config_files: &mut Vec<PathBuf>, config_file: PathBuf)
 /// directory because multiple file paths often share ancestor directories.
 struct DirConfigFileFinder<'a, TEnvironment: Environment> {
   environment: &'a TEnvironment,
+  current_config_path: Option<PathBuf>,
   cache: HashMap<PathBuf, Option<PathBuf>>,
 }
 
 impl<'a, TEnvironment: Environment> DirConfigFileFinder<'a, TEnvironment> {
-  pub fn new(environment: &'a TEnvironment) -> Self {
+  pub fn new(environment: &'a TEnvironment, current_config_path: Option<PathBuf>) -> Self {
     Self {
       environment,
+      current_config_path,
       cache: Default::default(),
     }
   }
@@ -569,6 +576,8 @@ impl<'a, TEnvironment: Environment> DirConfigFileFinder<'a, TEnvironment> {
     let result = POSSIBLE_CONFIG_FILE_NAMES
       .iter()
       .map(|file_name| dir.join(file_name))
+      // the config file already in use doesn't create a new scope
+      .filter(|path| Some(path.as_path()) != self.current_config_path.as_deref())
       .find(|path| self.environment.path_is_file(path));
     self.cache.insert(dir.to_path_buf(), result.clone());
     result
@@ -640,6 +649,7 @@ const PUSH_DIR_ENTRIES_BATCH_COUNT: usize = 500;
 struct ReadDirRunnerOptions {
   start_dir: PathBuf,
   config_discovery: ConfigDiscovery,
+  current_config_path: Option<PathBuf>,
   thread_count: usize,
 }
 
@@ -711,7 +721,10 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
         .filter_map(|e| match e {
           DirEntry::Directory(_) => None,
           DirEntry::File { name, path } => {
-            if name.to_str().is_some_and(|name| POSSIBLE_CONFIG_FILE_NAMES.contains(&name)) {
+            // the config file already in use doesn't create a new scope
+            if name.to_str().is_some_and(|name| POSSIBLE_CONFIG_FILE_NAMES.contains(&name))
+              && Some(path.as_path()) != self.options.current_config_path.as_deref()
+            {
               Some(path)
             } else {
               None
@@ -1011,6 +1024,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1054,6 +1068,7 @@ mod test {
       let result = glob(
         &environment,
         GlobOptions {
+          current_config_path: None,
           start_dir: PathBuf::from("/"),
           config_discovery: ConfigDiscovery::Default,
           file_patterns: GlobPatterns {
@@ -1094,6 +1109,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1130,6 +1146,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1164,6 +1181,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1197,6 +1215,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1230,6 +1249,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1263,6 +1283,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1297,6 +1318,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Disabled,
         file_patterns: GlobPatterns {
@@ -1326,6 +1348,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1353,6 +1376,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         // this happens when running `dprint fmt "../other/**"` from /sub
         start_dir: PathBuf::from("/sub"),
         config_discovery: ConfigDiscovery::Default,
@@ -1381,6 +1405,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1407,6 +1432,7 @@ mod test {
     let err_message = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1432,6 +1458,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1459,6 +1486,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1491,6 +1519,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1525,6 +1554,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/test/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1560,6 +1590,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {
@@ -1593,6 +1624,7 @@ mod test {
     let result = glob(
       &environment,
       GlobOptions {
+        current_config_path: None,
         start_dir: PathBuf::from("/"),
         config_discovery: ConfigDiscovery::Default,
         file_patterns: GlobPatterns {

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -3,12 +3,15 @@ use anyhow::Result;
 use anyhow::anyhow;
 use parking_lot::Condvar;
 use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::arg_parser::ConfigDiscovery;
+use crate::configuration::POSSIBLE_CONFIG_FILE_NAMES;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::DirEntry;
 use crate::environment::Environment;
@@ -21,12 +24,29 @@ use super::ExcludeMatchDetail;
 use super::GlobMatcher;
 use super::GlobMatcherOptions;
 use super::GlobMatchesDetail;
+use super::GlobPattern;
 use super::GlobPatterns;
+use super::escape_glob_text;
+use super::is_pattern;
+use super::non_negated_glob;
+use super::unescape_glob_text;
 
 #[derive(Debug, Default, Clone)]
 pub struct GlobOutput {
   pub file_paths: Vec<PathBuf>,
   pub config_files: Vec<PathBuf>,
+  /// CLI paths and patterns that are outside the pattern base directory.
+  /// The caller resolves the config file to use for these separately.
+  pub outside_base_paths: Vec<OutsideBasePath>,
+}
+
+/// A CLI path or glob pattern that is outside the pattern base directory.
+#[derive(Debug, Clone)]
+pub struct OutsideBasePath {
+  /// The directory to start searching for the governing config file from.
+  pub config_search_dir: PathBuf,
+  /// The absolute path or pattern to resolve in the new scope.
+  pub include_pattern: String,
 }
 
 pub struct GlobOptions {
@@ -43,7 +63,7 @@ pub struct GlobOptions {
   pub no_gitignore: bool,
 }
 
-pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOutput> {
+pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<GlobOutput> {
   if opts
     .file_patterns
     .arg_includes
@@ -59,7 +79,20 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
   let start_instant = std::time::Instant::now();
   log_debug!(environment, "Globbing: {:?}", opts.file_patterns);
 
-  let git_ignore_tree = if opts.no_gitignore {
+  // resolve literal (non-glob) CLI paths directly against the file system so
+  // they can be matched without directory traversal (this also allows matching
+  // paths outside the directory the traversal starts in, like ../file.txt)
+  let mut literal_arg_paths = extract_literal_arg_paths(environment, &mut opts.file_patterns, &opts.pattern_base);
+  rewrite_literal_exclude_paths(environment, &mut opts.file_patterns, &opts.pattern_base);
+  extract_outside_arg_patterns(&mut opts.file_patterns, &opts.pattern_base, &mut literal_arg_paths.outside_base_paths);
+  let mut run_traversal = requires_traversal(&opts.file_patterns);
+  if run_traversal {
+    opts.start_dir = expand_start_dir_for_arg_patterns(opts.start_dir, &opts.file_patterns, &opts.pattern_base);
+  } else {
+    log_debug!(environment, "Skipping traversal because the CLI args were all file paths.");
+  }
+
+  let mut git_ignore_tree = if opts.no_gitignore {
     None
   } else {
     Some(GitIgnoreTree::new(
@@ -75,42 +108,460 @@ pub fn glob(environment: &impl Environment, opts: GlobOptions) -> Result<GlobOut
     &GlobMatcherOptions {
       // make it work the same way on every operating system
       case_sensitive: true,
-      base_dir: opts.pattern_base,
+      base_dir: opts.pattern_base.clone(),
     },
   )?;
 
-  let shared_state = Arc::new(SharedState::new(opts.start_dir.clone()));
+  let mut output = GlobOutput {
+    outside_base_paths: literal_arg_paths.outside_base_paths,
+    ..Default::default()
+  };
 
-  // This is a performance improvement to attempt to reduce the time of globbing down
-  // to the speed of `fs::read_dir` calls. Essentially, run all the `fs::read_dir` calls
-  // on separate threads and do the glob matching on the current thread.
-  //
-  // Reading directories is I/O bound, so spreading the reads across several threads
-  // saturates the disk far better than a single reader can. See issue #1001.
-  let read_dir_thread_count = resolve_read_dir_thread_count(environment);
-  log_debug!(environment, "Reading directories on {} thread(s)", read_dir_thread_count);
-  let read_dir_runner = Arc::new(ReadDirRunner::new(
-    environment.clone(),
-    shared_state.clone(),
-    ReadDirRunnerOptions {
-      start_dir: opts.start_dir,
-      config_discovery: opts.config_discovery,
-      thread_count: read_dir_thread_count,
-    },
-  ));
-  for _ in 0..read_dir_thread_count {
-    let read_dir_runner = read_dir_runner.clone();
-    dprint_core::async_runtime::spawn_blocking(move || read_dir_runner.run());
+  let discover_configs = opts.config_discovery.traverse_descendants();
+  let mut config_file_finder = DirConfigFileFinder::new(environment);
+
+  // check the directories between the pattern base and the start directory the
+  // same way a traversal descending from the pattern base would so matching
+  // works the same regardless of the directory dprint is run from
+  if run_traversal && opts.start_dir != opts.pattern_base.as_ref() && opts.start_dir.starts_with(opts.pattern_base.as_ref()) {
+    match check_dir_chain(
+      &glob_matcher,
+      &mut git_ignore_tree,
+      discover_configs.then_some(&mut config_file_finder),
+      opts.pattern_base.as_ref(),
+      &opts.start_dir,
+    ) {
+      DirChainResult::Matched => {}
+      DirChainResult::Excluded => {
+        log_debug!(environment, "Skipping traversal because the start directory is excluded.");
+        run_traversal = false;
+      }
+      DirChainResult::HasConfigFile(config_file) => {
+        // the sub scope created for the config file handles this directory
+        log_debug!(environment, "Skipping traversal because the start directory has its own config file.");
+        push_dedup_config_file(&mut output.config_files, config_file);
+        run_traversal = false;
+      }
+    }
   }
 
-  // run the glob matching on the current thread (it communicates with the reader threads)
-  let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
-  let results = glob_matching_processor.run()?;
+  // match the literal file paths (a gitignored file is still matched when
+  // explicitly specified, but not when one of its ancestor directories is
+  // gitignored because a traversal wouldn't descend into the directory)
+  for file_path in literal_arg_paths.file_paths {
+    if run_traversal && file_path.starts_with(&opts.start_dir) {
+      continue; // the traversal will find this file
+    }
+    // examine the file's ancestor directories top down the same way a
+    // traversal would: an excluded directory excludes everything within it
+    // and a directory with its own config file is handled by the sub scope
+    // created for that config file instead of the current scope
+    if let Some(parent) = file_path.parent()
+      && parent.starts_with(opts.pattern_base.as_ref())
+    {
+      match check_dir_chain(
+        &glob_matcher,
+        &mut git_ignore_tree,
+        discover_configs.then_some(&mut config_file_finder),
+        opts.pattern_base.as_ref(),
+        parent,
+      ) {
+        DirChainResult::Matched => {}
+        DirChainResult::Excluded => continue,
+        DirChainResult::HasConfigFile(config_file) => {
+          push_dedup_config_file(&mut output.config_files, config_file);
+          continue;
+        }
+      }
+    }
+    if glob_matcher.matches(&file_path) {
+      output.file_paths.push(file_path);
+    }
+  }
 
-  log_debug!(environment, "File(s) matched: {:?}", results);
+  if run_traversal {
+    let shared_state = Arc::new(SharedState::new(opts.start_dir.clone()));
+
+    // This is a performance improvement to attempt to reduce the time of globbing down
+    // to the speed of `fs::read_dir` calls. Essentially, run all the `fs::read_dir` calls
+    // on separate threads and do the glob matching on the current thread.
+    //
+    // Reading directories is I/O bound, so spreading the reads across several threads
+    // saturates the disk far better than a single reader can. See issue #1001.
+    let read_dir_thread_count = resolve_read_dir_thread_count(environment);
+    log_debug!(environment, "Reading directories on {} thread(s)", read_dir_thread_count);
+    let read_dir_runner = Arc::new(ReadDirRunner::new(
+      environment.clone(),
+      shared_state.clone(),
+      ReadDirRunnerOptions {
+        start_dir: opts.start_dir,
+        config_discovery: opts.config_discovery,
+        thread_count: read_dir_thread_count,
+      },
+    ));
+    for _ in 0..read_dir_thread_count {
+      let read_dir_runner = read_dir_runner.clone();
+      dprint_core::async_runtime::spawn_blocking(move || read_dir_runner.run());
+    }
+
+    // run the glob matching on the current thread (it communicates with the reader threads)
+    let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
+    let results = glob_matching_processor.run()?;
+    output.file_paths.extend(results.file_paths);
+    output.config_files.extend(results.config_files);
+  }
+
+  log_debug!(environment, "File(s) matched: {:?}", output);
   log_debug!(environment, "Finished globbing in {}ms", start_instant.elapsed().as_millis());
 
-  Ok(results)
+  Ok(output)
+}
+
+struct LiteralArgPaths {
+  /// Files to match in the current scope.
+  file_paths: Vec<PathBuf>,
+  /// Existing paths outside the pattern base directory.
+  outside_base_paths: Vec<OutsideBasePath>,
+}
+
+/// Resolves the positive literal CLI patterns against the file system.
+///
+/// Existing files are returned so they can be matched directly without any
+/// directory traversal, and patterns for existing directories are expanded to
+/// match everything within them (ex. `dprint fmt some_dir`). A glob-like
+/// pattern whose text names an existing path is treated as that path instead
+/// of a glob (ex. `dprint fmt routes/[id].svelte`). Paths outside the pattern
+/// base directory are returned separately because the config file to use for
+/// them needs to be resolved by the caller.
+fn extract_literal_arg_paths(environment: &impl Environment, file_patterns: &mut GlobPatterns, pattern_base: &CanonicalizedPathBuf) -> LiteralArgPaths {
+  let mut seen = HashSet::new();
+  let mut result = LiteralArgPaths {
+    file_paths: Vec::new(),
+    outside_base_paths: Vec::new(),
+  };
+  for pattern in file_patterns.arg_includes.iter_mut().flatten() {
+    if pattern.is_negated() {
+      // a negated arg with an existing literal name should skip that path
+      // instead of matching as a glob (ex. `!routes/[id].svelte`)
+      rewrite_literal_arg_pattern(environment, pattern, pattern_base);
+      continue;
+    }
+    if !could_be_literal_path(&pattern.relative_pattern) {
+      continue;
+    }
+    let relative_path = pattern.relative_pattern.strip_prefix("./").unwrap_or(&pattern.relative_pattern);
+    let relative_path = relative_path.trim_end_matches('/');
+    // unescape so escaped glob characters resolve to the actual path
+    // (ex. `\[a\]/file.js`)
+    let relative_path = unescape_glob_text(relative_path);
+    let (path, is_file) = if relative_path.is_empty() {
+      // the pattern resolved to its base directory itself (ex. `dprint fmt ..`)
+      (pattern.base_dir.as_ref().to_path_buf(), false)
+    } else {
+      // use platform-style separators so the resolved paths are
+      // consistent with the paths a traversal produces
+      let path = if cfg!(windows) {
+        pattern.base_dir.join(relative_path.replace('/', "\\"))
+      } else {
+        pattern.base_dir.join(relative_path.as_ref())
+      };
+      let is_file = environment.path_is_file(&path);
+      if !is_file && !environment.path_exists(&path) {
+        // a glob-like pattern stays a glob when nothing has its literal name
+        continue;
+      }
+      // resolve symlinks and casing differences so the path gets classified
+      // and matched based on where it actually is on the file system
+      let path = match environment.canonicalize(&path) {
+        Ok(canonical) => canonical.into_path_buf(),
+        Err(_) => path,
+      };
+      (path, is_file)
+    };
+    if !is_file && pattern_base.as_ref().starts_with(&path) {
+      // a directory at or above the pattern base directory, so match
+      // everything in the current scope
+      if path != *pattern_base.as_ref() && seen.insert(path.clone()) {
+        // also resolve the parts of the ancestor directory outside the
+        // current scope separately (ex. sibling directories with their own
+        // config files)
+        result.outside_base_paths.push(OutsideBasePath {
+          config_search_dir: path.clone(),
+          include_pattern: path.to_string_lossy().into_owned(),
+        });
+      }
+      pattern.relative_pattern = "**".to_string();
+      pattern.base_dir = pattern_base.clone();
+    } else if !path.starts_with(pattern_base.as_ref()) {
+      if seen.insert(path.clone()) {
+        result.outside_base_paths.push(OutsideBasePath {
+          config_search_dir: if is_file {
+            path.parent().map(|p| p.to_path_buf()).unwrap_or_else(|| path.clone())
+          } else {
+            path.clone()
+          },
+          include_pattern: path.to_string_lossy().into_owned(),
+        });
+      }
+      // escape so the retained pattern is treated as a literal path instead
+      // of a glob (the outside scope resolves the path itself)
+      pattern.relative_pattern = format!("./{}", escape_glob_text(&relative_path));
+    } else {
+      // rewrite the pattern to the canonicalized path so the matcher's
+      // literal path set agrees with the resolved path (escaping so glob
+      // characters in the path match literally)
+      let relative = path.strip_prefix(pattern_base.as_ref()).unwrap().to_string_lossy().replace('\\', "/");
+      pattern.base_dir = pattern_base.clone();
+      if is_file {
+        pattern.relative_pattern = format!("./{}", escape_glob_text(&relative));
+        if seen.insert(path.clone()) {
+          result.file_paths.push(path);
+        }
+      } else {
+        // an existing directory, so match everything within it
+        pattern.relative_pattern = format!("./{}/**", escape_glob_text(&relative));
+      }
+    }
+  }
+  result
+}
+
+/// Rewrites the CLI arg patterns whose text names an existing path to match
+/// that path literally, for matchers built without a full `glob()` (ex.
+/// `dprint fmt --stdin`). Within `glob()` the positive include args are
+/// instead handled by `extract_literal_arg_paths` because they additionally
+/// resolve directory contents and outside paths.
+pub fn rewrite_literal_arg_patterns(environment: &impl Environment, file_patterns: &mut GlobPatterns, pattern_base: &CanonicalizedPathBuf) {
+  for pattern in file_patterns.arg_includes.iter_mut().flatten() {
+    rewrite_literal_arg_pattern(environment, pattern, pattern_base);
+  }
+  rewrite_literal_exclude_paths(environment, file_patterns, pattern_base);
+}
+
+/// Rewrites the exclude args whose text names an existing path to match that
+/// path literally, the same way include args are resolved (ex. `--excludes
+/// "[a]"` excludes a directory named `[a]` instead of matching as a character
+/// class).
+fn rewrite_literal_exclude_paths(environment: &impl Environment, file_patterns: &mut GlobPatterns, pattern_base: &CanonicalizedPathBuf) {
+  for pattern in file_patterns.arg_excludes.iter_mut().flatten() {
+    rewrite_literal_arg_pattern(environment, pattern, pattern_base);
+  }
+}
+
+/// Rewrites a single arg pattern to match literally when its text names an
+/// existing path, preserving any negation (ex. `!routes/[id].svelte` skips
+/// the file with that name instead of matching as a character class).
+pub fn rewrite_literal_arg_pattern(environment: &impl Environment, pattern: &mut GlobPattern, pattern_base: &CanonicalizedPathBuf) {
+  let is_negated = pattern.is_negated();
+  let text = non_negated_glob(&pattern.relative_pattern);
+  if !is_pattern(text) || !could_be_literal_path(text) {
+    return;
+  }
+  let relative_path = text.strip_prefix("./").unwrap_or(text);
+  let relative_path = relative_path.trim_end_matches('/');
+  if relative_path.is_empty() {
+    return;
+  }
+  let path = if cfg!(windows) {
+    pattern.base_dir.join(relative_path.replace('/', "\\"))
+  } else {
+    pattern.base_dir.join(relative_path)
+  };
+  if !environment.path_exists(&path) {
+    return;
+  }
+  let canonical_path = match environment.canonicalize(&path) {
+    Ok(canonical) => canonical.into_path_buf(),
+    Err(_) => path,
+  };
+  // rebase onto the pattern base when the canonical path is within it,
+  // otherwise keep the uncanonicalized name (ex. a symlink pointing outside
+  // the base still gets excluded by the name a traversal encounters)
+  let (base_dir, relative) = match canonical_path.strip_prefix(pattern_base.as_ref()) {
+    Ok(relative) if !relative.as_os_str().is_empty() => (pattern_base.clone(), relative.to_string_lossy().replace('\\', "/")),
+    _ => (pattern.base_dir.clone(), relative_path.to_string()),
+  };
+  pattern.base_dir = base_dir;
+  pattern.relative_pattern = format!("{}./{}", if is_negated { "!" } else { "" }, escape_glob_text(&relative));
+}
+
+/// Gets whether the pattern's text could name a literal path on the file
+/// system and so is worth checking for existence.
+///
+/// Patterns with `*` or `?` are always treated as globs (`*` isn't even
+/// allowed in Windows file names), but `[` and `{` are valid in file names
+/// (ex. `routes/[id].svelte`), so those are resolved against the file system
+/// (see issues #552, #920, #947).
+fn could_be_literal_path(pattern: &str) -> bool {
+  let mut was_last_escape = false;
+  for c in pattern.chars() {
+    if !was_last_escape && matches!(c, '*' | '?') {
+      return false;
+    }
+    was_last_escape = matches!(c, '\\');
+  }
+  true
+}
+
+/// Extracts the positive CLI glob patterns based outside the pattern base
+/// directory (ex. `dprint fmt ../other/**` when `../other` is outside the
+/// config's directory or on another drive). They can never match anything in
+/// the current scope, so the caller resolves the config file to use for them
+/// separately the same way it does for literal paths outside the base. A
+/// pattern based at an ancestor of the base is kept for the current scope and
+/// additionally resolved separately for the parts outside the scope.
+fn extract_outside_arg_patterns(file_patterns: &mut GlobPatterns, pattern_base: &CanonicalizedPathBuf, outside_base_paths: &mut Vec<OutsideBasePath>) {
+  let Some(includes) = &mut file_patterns.arg_includes else {
+    return;
+  };
+  includes.retain(|pattern| {
+    if !is_positive_glob_pattern(pattern) {
+      return true;
+    }
+    let deepest_base = pattern.clone().into_deepest_base().base_dir;
+    if deepest_base.starts_with(pattern_base) {
+      return true; // only matches within the scope
+    }
+    outside_base_paths.push(OutsideBasePath {
+      config_search_dir: deepest_base.as_ref().to_path_buf(),
+      include_pattern: pattern.as_absolute_pattern_text(),
+    });
+    // a pattern based at an ancestor directory also matches within the scope
+    pattern_base.starts_with(&deepest_base)
+  });
+}
+
+/// Gets whether resolving the patterns requires traversing the file system.
+///
+/// Traversal isn't necessary when the CLI args are all literal file paths
+/// because those are resolved directly against the file system.
+fn requires_traversal(file_patterns: &GlobPatterns) -> bool {
+  match &file_patterns.arg_includes {
+    // no CLI paths were provided, so traverse for the config includes
+    None => true,
+    Some(includes) => includes.iter().any(is_positive_glob_pattern),
+  }
+}
+
+/// Gets whether the pattern is a non-negated glob pattern
+/// as opposed to a literal path.
+fn is_positive_glob_pattern(pattern: &GlobPattern) -> bool {
+  !pattern.is_negated() && is_pattern(&pattern.relative_pattern)
+}
+
+/// Moves the traversal start directory up to the nearest ancestor directory
+/// containing the positive CLI glob patterns so files outside the start
+/// directory can be found (ex. `dprint fmt ../sub_dir/**/*.ts`). This stays
+/// fast because the traversal quickly prunes directories the patterns can't
+/// match (see `GlobPattern::matches_dir_for_traversal`).
+fn expand_start_dir_for_arg_patterns(mut start_dir: PathBuf, file_patterns: &GlobPatterns, pattern_base: &CanonicalizedPathBuf) -> PathBuf {
+  for pattern in file_patterns.arg_includes.iter().flatten() {
+    if !is_positive_glob_pattern(pattern) {
+      continue;
+    }
+    let deepest_base = pattern.clone().into_deepest_base().base_dir;
+    if !deepest_base.starts_with(pattern_base) {
+      continue;
+    }
+    // move the start dir up (bounded by the pattern base) until it contains
+    // the pattern's base directory
+    while !deepest_base.as_ref().starts_with(&start_dir) {
+      match start_dir.parent() {
+        Some(parent) if start_dir != *pattern_base.as_ref() => start_dir = parent.to_path_buf(),
+        _ => break,
+      }
+    }
+  }
+  start_dir
+}
+
+enum DirChainResult {
+  /// Nothing along the chain prevents matching within the directory.
+  Matched,
+  /// A directory along the chain is excluded or gitignored.
+  Excluded,
+  /// A directory along the chain has its own config file, so the sub scope
+  /// created for that config file handles everything within it.
+  HasConfigFile(PathBuf),
+}
+
+/// Checks the directories between the base directory (exclusive) and the
+/// provided directory (inclusive) top down the same way a traversal
+/// descending into them would.
+fn check_dir_chain<TEnvironment: Environment>(
+  glob_matcher: &GlobMatcher,
+  git_ignore_tree: &mut Option<GitIgnoreTree<TEnvironment>>,
+  mut config_file_finder: Option<&mut DirConfigFileFinder<'_, TEnvironment>>,
+  base_dir: &Path,
+  dir: &Path,
+) -> DirChainResult {
+  for dir in dirs_from_base_to(base_dir, dir) {
+    if dir.file_name().is_some_and(|f| f == ".git") {
+      return DirChainResult::Excluded;
+    }
+    match glob_matcher.is_dir_ignored(dir) {
+      ExcludeMatchDetail::Excluded => return DirChainResult::Excluded,
+      ExcludeMatchDetail::OptedOutExclude => {}
+      ExcludeMatchDetail::NotExcluded => {
+        if let Some(tree) = git_ignore_tree.as_mut()
+          && let Some(gitignore) = tree.get_resolved_git_ignore_for_file(dir)
+          && gitignore.is_ignored(dir, /* is dir */ true)
+        {
+          return DirChainResult::Excluded;
+        }
+      }
+    }
+    if let Some(finder) = config_file_finder.as_deref_mut()
+      && let Some(config_file) = finder.find(dir)
+    {
+      return DirChainResult::HasConfigFile(config_file);
+    }
+  }
+  DirChainResult::Matched
+}
+
+/// Gets the directories between the base directory (exclusive) and the
+/// provided directory (inclusive) ordered top down.
+fn dirs_from_base_to<'a>(base_dir: &Path, dir: &'a Path) -> Vec<&'a Path> {
+  let mut dirs = dir.ancestors().take_while(|ancestor| *ancestor != base_dir).collect::<Vec<_>>();
+  dirs.reverse();
+  dirs
+}
+
+/// Adds a config file found along a directory chain, deduplicating because
+/// multiple file paths often resolve to the same config file.
+fn push_dedup_config_file(config_files: &mut Vec<PathBuf>, config_file: PathBuf) {
+  if !config_files.contains(&config_file) {
+    config_files.push(config_file);
+  }
+}
+
+/// Finds the dprint config file within a directory, caching the result per
+/// directory because multiple file paths often share ancestor directories.
+struct DirConfigFileFinder<'a, TEnvironment: Environment> {
+  environment: &'a TEnvironment,
+  cache: HashMap<PathBuf, Option<PathBuf>>,
+}
+
+impl<'a, TEnvironment: Environment> DirConfigFileFinder<'a, TEnvironment> {
+  pub fn new(environment: &'a TEnvironment) -> Self {
+    Self {
+      environment,
+      cache: Default::default(),
+    }
+  }
+
+  pub fn find(&mut self, dir: &Path) -> Option<PathBuf> {
+    if let Some(result) = self.cache.get(dir) {
+      return result.clone();
+    }
+    let result = POSSIBLE_CONFIG_FILE_NAMES
+      .iter()
+      .map(|file_name| dir.join(file_name))
+      .find(|path| self.environment.path_is_file(path));
+    self.cache.insert(dir.to_path_buf(), result.clone());
+    result
+  }
 }
 
 /// Default number of threads used for reading directories.
@@ -249,7 +700,7 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
         .filter_map(|e| match e {
           DirEntry::Directory(_) => None,
           DirEntry::File { name, path } => {
-            if matches!(name.to_str(), Some(".dprint.json" | "dprint.json" | ".dprint.jsonc" | "dprint.jsonc")) {
+            if name.to_str().is_some_and(|name| POSSIBLE_CONFIG_FILE_NAMES.contains(&name)) {
               Some(path)
             } else {
               None
@@ -753,6 +1204,188 @@ mod test {
     let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
     result.sort();
     assert_eq!(result, vec!["/globally_excluded.txt", "/included.txt"]);
+  }
+
+  #[tokio::test]
+  async fn should_match_literal_file_paths_without_traversal() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/sub/file.txt", "")
+      .write_file("/sub/other.txt", "")
+      .build();
+    // error any attempt at reading a directory in order to
+    // prove that literal file paths don't cause a traversal
+    environment.set_dir_info_error(std::io::Error::other("FAILURE"));
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![
+            GlobPattern::new("./sub/file.txt".to_string(), root_dir.clone()),
+            GlobPattern::new("./not_exists.txt".to_string(), root_dir.clone()),
+          ]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    assert_eq!(result.file_paths, vec![PathBuf::from("/sub/file.txt")]);
+    assert!(result.config_files.is_empty());
+  }
+
+  #[tokio::test]
+  async fn literal_file_path_in_dir_with_config_file_resolves_config() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/sub/dprint.json", "{}")
+      .write_file("/sub/file.txt", "")
+      .write_file("/sub/nested/dprint.json", "{}")
+      .write_file("/sub/nested/file.txt", "")
+      .write_file("/file.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![
+            GlobPattern::new("./file.txt".to_string(), root_dir.clone()),
+            GlobPattern::new("./sub/file.txt".to_string(), root_dir.clone()),
+            GlobPattern::new("./sub/nested/file.txt".to_string(), root_dir.clone()),
+          ]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    // only the file directly in the current scope is matched and both files
+    // below the sub config resolve to the shallowest config file, which will
+    // discover the nested one recursively when its scope resolves
+    assert_eq!(result.file_paths, vec![PathBuf::from("/file.txt")]);
+    assert_eq!(result.config_files, vec![PathBuf::from("/sub/dprint.json")]);
+  }
+
+  #[tokio::test]
+  async fn literal_file_path_ignores_config_files_when_config_discovery_disabled() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/sub/dprint.json", "{}")
+      .write_file("/sub/file.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Disabled,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![GlobPattern::new("./sub/file.txt".to_string(), root_dir.clone())]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    assert_eq!(result.file_paths, vec![PathBuf::from("/sub/file.txt")]);
+    assert!(result.config_files.is_empty());
+  }
+
+  #[tokio::test]
+  async fn literal_file_path_in_excluded_dir_not_matched() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/ignored/file.txt", "")
+      // the config file is not discovered either because the
+      // directory it's in is excluded
+      .write_file("/ignored/dprint.json", "{}")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![GlobPattern::new("./ignored/file.txt".to_string(), root_dir.clone())]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
+          arg_excludes: None,
+          config_excludes: vec![GlobPattern::new("./ignored".to_string(), root_dir)],
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    assert!(result.file_paths.is_empty());
+    assert!(result.config_files.is_empty());
+  }
+
+  #[tokio::test]
+  async fn should_traverse_from_glob_pattern_base_dir_outside_start_dir() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/other/file.txt", "")
+      .write_file("/sub/file.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        // this happens when running `dprint fmt "../other/**"` from /sub
+        start_dir: PathBuf::from("/sub"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![GlobPattern::new("./other/**".to_string(), root_dir.clone())]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    assert_eq!(result.file_paths, vec![PathBuf::from("/other/file.txt")]);
+  }
+
+  #[tokio::test]
+  async fn should_expand_literal_dir_path_to_match_contents() {
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/sub/file1.txt", "")
+      .write_file("/sub/nested/file2.txt", "")
+      .write_file("/other/file3.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          arg_includes: Some(vec![GlobPattern::new("./sub".to_string(), root_dir.clone())]),
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    result.sort();
+    assert_eq!(result, vec!["/sub/file1.txt", "/sub/nested/file2.txt"]);
   }
 
   #[tokio::test]

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -378,7 +378,7 @@ pub fn rewrite_literal_arg_pattern(environment: &impl Environment, pattern: &mut
   } else {
     pattern.base_dir.join(relative_path)
   };
-  if environment.path_kind(&path).is_none() {
+  if !environment.path_exists(&path) {
     return;
   }
   let canonical_path = match environment.canonicalize(&path) {

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -15,6 +15,7 @@ use crate::configuration::POSSIBLE_CONFIG_FILE_NAMES;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::DirEntry;
 use crate::environment::Environment;
+use crate::environment::PathKind;
 use crate::utils::gitignore::DirEntriesHint;
 use crate::utils::gitignore::GitIgnoreTree;
 use crate::utils::gitignore::GitIgnoreTreeOptions;
@@ -265,16 +266,26 @@ fn extract_literal_arg_paths(environment: &impl Environment, file_patterns: &mut
       } else {
         pattern.base_dir.join(relative_path.as_ref())
       };
-      let is_file = environment.path_is_file(&path);
-      if !is_file && !environment.path_exists(&path) {
+      let Some(kind) = environment.path_kind(&path) else {
         // a glob-like pattern stays a glob when nothing has its literal name
         continue;
-      }
+      };
       // resolve symlinks and casing differences so the path gets classified
       // and matched based on where it actually is on the file system
       let path = match environment.canonicalize(&path) {
         Ok(canonical) => canonical.into_path_buf(),
         Err(_) => path,
+      };
+      let is_file = match kind {
+        PathKind::File => true,
+        PathKind::Dir => false,
+        // stat the canonicalized path to see what the symlink points at
+        PathKind::Symlink => match environment.path_kind(&path) {
+          Some(PathKind::File) => true,
+          Some(PathKind::Dir) => false,
+          // a broken symlink stays a glob like a nonexistent path
+          _ => continue,
+        },
       };
       (path, is_file)
     };
@@ -367,7 +378,7 @@ pub fn rewrite_literal_arg_pattern(environment: &impl Environment, pattern: &mut
   } else {
     pattern.base_dir.join(relative_path)
   };
-  if !environment.path_exists(&path) {
+  if environment.path_kind(&path).is_none() {
     return;
   }
   let canonical_path = match environment.canonicalize(&path) {

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -14,6 +14,7 @@ use ignore::overrides::OverrideBuilder;
 use crate::environment::CanonicalizedPathBuf;
 
 use super::GlobPattern;
+use super::GlobPatternKind;
 use super::GlobPatterns;
 use super::is_pattern;
 use super::unescape_glob_text;
@@ -62,24 +63,24 @@ impl GlobMatcher {
     let config_excludes = patterns
       .config_excludes
       .into_iter()
-      .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
+      .filter_map(|pattern| pattern.into_new_base(base_dir.clone(), GlobPatternKind::Exclude))
       .collect::<Vec<_>>();
     let config_includes = patterns.config_includes.map(|includes| {
       includes
         .into_iter()
-        .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
+        .filter_map(|pattern| pattern.into_new_base(base_dir.clone(), GlobPatternKind::Include))
         .collect::<Vec<_>>()
     });
     let arg_includes = patterns.arg_includes.map(|includes| {
       includes
         .into_iter()
-        .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
+        .filter_map(|pattern| pattern.into_new_base(base_dir.clone(), GlobPatternKind::Include))
         .collect::<Vec<_>>()
     });
     let arg_excludes = patterns.arg_excludes.map(|excludes| {
       excludes
         .into_iter()
-        .filter_map(|pattern| pattern.into_new_base(base_dir.clone()))
+        .filter_map(|pattern| pattern.into_new_base(base_dir.clone(), GlobPatternKind::Exclude))
         .collect::<Vec<_>>()
     });
 
@@ -302,9 +303,11 @@ fn literal_relative_path(pattern: &GlobPattern) -> Option<PathBuf> {
   Some(PathBuf::from(unescape_glob_text(relative).as_ref()))
 }
 
+/// Adds an include pattern to the override builder (only the include matcher
+/// uses overrides—excludes go straight into a gitignore matcher).
 fn add_override_pattern(builder: &mut OverrideBuilder, pattern: &GlobPattern, base_dir: &CanonicalizedPathBuf) -> Result<()> {
   if pattern.base_dir != *base_dir {
-    match pattern.clone().into_new_base(base_dir.clone()) {
+    match pattern.clone().into_new_base(base_dir.clone(), GlobPatternKind::Include) {
       Some(pattern) => {
         builder.add(&normalize_pattern(&pattern))?;
       }

--- a/crates/dprint/src/utils/glob/glob_matcher.rs
+++ b/crates/dprint/src/utils/glob/glob_matcher.rs
@@ -16,6 +16,7 @@ use crate::environment::CanonicalizedPathBuf;
 use super::GlobPattern;
 use super::GlobPatterns;
 use super::is_pattern;
+use super::unescape_glob_text;
 
 pub struct GlobMatcherOptions {
   pub case_sensitive: bool,
@@ -168,6 +169,11 @@ impl GlobMatcher {
 
       let path = path.strip_prefix(&self.base_dir).unwrap();
       self.check_exclude(path, true)
+    } else if self.base_dir.as_ref().starts_with(path) {
+      // an ancestor of the base directory (ex. the config directory when
+      // override args cause the base to be a deeper cwd) can't match any
+      // patterns, but it's not ignored because traversal descends through it
+      ExcludeMatchDetail::NotExcluded
     } else {
       ExcludeMatchDetail::Excluded
     }
@@ -291,7 +297,9 @@ fn literal_relative_path(pattern: &GlobPattern) -> Option<PathBuf> {
   if !anchored || relative.is_empty() || relative.ends_with('/') {
     return None;
   }
-  Some(PathBuf::from(relative))
+  // unescape so an escaped literal (ex. `./\[id\].svelte`) is stored as the
+  // actual file path
+  Some(PathBuf::from(unescape_glob_text(relative).as_ref()))
 }
 
 fn add_override_pattern(builder: &mut OverrideBuilder, pattern: &GlobPattern, base_dir: &CanonicalizedPathBuf) -> Result<()> {

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -10,6 +10,18 @@ use super::is_pattern;
 use super::non_negated_glob;
 use super::unescape_glob_text;
 
+/// What a pattern does with the files it matches, which decides whether naming
+/// a directory also covers everything within it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobPatternKind {
+  /// Naming a directory only matches that path (ex. a config `includes` entry
+  /// of `sub` doesn't pull in `sub/file.ts`—that needs `sub/**`).
+  Include,
+  /// Naming a directory excludes everything within it, the same way gitignore
+  /// and a traversal that prunes the directory behave.
+  Exclude,
+}
+
 #[derive(Debug)]
 pub struct GlobPatterns {
   pub arg_includes: Option<Vec<GlobPattern>>,
@@ -30,7 +42,7 @@ impl GlobPatterns {
       .flat_map(|i| i.iter())
       .chain(self.config_includes.iter().flat_map(|i| i.iter()))
       .filter_map(|pattern| {
-        if !is_pattern(&pattern.relative_pattern) {
+        if !is_pattern(&pattern.relative_pattern) && !pattern.is_negated() {
           // unescape so an escaped literal (ex. `./\[id\].svelte`) resolves
           // to the actual file path
           Some(pattern.base_dir.join(unescape_glob_text(&pattern.relative_pattern).as_ref()))
@@ -157,7 +169,7 @@ impl GlobPattern {
     }
   }
 
-  pub fn into_new_base(self, new_base_dir: CanonicalizedPathBuf) -> Option<Self> {
+  pub fn into_new_base(self, new_base_dir: CanonicalizedPathBuf, kind: GlobPatternKind) -> Option<Self> {
     if self.base_dir == new_base_dir {
       Some(self)
     } else if let Ok(prefix) = self.base_dir.strip_prefix(&new_base_dir) {
@@ -229,10 +241,16 @@ impl GlobPattern {
         .split(if cfg!(windows) { if prefix.contains('\\') { '\\' } else { '/' } } else { '/' })
         .collect::<VecDeque<_>>();
 
+      // an exclude naming a directory covers everything within it, so a
+      // pattern that names an ancestor of the new base becomes `**`. This
+      // doesn't apply to includes, where naming a directory only matches that
+      // one path.
+      let covers_new_base = kind == GlobPatternKind::Exclude;
+
       // an empty pattern (ex. `--excludes ..` resolving to its base directory)
       // names the old base directory, an ancestor of the new base
       if pattern.is_empty() {
-        return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
+        return covers_new_base.then(|| GlobPattern::new(build_pattern("**"), new_base_dir));
       }
 
       loop {
@@ -243,7 +261,8 @@ impl GlobPattern {
         // a final pattern component naming this directory means the pattern
         // covers the new base directory, so it applies to everything within
         // (ex. an `--excludes ../other` arg rebased into a scope at `other`)
-        if !pattern.contains('/')
+        if covers_new_base
+          && !pattern.contains('/')
           && let Some(first_item) = prefix.front()
           && (pattern == "*" || unescape_glob_text(pattern) == *first_item)
         {
@@ -306,6 +325,16 @@ impl GlobPattern {
 mod test {
   use super::*;
 
+  /// Rebases the pattern, asserting both kinds agree. The cases where include
+  /// and exclude semantics differ are asserted with explicit kinds instead.
+  #[track_caller]
+  fn into_new_base(pattern: GlobPattern, new_base_dir: CanonicalizedPathBuf) -> Option<GlobPattern> {
+    let as_include = pattern.clone().into_new_base(new_base_dir.clone(), GlobPatternKind::Include);
+    let as_exclude = pattern.into_new_base(new_base_dir, GlobPatternKind::Exclude);
+    assert_eq!(as_include, as_exclude);
+    as_exclude
+  }
+
   #[test]
   fn should_invert() {
     let test_dir = CanonicalizedPathBuf::new_for_testing("/test");
@@ -325,7 +354,7 @@ mod test {
     assert_eq!(pattern.relative_pattern, "**/*");
     assert_eq!(pattern.base_dir, test_dir_dir);
 
-    let pattern = pattern.into_new_base(test_dir.clone()).unwrap();
+    let pattern = into_new_base(pattern, test_dir.clone()).unwrap();
     assert_eq!(pattern.relative_pattern, "./dir/**/*");
     assert_eq!(pattern.base_dir, test_dir);
   }
@@ -335,7 +364,7 @@ mod test {
     let root_dir = CanonicalizedPathBuf::new_for_testing("/");
     let test_dir_dir = CanonicalizedPathBuf::new_for_testing("/test/dir");
     let pattern = GlobPattern::new("./**/*".to_string(), test_dir_dir);
-    let pattern = pattern.into_new_base(root_dir.clone()).unwrap();
+    let pattern = into_new_base(pattern, root_dir.clone()).unwrap();
     assert_eq!(pattern.relative_pattern, "./test/dir/**/*");
     assert_eq!(pattern.base_dir, root_dir);
   }
@@ -349,11 +378,11 @@ mod test {
     assert_eq!(pattern.relative_pattern, "asdf");
     assert_eq!(pattern.base_dir, test_dir_dir);
 
-    let pattern = pattern.into_new_base(test_dir.clone()).unwrap();
+    let pattern = into_new_base(pattern, test_dir.clone()).unwrap();
     assert_eq!(pattern.relative_pattern, "./dir/**/asdf");
     assert_eq!(pattern.base_dir, test_dir);
 
-    let pattern = pattern.into_new_base(root_dir.clone()).unwrap();
+    let pattern = into_new_base(pattern, root_dir.clone()).unwrap();
     assert_eq!(pattern.relative_pattern, "./test/dir/**/asdf");
     assert_eq!(pattern.base_dir, root_dir);
   }
@@ -366,7 +395,7 @@ mod test {
     assert_eq!(pattern.base_dir, base_dir);
 
     let sibling_dir = CanonicalizedPathBuf::new_for_testing("/sibling");
-    assert_eq!(pattern.into_new_base(sibling_dir.clone()), None);
+    assert_eq!(into_new_base(pattern, sibling_dir.clone()), None);
   }
 
   #[test]
@@ -374,7 +403,7 @@ mod test {
     let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
     let pattern = GlobPattern::new("**/*.ts".to_string(), base_dir.clone());
     let parent_dir = CanonicalizedPathBuf::new_for_testing("/");
-    let new_pattern = pattern.into_new_base(parent_dir.clone()).unwrap();
+    let new_pattern = into_new_base(pattern, parent_dir.clone()).unwrap();
     assert_eq!(new_pattern.base_dir, parent_dir);
     assert_eq!(new_pattern.relative_pattern, "./base/**/*.ts");
   }
@@ -386,14 +415,14 @@ mod test {
     // child
     {
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.clone().into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "**/*.ts");
     }
     // grandchild
     {
       let grandchild_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/dir");
-      let new_pattern = pattern.into_new_base(grandchild_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, grandchild_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, grandchild_dir);
       assert_eq!(new_pattern.relative_pattern, "**/*.ts");
     }
@@ -401,59 +430,68 @@ mod test {
     {
       let pattern = GlobPattern::new("!**/*.ts".to_string(), base_dir.clone());
       let grandchild_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/dir");
-      let new_pattern = pattern.into_new_base(grandchild_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, grandchild_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, grandchild_dir);
       assert_eq!(new_pattern.relative_pattern, "!**/*.ts");
     }
   }
 
+  /// An exclude naming a directory covers everything within it, so it becomes
+  /// `**` in the new base. An include naming a directory only matches that one
+  /// path, so it has nothing to say about the directory's contents and is
+  /// dropped instead.
   #[test]
   fn should_handle_mapping_into_descendant_dir_the_pattern_names() {
     let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
-    // the pattern naming the new base directory applies to everything within
+    // the pattern naming the new base directory
     {
       let pattern = GlobPattern::new("./sub".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = pattern.clone().into_new_base(child_dir.clone(), GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "./**");
+      assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
     }
     // same for an ancestor of the new base directory
     {
       let pattern = GlobPattern::new("./sub".to_string(), base_dir.clone());
       let grandchild_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/dir");
-      let new_pattern = pattern.into_new_base(grandchild_dir.clone()).unwrap();
+      let new_pattern = pattern.clone().into_new_base(grandchild_dir.clone(), GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.base_dir, grandchild_dir);
       assert_eq!(new_pattern.relative_pattern, "./**");
+      assert_eq!(pattern.into_new_base(grandchild_dir, GlobPatternKind::Include), None);
     }
     // negated
     {
       let pattern = GlobPattern::new("!./sub".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = pattern.into_new_base(child_dir, GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.relative_pattern, "!./**");
     }
     // escaped glob characters in the name
     {
       let pattern = GlobPattern::new("./\\[sub\\]".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/[sub]");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = pattern.into_new_base(child_dir, GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.relative_pattern, "./**");
     }
     // a * final component matches any directory name
     {
       let pattern = GlobPattern::new("./*".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = pattern.clone().into_new_base(child_dir.clone(), GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.relative_pattern, "./**");
+      // as an include, `./*` matches the directory but not what's inside it
+      assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
     }
     // an empty pattern names the old base directory itself
     // (ex. `--excludes ..` resolving to its base directory)
     {
       let pattern = GlobPattern::new("./".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = pattern.clone().into_new_base(child_dir.clone(), GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.relative_pattern, "./**");
+      assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
     }
   }
 
@@ -464,20 +502,20 @@ mod test {
     // child
     {
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.clone().into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "*.ts");
     }
     // grandchild
     {
       let grandchild_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/dir");
-      assert_eq!(pattern.into_new_base(grandchild_dir.clone()), None);
+      assert_eq!(into_new_base(pattern, grandchild_dir.clone()), None);
     }
     // negated
     {
       let pattern = GlobPattern::new("!*/*.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "!*.ts");
     }
@@ -489,21 +527,21 @@ mod test {
     {
       let pattern = GlobPattern::new("./sub/a.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "./a.ts");
     }
     {
       let pattern = GlobPattern::new("!./sub/a.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "!./a.ts");
     }
     {
       let pattern = GlobPattern::new("./sub/**/*.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "./**/*.ts");
     }
@@ -511,7 +549,7 @@ mod test {
       // deeper descendant
       let pattern = GlobPattern::new("./sub/nested/a.ts".to_string(), base_dir.clone());
       let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/nested");
-      let new_pattern = pattern.into_new_base(descendant_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, descendant_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, descendant_dir);
       assert_eq!(new_pattern.relative_pattern, "./a.ts");
     }
@@ -519,7 +557,7 @@ mod test {
       // not under the new base directory
       let pattern = GlobPattern::new("./other/a.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      assert_eq!(pattern.into_new_base(child_dir), None);
+      assert_eq!(into_new_base(pattern, child_dir), None);
     }
   }
 
@@ -529,14 +567,14 @@ mod test {
     {
       let pattern = GlobPattern::new("**".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "**");
     }
     {
       let pattern = GlobPattern::new("./**".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "./**");
     }
@@ -544,14 +582,14 @@ mod test {
       // dir pattern expanded to dir/** rebased into a deeper descendant
       let pattern = GlobPattern::new("sub/**".to_string(), base_dir.clone());
       let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/nested");
-      let new_pattern = pattern.into_new_base(descendant_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, descendant_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, descendant_dir);
       assert_eq!(new_pattern.relative_pattern, "**");
     }
     {
       let pattern = GlobPattern::new("!**".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern, child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "!**");
     }
@@ -563,21 +601,21 @@ mod test {
     {
       let pattern = GlobPattern::new("!sub/*.ts".to_string(), base_dir.clone());
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
-      let new_pattern = pattern.clone().into_new_base(child_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "!*.ts");
     }
     {
       let pattern = GlobPattern::new("sub/*/dir/*.ts".to_string(), base_dir.clone());
       let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/something/dir");
-      let new_pattern = pattern.clone().into_new_base(descendant_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), descendant_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, descendant_dir);
       assert_eq!(new_pattern.relative_pattern, "*.ts");
     }
     {
       let pattern = GlobPattern::new("!sub/*/dir/*.ts".to_string(), base_dir.clone());
       let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/something");
-      let new_pattern = pattern.clone().into_new_base(descendant_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), descendant_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, descendant_dir);
       assert_eq!(new_pattern.relative_pattern, "!dir/*.ts");
     }
@@ -585,7 +623,7 @@ mod test {
       let base_dir = CanonicalizedPathBuf::new_for_testing("C:\\base");
       let pattern = GlobPattern::new("!sub/*/dir/*.ts".to_string(), base_dir.clone());
       let descendant_dir = CanonicalizedPathBuf::new_for_testing("C:\\base\\sub\\something");
-      let new_pattern = pattern.clone().into_new_base(descendant_dir.clone()).unwrap();
+      let new_pattern = into_new_base(pattern.clone(), descendant_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, descendant_dir);
       assert_eq!(new_pattern.relative_pattern, "!dir/*.ts");
     }

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -4,9 +4,11 @@ use std::path::PathBuf;
 
 use crate::environment::CanonicalizedPathBuf;
 
+use super::escape_glob_text;
 use super::is_negated_glob;
 use super::is_pattern;
 use super::non_negated_glob;
+use super::unescape_glob_text;
 
 #[derive(Debug)]
 pub struct GlobPatterns {
@@ -29,7 +31,9 @@ impl GlobPatterns {
       .chain(self.config_includes.iter().flat_map(|i| i.iter()))
       .filter_map(|pattern| {
         if !is_pattern(&pattern.relative_pattern) {
-          Some(pattern.base_dir.join(&pattern.relative_pattern))
+          // unescape so an escaped literal (ex. `./\[id\].svelte`) resolves
+          // to the actual file path
+          Some(pattern.base_dir.join(unescape_glob_text(&pattern.relative_pattern).as_ref()))
         } else {
           None
         }
@@ -76,7 +80,7 @@ impl GlobPattern {
         let component = *component;
         if part == "**" {
           return true;
-        } else if !is_pattern(part) && !component.as_os_str().eq_ignore_ascii_case(part) {
+        } else if !is_pattern(part) && !component.as_os_str().eq_ignore_ascii_case(unescape_glob_text(part).as_ref()) {
           return false;
         }
         components.next();
@@ -137,6 +141,9 @@ impl GlobPattern {
     let new_base_dir = if base_parts.is_empty() {
       self.base_dir.clone()
     } else {
+      // unescape so escaped literal parts (ex. `\[a\]`) become the actual
+      // directory name in the new base path
+      let base_parts = base_parts.iter().map(|part| unescape_glob_text(part)).collect::<Vec<_>>();
       self.base_dir.join_panic_relative(base_parts.join("/"))
     };
 
@@ -164,7 +171,9 @@ impl GlobPattern {
         if value.starts_with('/') {
           value.drain(..1);
         }
-        value
+        // escape so glob characters in the path (ex. a `[a]` directory)
+        // match literally
+        escape_glob_text(&value)
       };
 
       let new_relative_pattern = {
@@ -198,20 +207,47 @@ impl GlobPattern {
       };
       Some(GlobPattern::new(new_pattern, new_base_dir))
     } else if let Ok(prefix) = new_base_dir.strip_prefix(&self.base_dir) {
-      let is_negated = is_negated_glob(&self.relative_pattern);
-      let mut pattern = non_negated_glob(&self.relative_pattern);
+      let is_negated = self.is_negated();
+      let non_negated = non_negated_glob(&self.relative_pattern);
+      // a ./ prefix anchors the pattern to its base directory, so strip it
+      // before walking the prefix and keep the result anchored to the new base
+      let is_anchored = non_negated.starts_with("./");
+      let mut pattern = non_negated.strip_prefix("./").unwrap_or(non_negated);
+      let build_pattern = |pattern: &str| {
+        let mut value = String::new();
+        if is_negated {
+          value.push('!');
+        }
+        if is_anchored {
+          value.push_str("./");
+        }
+        value.push_str(pattern);
+        value
+      };
       let prefix = prefix.to_string_lossy();
       let mut prefix = prefix
         .split(if cfg!(windows) { if prefix.contains('\\') { '\\' } else { '/' } } else { '/' })
         .collect::<VecDeque<_>>();
 
+      // an empty pattern (ex. `--excludes ..` resolving to its base directory)
+      // names the old base directory, an ancestor of the new base
+      if pattern.is_empty() {
+        return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
+      }
+
       loop {
         let mut found_sub_match = false;
-        if pattern.starts_with("**/") {
-          return Some(GlobPattern::new(
-            if is_negated { format!("!{}", pattern) } else { pattern.to_string() },
-            new_base_dir,
-          ));
+        if pattern == "**" || pattern.starts_with("**/") {
+          return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
+        }
+        // a final pattern component naming this directory means the pattern
+        // covers the new base directory, so it applies to everything within
+        // (ex. an `--excludes ../other` arg rebased into a scope at `other`)
+        if !pattern.contains('/')
+          && let Some(first_item) = prefix.front()
+          && (pattern == "*" || unescape_glob_text(pattern) == *first_item)
+        {
+          return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
         }
         // check for a * dir
         if let Some(new_pattern) = pattern.strip_prefix("*/") {
@@ -219,24 +255,21 @@ impl GlobPattern {
           prefix.pop_front();
           if prefix.is_empty() {
             // we've hit the new base directory
-            return Some(GlobPattern::new(
-              if is_negated { format!("!{}", pattern) } else { pattern.to_string() },
-              new_base_dir,
-            ));
+            return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
           }
           found_sub_match = true;
         }
-        // check for a match for the name
+        // check for a match for the name (unescaping so an escaped literal
+        // part like `\[a\]` matches the actual directory name)
         let first_item = prefix.front().unwrap();
-        if let Some(new_pattern) = pattern.strip_prefix(&format!("{}/", first_item)) {
+        if let Some((first_part, new_pattern)) = pattern.split_once('/')
+          && unescape_glob_text(first_part) == *first_item
+        {
           pattern = new_pattern;
           prefix.pop_front();
           if prefix.is_empty() {
             // we've hit the new base directory
-            return Some(GlobPattern::new(
-              if is_negated { format!("!{}", pattern) } else { pattern.to_string() },
-              new_base_dir,
-            ));
+            return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
           }
           found_sub_match = true;
         }
@@ -375,6 +408,56 @@ mod test {
   }
 
   #[test]
+  fn should_handle_mapping_into_descendant_dir_the_pattern_names() {
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
+    // the pattern naming the new base directory applies to everything within
+    {
+      let pattern = GlobPattern::new("./sub".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+    // same for an ancestor of the new base directory
+    {
+      let pattern = GlobPattern::new("./sub".to_string(), base_dir.clone());
+      let grandchild_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/dir");
+      let new_pattern = pattern.into_new_base(grandchild_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, grandchild_dir);
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+    // negated
+    {
+      let pattern = GlobPattern::new("!./sub".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "!./**");
+    }
+    // escaped glob characters in the name
+    {
+      let pattern = GlobPattern::new("./\\[sub\\]".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/[sub]");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+    // a * final component matches any directory name
+    {
+      let pattern = GlobPattern::new("./*".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+    // an empty pattern names the old base directory itself
+    // (ex. `--excludes ..` resolving to its base directory)
+    {
+      let pattern = GlobPattern::new("./".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+  }
+
+  #[test]
   fn should_handle_mapping_into_child_dir_if_star() {
     let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
     let pattern = GlobPattern::new("*/*.ts".to_string(), base_dir.clone());
@@ -397,6 +480,80 @@ mod test {
       let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
       assert_eq!(new_pattern.base_dir, child_dir);
       assert_eq!(new_pattern.relative_pattern, "!*.ts");
+    }
+  }
+
+  #[test]
+  fn should_handle_mapping_anchored_pattern_into_descendant_dir() {
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
+    {
+      let pattern = GlobPattern::new("./sub/a.ts".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "./a.ts");
+    }
+    {
+      let pattern = GlobPattern::new("!./sub/a.ts".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "!./a.ts");
+    }
+    {
+      let pattern = GlobPattern::new("./sub/**/*.ts".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "./**/*.ts");
+    }
+    {
+      // deeper descendant
+      let pattern = GlobPattern::new("./sub/nested/a.ts".to_string(), base_dir.clone());
+      let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/nested");
+      let new_pattern = pattern.into_new_base(descendant_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, descendant_dir);
+      assert_eq!(new_pattern.relative_pattern, "./a.ts");
+    }
+    {
+      // not under the new base directory
+      let pattern = GlobPattern::new("./other/a.ts".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      assert_eq!(pattern.into_new_base(child_dir), None);
+    }
+  }
+
+  #[test]
+  fn should_handle_mapping_bare_match_all_pattern_into_descendant_dir() {
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
+    {
+      let pattern = GlobPattern::new("**".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "**");
+    }
+    {
+      let pattern = GlobPattern::new("./**".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "./**");
+    }
+    {
+      // dir pattern expanded to dir/** rebased into a deeper descendant
+      let pattern = GlobPattern::new("sub/**".to_string(), base_dir.clone());
+      let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/nested");
+      let new_pattern = pattern.into_new_base(descendant_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, descendant_dir);
+      assert_eq!(new_pattern.relative_pattern, "**");
+    }
+    {
+      let pattern = GlobPattern::new("!**".to_string(), base_dir.clone());
+      let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+      let new_pattern = pattern.into_new_base(child_dir.clone()).unwrap();
+      assert_eq!(new_pattern.base_dir, child_dir);
+      assert_eq!(new_pattern.relative_pattern, "!**");
     }
   }
 

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 pub fn is_negated_glob(pattern: &str) -> bool {
   let mut chars = pattern.chars();
   let first_char = chars.next();
@@ -17,13 +19,64 @@ pub fn is_pattern(pattern: &str) -> bool {
 
   let mut was_last_escape = false;
   for c in pattern.chars() {
-    if !was_last_escape && matches!(c, '*' | '{' | '?') {
+    if !was_last_escape && matches!(c, '*' | '{' | '?' | '[') {
       return true;
     }
 
     was_last_escape = matches!(c, '\\');
   }
   false
+}
+
+/// Escapes glob metacharacters so the text matches literally
+/// (ex. `routes/[id].svelte` -> `routes/\[id\].svelte`).
+pub fn escape_glob_text(text: &str) -> String {
+  let mut result = String::with_capacity(text.len());
+  for c in text.chars() {
+    if matches!(c, '\\' | '*' | '{' | '}' | '?' | '[' | ']' | '!') {
+      result.push('\\');
+    }
+    result.push(c);
+  }
+  result
+}
+
+/// Escapes glob metacharacters using character classes (ex. `[` -> `[[]`) so
+/// the result contains no backslashes and survives CLI pattern processing,
+/// which converts backslashes to forward slashes.
+pub fn escape_glob_text_for_cli(text: &str) -> String {
+  let mut result = String::with_capacity(text.len());
+  for c in text.chars() {
+    match c {
+      '[' | ']' | '{' | '}' | '*' | '?' => {
+        result.push('[');
+        result.push(c);
+        result.push(']');
+      }
+      _ => result.push(c),
+    }
+  }
+  result
+}
+
+/// Removes glob escapes (ex. `routes/\[id\].svelte` -> `routes/[id].svelte`).
+pub fn unescape_glob_text(text: &str) -> Cow<'_, str> {
+  if !text.contains('\\') {
+    return Cow::Borrowed(text);
+  }
+  let mut result = String::with_capacity(text.len());
+  let mut chars = text.chars();
+  while let Some(c) = chars.next() {
+    if c == '\\' {
+      match chars.next() {
+        Some(next) => result.push(next),
+        None => result.push(c),
+      }
+    } else {
+      result.push(c);
+    }
+  }
+  Cow::Owned(result)
 }
 
 pub fn is_absolute_pattern(pattern: &str) -> bool {
@@ -60,6 +113,28 @@ fn is_windows_absolute_pattern(pattern: &str) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn should_escape_and_unescape_glob_text() {
+    assert_eq!(escape_glob_text("routes/[id].svelte"), "routes/\\[id\\].svelte");
+    assert_eq!(escape_glob_text("{{myfile}}.yaml"), "\\{\\{myfile\\}\\}.yaml");
+    assert_eq!(escape_glob_text("a*b?c!d\\e"), "a\\*b\\?c\\!d\\\\e");
+    assert_eq!(escape_glob_text("plain/file.txt"), "plain/file.txt");
+
+    assert_eq!(escape_glob_text_for_cli("/[app]/dir"), "/[[]app[]]/dir");
+    assert_eq!(escape_glob_text_for_cli("/plain/dir"), "/plain/dir");
+
+    assert_eq!(unescape_glob_text("routes/\\[id\\].svelte"), "routes/[id].svelte");
+    assert_eq!(unescape_glob_text("plain/file.txt"), "plain/file.txt");
+    assert_eq!(unescape_glob_text("a\\\\b"), "a\\b");
+    // a trailing lone backslash stays as-is
+    assert_eq!(unescape_glob_text("a\\"), "a\\");
+
+    // escaped text is not considered a pattern and round trips
+    assert!(is_pattern("routes/[id].svelte"));
+    assert!(!is_pattern(&escape_glob_text("routes/[id].svelte")));
+    assert_eq!(unescape_glob_text(&escape_glob_text("a*b?c!d\\e[]{}")), "a*b?c!d\\e[]{}");
+  }
 
   #[test]
   fn should_get_if_absolute_pattern() {

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -221,7 +221,7 @@ Alternatively, you can disable all `.gitignore` handling with the `--no-gitignor
 
 To match a path that contains glob characters (ex. `[` or `{`) in `includes`/`excludes`, wrap each one in a character class:
 
-```json
+```jsonc
 {
   "excludes": [
     // excludes a file named {{myfile}}.json

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -232,8 +232,6 @@ To match a path that contains glob characters (ex. `[` or `{`) in `includes`/`ex
 }
 ```
 
-This is only necessary in the config file—a CLI argument that names an existing file or directory is matched literally.
-
 ## Includes
 
 The `includes` property can be used to limit dprint to only formatting certain files. Generally, you don't need to bother providing this.

--- a/website/src/config.md
+++ b/website/src/config.md
@@ -217,6 +217,23 @@ Files that are gitignored will be excluded by default, but you can "un-exclude" 
 
 Alternatively, you can disable all `.gitignore` handling with the `--no-gitignore` CLI flag (see [CLI docs](/cli#ignoring-gitignore)).
 
+### Escaping glob characters
+
+To match a path that contains glob characters (ex. `[` or `{`) in `includes`/`excludes`, wrap each one in a character class:
+
+```json
+{
+  "excludes": [
+    // excludes a file named {{myfile}}.json
+    "[{][{]myfile[}][}].json",
+    // excludes a directory named [id]
+    "routes/[[]id[]]"
+  ]
+}
+```
+
+This is only necessary in the config file—a CLI argument that names an existing file or directory is matched literally.
+
 ## Includes
 
 The `includes` property can be used to limit dprint to only formatting certain files. Generally, you don't need to bother providing this.


### PR DESCRIPTION
Resolves literal (non-glob) CLI path args directly instead of discovering them via directory traversal, and makes file inclusion/exclusion behave the same regardless of the cwd, path spelling, and arg form (literal path vs glob vs traversal).

## Behaviour

- **Literal file args resolve without a traversal.** `dprint fmt a.ts b.ts …` stats and formats those paths directly. Exclusions still apply the same way a traversal would apply them: the file's ancestor directories are checked top down, so a file inside a config-excluded or gitignored directory is not formatted even when explicitly specified (explicitly specifying a file still overrides a gitignore entry for the file itself).
- **Directory args format everything within the directory.** An arg at or above the config directory widens to the whole scope, and an ancestor directory arg (ex. `dprint fmt ..`) behaves like running dprint from that directory, including discovering sibling directories' config files.
- **Paths outside the config's directory now work.** They use the config found in their own ancestor tree (nearest config wins), else an explicit `--config`/in-use global config, else the user's global config, else error.
- **Glob-like args that name an existing path are treated as that path** (#552, #920, #947). This only applies to args whose glob characters are valid in file names (`[` and `{`); args with `*` or `?` are always globs. Applies to positional args, negated args, `--excludes`, `--stdin`, and the override flags. Config file patterns intentionally keep pure glob semantics—use character classes there (ex. `[{]`), which is now documented.
- **Paths are canonicalized before matching**, so symlink/junction and differently-cased spellings resolve to the same result.
- `--stdin` and the editor service now apply gitignore/exclusion rules the same way `fmt <path>` does.

## Perf

In the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) repo:

| Scenario | this PR | main | 0.55.2 |
  | --- | ---: | ---: | ---: |
  | Full traversal (`output-file-paths`, 20k files) | 126.8 ms | 125.2 ms | 123.9 ms |
  | Single file arg (`types/node/package.json`) | **10.9 ms** | 18.3 ms | 18.3 ms |
  | 500 file args | **325 ms** | 1,260 ms | 1,040 ms |
  | Dir arg (`types/node`) | **20.1 ms** | 22.0 ms | n/a¹ |
  | Glob arg (`types/re*/*.json`, 1.6k files) | 70.5 ms | 70.7 ms | 72.7 ms |
  
Supersedes #1205

Closes #920
Closes #552
Closes #947
Closes #1111