### PR TITLE
fix: don't duplicate a plugin specified in both a config and its extended config (#1043)

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -1008,6 +1008,51 @@ mod test {
   }
 
   #[test]
+  fn should_use_extended_config_when_specifying_same_plugin_as_extended_config() {
+    // https://github.com/dprint/dprint/issues/1043
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_remote_config("https://dprint.dev/shared.json", |c| {
+        c.add_remote_wasm_plugin().add_config_section("test-plugin", r#"{ "ending": "shared-ending" }"#);
+      })
+      .with_default_config(|c| {
+        c.add_config_section("extends", r#""https://dprint.dev/shared.json""#).add_remote_wasm_plugin();
+      })
+      .write_file("/file.txt", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "/file.txt"], &environment).unwrap();
+
+    environment.take_stdout_messages();
+    environment.take_stderr_messages();
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text_shared-ending");
+  }
+
+  #[test]
+  fn should_use_extended_config_when_specifying_different_version_of_extended_config_plugin() {
+    // https://github.com/dprint/dprint/issues/1043
+    // The local config pins a newer version of a plugin that the config it extends
+    // also specifies. The local version wins and still picks up the extended
+    // config's configuration for it.
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .add_remote_wasm_0_1_0_plugin()
+      .with_remote_config("https://dprint.dev/shared.json", |c| {
+        c.add_remote_wasm_plugin_0_1_0()
+          .add_config_section("test-plugin", r#"{ "ending": "shared-ending" }"#);
+      })
+      .with_default_config(|c| {
+        c.add_config_section("extends", r#""https://dprint.dev/shared.json""#).add_remote_wasm_plugin();
+      })
+      .write_file("/file.txt", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "/file.txt"], &environment).unwrap();
+
+    environment.take_stdout_messages();
+    environment.take_stderr_messages();
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text_shared-ending");
+  }
+
+  #[test]
   fn should_ignore_config_file_in_start_dir_when_config_file_url_specified() {
     // a remote config file has no local path, so nothing identifies the local
     // config file in the directory the traversal starts in as the one in use

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -331,8 +331,12 @@ async fn handle_config_file<TEnvironment: Environment>(
   };
   // =========
 
-  // combine plugins
+  // combine plugins, keeping the higher-precedence (earlier) entry when the same
+  // plugin is specified both here and in the config it extends. Without this a
+  // plugin listed in both would appear twice and, sharing a config key, cause
+  // the extended configuration to be ignored (see issue #1043).
   resolved_config.plugins.extend(plugins);
+  resolved_config.plugins = filter_duplicate_plugin_sources(std::mem::take(&mut resolved_config.plugins));
 
   merge_config_map_into(&mut resolved_config.config_map, new_config_map)?;
 
@@ -892,6 +896,58 @@ mod tests {
       assert_eq!(result.config_map, expected_config_map);
       let logged_warnings = environment.take_stderr_messages();
       assert_eq!(logged_warnings, vec![get_warn_includes_message()]);
+    });
+  }
+
+  #[test]
+  fn should_dedupe_plugin_specified_in_both_local_and_extended_config() {
+    // https://github.com/dprint/dprint/issues/1043
+    // A plugin specified locally that is also specified by an extended config
+    // must not be duplicated in the resolved plugins. Previously the extended
+    // config's plugins were appended without deduplication, producing two
+    // entries for the same plugin (and thus the same config key), which caused
+    // the extended configuration to be ignored.
+    let environment = TestEnvironment::new();
+    environment.add_remote_file(
+      "https://dprint.dev/test.json",
+      r#"{
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm"],
+            "lineWidth": 4,
+            "test": {
+                "prop": 6
+            },
+            "excludes": ["test-excludes"]
+        }"#
+        .as_bytes(),
+    );
+    environment
+      .write_file(
+        &PathBuf::from("/test.json"),
+        r#"{
+            "extends": "https://dprint.dev/test.json",
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm"]
+        }"#,
+      )
+      .unwrap();
+
+    environment.clone().run_in_runtime(async move {
+      let result = get_result("/test.json", &environment).await.unwrap();
+      // the plugin must appear only once
+      assert_eq!(
+        result.plugins,
+        vec![PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm")]
+      );
+      // and the extended config's settings must be preserved
+      assert_eq!(result.excludes, Some(vec!["test-excludes".to_string()]));
+      assert_eq!(
+        result.config_map.get("test"),
+        Some(&ConfigMapValue::PluginConfig(RawPluginConfig {
+          locked: false,
+          associations: None,
+          overrides: Vec::new(),
+          properties: ConfigKeyMap::from([(String::from("prop"), ConfigKeyValue::from_i32(6))]),
+        }))
+      );
     });
   }
 

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::hash::Hasher;
 use std::path::Path;
 use std::path::PathBuf;
@@ -976,7 +977,7 @@ pub async fn resolve_plugins_scope<TEnvironment: Environment>(
   plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
 ) -> Result<PluginsScope<TEnvironment>, ResolvePluginsError> {
   // resolve the plugins
-  let plugins = plugin_resolver.resolve_plugins(config.plugins.clone()).await?;
+  let plugins = filter_duplicate_plugin_names(plugin_resolver.resolve_plugins(config.plugins.clone()).await?);
   let mut config_map = config.config_map.clone();
 
   // resolve each plugin's configuration
@@ -1029,6 +1030,21 @@ pub async fn resolve_plugins_scope<TEnvironment: Environment>(
   }
 
   Ok(PluginsScope::new(environment.clone(), plugins, config, global_config_result.diagnostics)?)
+}
+
+/// Keeps only the highest precedence plugin for each plugin name.
+///
+/// The same plugin may end up specified more than once with different sources
+/// (ex. a config pinning a newer version of a plugin that the config it extends
+/// also specifies). Plugins are ordered by descending precedence, so the first
+/// entry for a name wins.
+///
+/// This can't be done when resolving the configuration because a plugin's name
+/// is only known once it has been resolved.
+fn filter_duplicate_plugin_names(plugins: Vec<Rc<PluginWrapper>>) -> Vec<Rc<PluginWrapper>> {
+  let mut names = HashSet::with_capacity(plugins.len());
+
+  plugins.into_iter().filter(|plugin| names.insert(plugin.info().name.clone())).collect()
 }
 
 fn resolve_plugin_config_overrides<TEnvironment: Environment>(


### PR DESCRIPTION
Fixes #1043

## Problem

When a config both `extends` another config **and** lists a plugin that the extended config also lists, the plugin ends up duplicated in the resolved plugin list, and the extended configuration is silently ignored.

Minimal repro (from #1043): a local config that extends a shared config and repeats one of its plugins loses the shared `typescript`/`excludes`/etc. settings the moment the local `plugins` array is added.

## Root cause

In `handle_config_file` (`crates/dprint/src/configuration/resolve_config.rs`), the extended config's plugins were appended with:

```rust
resolved_config.plugins.extend(plugins);
```

with no deduplication. So a plugin listed in both configs produced two entries for the same source.

Downstream, in `resolve_plugins_scope`, both entries resolve to the same plugin. The first one `shift_remove`s that plugin's config key out of the shared config map, so the second gets an empty config. `PluginsScope::new` then collects the plugins into an `IndexMap` keyed by plugin *name*, so the second, config-less instance replaces the first — and the extended configuration disappears.

The other two places that combine plugin lists already guard against the duplicate source: the local-config path calls `filter_duplicate_plugin_sources`, and so does `inherit_config`. The `extends` path was the only one missing it.

## Fix

Two parts, because deduplicating by source alone doesn't cover the case in the issue report.

**1. Deduplicate by plugin source when combining `extends` plugins** (`resolve_config.rs`), keeping the higher-precedence (earlier) entry, consistent with the other paths:

```rust
resolved_config.plugins.extend(plugins);
resolved_config.plugins = filter_duplicate_plugin_sources(std::mem::take(&mut resolved_config.plugins));
```

**2. Deduplicate by plugin name once the plugins are resolved** (`resolution.rs`). The config in #1043 pins `typescript-0.95.13.wasm` locally while the extended shared config specifies `0.93.0`. Those are different sources, so step 1 doesn't touch them, yet they resolve to the same plugin and hit exactly the same name collision described above — the extended config's older version even won over the locally pinned one. `resolve_plugins_scope` now keeps the highest precedence plugin per name before associating configuration:

```rust
let plugins = filter_duplicate_plugin_names(plugin_resolver.resolve_plugins(config.plugins.clone()).await?);
```

A plugin's name is only known after it has been resolved, which is why this can't live alongside the source-level dedupe.

## Tests

- `should_dedupe_plugin_specified_in_both_local_and_extended_config` (`resolve_config.rs`) covers the source-level dedupe.
- `should_use_extended_config_when_specifying_same_plugin_as_extended_config` and `should_use_extended_config_when_specifying_different_version_of_extended_config_plugin` (`commands/formatting.rs`) run a real `fmt` and assert the extended config's settings are actually applied, which is the symptom reported in #1043. Each fails without its corresponding part of the fix.

---

Disclosure: the original change was written with AI assistance (Claude Code).
