### PR TITLE
fix: apply implicit `node_modules` exclude and unanchored patterns in rebased scopes

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -1006,7 +1006,9 @@ impl ClapExtensions for clap::Command {
       .arg(
         Arg::new("allow-node-modules")
           .long("allow-node-modules")
-          .help("Allows traversing node module directories (unstable - This flag will be renamed to be non-node specific in the future).")
+          .help(
+            "Allows traversing node module directories. This is implicit when the current working directory is within one (unstable - This flag will be renamed to be non-node specific in the future).",
+          )
           .num_args(0),
       )
       .arg(

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -752,6 +752,81 @@ mod test {
   }
 
   #[test]
+  fn should_ignore_files_in_node_modules_in_ancestor_dir_arg() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/node_modules/file.txt", "text")
+      .write_file("/file.txt", "text")
+      .write_file("/sub/node_modules/file.txt", "text")
+      .write_file("/sub/file.txt", "text")
+      .set_cwd("/sub")
+      .build();
+
+    // the dir arg reaches above the cwd, so node_modules must be excluded
+    // based at the config's directory rather than only at the cwd
+    run_test_cli(vec!["fmt", ".."], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text_formatted");
+    assert_eq!(environment.read_file("/sub/file.txt").unwrap(), "text_formatted");
+    assert_eq!(environment.read_file("/node_modules/file.txt").unwrap(), "text");
+    assert_eq!(environment.read_file("/sub/node_modules/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_ignore_files_in_node_modules_in_dir_outside_config_dir() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_local_config("/project/dprint.json", |config| {
+        config.add_remote_wasm_plugin();
+      })
+      .with_global_config(|config| {
+        config
+          .add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "global-config" }"#);
+      })
+      .write_file("/other/file.txt", "text")
+      .write_file("/other/node_modules/file.txt", "text")
+      .set_cwd("/project")
+      .initialize()
+      .build();
+
+    // the outside path is formatted by the global config's scope, whose base
+    // path is the root directory rather than the cwd
+    run_test_cli(vec!["fmt", "../other"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/other/file.txt").unwrap(), "text_global-config");
+    assert_eq!(environment.read_file("/other/node_modules/file.txt").unwrap(), "text");
+  }
+
+  #[test]
+  fn should_ignore_files_in_node_modules_when_cwd_inside_one() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/node_modules/pkg/file.txt", "text")
+      .set_cwd("/node_modules/pkg")
+      .build();
+
+    // the implicit node_modules exclude is based at the config's directory, so
+    // it applies the same way it does when running from the config's directory
+    // (`--allow-node-modules` is the way to opt out of this)
+    for args in [vec!["fmt", "file.txt"], vec!["fmt"]] {
+      let error = run_test_cli(args, &environment).err().unwrap();
+      assert!(error.to_string().starts_with("No files found to format"), "{}", error);
+      error.assert_exit_code(14);
+      assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text");
+    }
+
+    run_test_cli(vec!["fmt", "--allow-node-modules"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+    assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text_formatted");
+  }
+
+  #[test]
   fn should_not_ignore_files_in_node_modules_when_allowed() {
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
       .write_file("/node_modules/file.txt", "const t=4;")
@@ -2583,6 +2658,28 @@ mod test {
       assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
       assert_eq!(environment.read_file("/sub/dir/file.txt").unwrap(), "text_formatted");
       assert_eq!(environment.read_file("/other.txt").unwrap(), "other");
+    }
+  }
+
+  #[test]
+  fn should_keep_config_excludes_with_includes_override_when_cwd_below_config_dir() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_remote_wasm_plugin().add_excludes("dist");
+      })
+      .write_file("/sub/dist/a.txt", "a")
+      .write_file("/sub/b.txt", "b")
+      .set_cwd("/sub")
+      .build();
+
+    // the override moves the matcher's base directory to the cwd, but the
+    // config exclude matches its name at any depth, so it still applies
+    for args in [vec!["fmt"], vec!["fmt", "--includes-override", "**/*.txt"]] {
+      environment.write_file("/sub/b.txt", "b").unwrap();
+      run_test_cli(args, &environment).unwrap();
+      assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+      assert_eq!(environment.read_file("/sub/b.txt").unwrap(), "b_formatted");
+      assert_eq!(environment.read_file("/sub/dist/a.txt").unwrap(), "a");
     }
   }
 

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -802,7 +802,7 @@ mod test {
   }
 
   #[test]
-  fn should_ignore_files_in_node_modules_when_cwd_inside_one() {
+  fn should_allow_node_modules_implicitly_when_cwd_inside_one() {
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
       .with_default_config(|config| {
         config.add_remote_wasm_plugin();
@@ -811,25 +811,41 @@ mod test {
       .set_cwd("/node_modules/pkg")
       .build();
 
-    // the implicit node_modules exclude is based at the config's directory, so
-    // it applies the same way it does when running from the config's directory
-    // (`--allow-node-modules` is the way to opt out of this)
+    // changing into a `node_modules` directory implicitly allows formatting
+    // there, since otherwise there would be nothing to format no matter what
+    // the user asked for
     for args in [
       vec!["fmt", "file.txt"],
       vec!["fmt"],
-      // an includes override moves the matcher's base to the cwd, but the exclude
-      // still has to reach the `node_modules` directory the cwd sits inside
+      // an includes override moves the matcher's base to the cwd, which must
+      // not change whether the implicit exclude applies
       vec!["fmt", "--includes-override", "**/*.txt"],
+      vec!["fmt", "--allow-node-modules"],
     ] {
-      let error = run_test_cli(args, &environment).err().unwrap();
-      assert!(error.to_string().starts_with("No files found to format"), "{}", error);
-      error.assert_exit_code(14);
-      assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text");
+      environment.write_file("/node_modules/pkg/file.txt", "text").unwrap();
+      run_test_cli(args, &environment).unwrap();
+      assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+      assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text_formatted");
     }
+  }
 
-    run_test_cli(vec!["fmt", "--allow-node-modules"], &environment).unwrap();
-    assert_eq!(environment.take_stdout_messages(), vec![get_singular_formatted_text()]);
+  #[test]
+  fn should_allow_nested_node_modules_when_cwd_inside_one() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .with_default_config(|config| {
+        config.add_remote_wasm_plugin();
+      })
+      .write_file("/node_modules/pkg/file.txt", "text")
+      .write_file("/node_modules/pkg/node_modules/dep/file.txt", "text")
+      .set_cwd("/node_modules/pkg")
+      .build();
+
+    // the implicit allow behaves exactly like passing the flag, so a nested
+    // `node_modules` below the cwd is formatted too
+    run_test_cli(vec!["fmt"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
     assert_eq!(environment.read_file("/node_modules/pkg/file.txt").unwrap(), "text_formatted");
+    assert_eq!(environment.read_file("/node_modules/pkg/node_modules/dep/file.txt").unwrap(), "text_formatted");
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -986,6 +986,34 @@ mod test {
   }
 
   #[test]
+  fn should_ignore_config_file_in_start_dir_when_config_file_url_specified() {
+    // a remote config file has no local path, so nothing identifies the local
+    // config file in the directory the traversal starts in as the one in use
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_remote_config("https://dprint.dev/test.json", |c| {
+        c.add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "custom-formatted" }"#);
+      })
+      .with_local_config("/dprint.json", |c| {
+        c.add_remote_wasm_plugin()
+          .add_config_section("test-plugin", r#"{ "ending": "local-formatted" }"#);
+      })
+      .write_file("/file1.txt", "text")
+      .write_file("/sub/file2.txt", "text2")
+      .build();
+
+    run_test_cli(vec!["fmt", "--config", "https://dprint.dev/test.json"], &environment).unwrap();
+
+    assert_eq!(environment.take_stdout_messages(), vec![get_plural_formatted_text(2)]);
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Compiling https://plugins.dprint.dev/test-plugin.wasm"]
+    );
+    assert_eq!(environment.read_file("/file1.txt").unwrap(), "text_custom-formatted");
+    assert_eq!(environment.read_file("/sub/file2.txt").unwrap(), "text2_custom-formatted");
+  }
+
+  #[test]
   fn should_format_files_with_config_associations() {
     let file_path1 = "/file1.txt";
     let file_path2 = "/file2.txt_ps";

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -814,7 +814,13 @@ mod test {
     // the implicit node_modules exclude is based at the config's directory, so
     // it applies the same way it does when running from the config's directory
     // (`--allow-node-modules` is the way to opt out of this)
-    for args in [vec!["fmt", "file.txt"], vec!["fmt"]] {
+    for args in [
+      vec!["fmt", "file.txt"],
+      vec!["fmt"],
+      // an includes override moves the matcher's base to the cwd, but the exclude
+      // still has to reach the `node_modules` directory the cwd sits inside
+      vec!["fmt", "--includes-override", "**/*.txt"],
+    ] {
       let error = run_test_cli(args, &environment).err().unwrap();
       assert!(error.to_string().starts_with("No files found to format"), "{}", error);
       error.assert_exit_code(14);

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -1971,6 +1971,12 @@ mod tests {
     // ...including when it names an ancestor other than the first one below the base
     assert_eq!(inherited_excludes(&["nested"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
     assert_eq!(inherited_excludes(&["nested"], "/", "/sub/nested/deep"), Some(vec!["**".to_string()]));
+    // ...and when it names one with a wildcard
+    assert_eq!(inherited_excludes(&["su*"], "/", "/sub"), Some(vec!["**".to_string()]));
+    assert_eq!(inherited_excludes(&["neste*"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
+    assert_eq!(inherited_excludes(&["**/sub"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
+    // a wildcard matching none of them keeps matching its name at any depth
+    assert_eq!(inherited_excludes(&["ot*"], "/", "/sub"), Some(vec!["ot*".to_string()]));
     // a pattern is normalized the way the ancestor config interprets it before
     // rebasing, so a backslash separator is a separator and not part of a name
     assert_eq!(inherited_excludes(&["dist\\sub"], "/", "/sub"), None);

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -1859,8 +1859,7 @@ mod tests {
       base_path: CanonicalizedPathBuf::new_for_testing("/"),
       is_global: false,
       includes: Some(vec!["**/*.txt".to_string()]),
-      // "**/node_modules" rebases into the nested directory, but the anchored
-      // "dist" points outside it and is dropped
+      // both patterns match at any depth, so both rebase into the nested directory
       excludes: Some(vec!["**/node_modules".to_string(), "dist".to_string()]),
       plugins: vec![
         PluginSourceReference::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
@@ -1915,7 +1914,10 @@ mod tests {
       ]
     );
     // ancestor excludes (rebased, droppable) come first, then the nested config's own
-    assert_eq!(result.excludes, Some(vec!["**/node_modules".to_string(), "sub-excludes".to_string()]));
+    assert_eq!(
+      result.excludes,
+      Some(vec!["**/node_modules".to_string(), "dist".to_string(), "sub-excludes".to_string()])
+    );
     // includes are not inherited
     assert_eq!(result.includes, None);
     // incremental is inherited when not specified
@@ -1955,6 +1957,13 @@ mod tests {
 
     // depth-relative patterns keep matching within the nested directory
     assert_eq!(inherited_excludes(&["**/node_modules"], "/", "/sub"), Some(vec!["**/node_modules".to_string()]));
+    // a pattern with no slash matches its name at any depth, so it's kept as-is
+    assert_eq!(inherited_excludes(&["dist"], "/", "/sub"), Some(vec!["dist".to_string()]));
+    assert_eq!(inherited_excludes(&["dist/"], "/", "/sub"), Some(vec!["dist/".to_string()]));
+    // ...unless it names the nested directory or one of its ancestors, in which
+    // case everything in the nested directory is excluded
+    assert_eq!(inherited_excludes(&["sub"], "/", "/sub"), Some(vec!["**".to_string()]));
+    assert_eq!(inherited_excludes(&["sub"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
     // a pattern anchored into the nested directory is rebased to be relative to it
     assert_eq!(inherited_excludes(&["sub/dist"], "/", "/sub"), Some(vec!["dist".to_string()]));
     // an anchored pattern that points outside the nested directory is dropped

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -17,6 +17,7 @@ use crate::configuration::ConfigMapValue;
 use crate::configuration::deserialize_config;
 use crate::environment::CanonicalizedPathBuf;
 use crate::environment::Environment;
+use crate::patterns::process_config_pattern;
 use crate::plugins::PluginSourceReference;
 use crate::plugins::parse_plugin_source_reference;
 use crate::utils::GlobPattern;
@@ -259,7 +260,10 @@ fn inherit_excludes(
   let mut result = ancestor
     .iter()
     .filter_map(|pattern| {
-      GlobPattern::new(pattern.clone(), ancestor_base.clone())
+      // normalize the same way the ancestor config's own excludes are (ex. backslash
+      // path separators, a leading `/` meaning the config's directory) so the rebase
+      // sees the pattern the way the ancestor interprets it
+      GlobPattern::new(process_config_pattern(pattern), ancestor_base.clone())
         .into_new_base(new_base.clone(), GlobPatternKind::Exclude)
         .map(|p| p.relative_pattern)
     })
@@ -1964,6 +1968,16 @@ mod tests {
     // case everything in the nested directory is excluded
     assert_eq!(inherited_excludes(&["sub"], "/", "/sub"), Some(vec!["**".to_string()]));
     assert_eq!(inherited_excludes(&["sub"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
+    // ...including when it names an ancestor other than the first one below the base
+    assert_eq!(inherited_excludes(&["nested"], "/", "/sub/nested"), Some(vec!["**".to_string()]));
+    assert_eq!(inherited_excludes(&["nested"], "/", "/sub/nested/deep"), Some(vec!["**".to_string()]));
+    // a pattern is normalized the way the ancestor config interprets it before
+    // rebasing, so a backslash separator is a separator and not part of a name
+    assert_eq!(inherited_excludes(&["dist\\sub"], "/", "/sub"), None);
+    assert_eq!(inherited_excludes(&["sub\\dist"], "/", "/sub"), Some(vec!["dist".to_string()]));
+    // a leading `/` anchors to the ancestor config's directory
+    assert_eq!(inherited_excludes(&["/sub/dist"], "/", "/sub"), Some(vec!["./dist".to_string()]));
+    assert_eq!(inherited_excludes(&["/dist"], "/", "/sub"), None);
     // a pattern anchored into the nested directory is rebased to be relative to it
     assert_eq!(inherited_excludes(&["sub/dist"], "/", "/sub"), Some(vec!["dist".to_string()]));
     // an anchored pattern that points outside the nested directory is dropped

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -220,11 +220,17 @@ fn get_config_exclude_file_patterns(
   // and make this work with that
   if !args.allow_node_modules {
     // glob walker will not search the children of a directory once it's ignored like this
+    //
+    // A pattern only applies below its own base directory, so base it at both the cwd and
+    // the config's base path: the cwd covers a config that lives above the cwd, while the
+    // config's base path covers what the cwd can't reach (ex. an ancestor dir arg like
+    // `dprint fmt ..` or a path outside the config's directory). The dedup below handles
+    // the two being the same directory.
     let node_modules_exclude = String::from("**/node_modules");
-    let mut exclude_node_module_patterns = vec![GlobPattern::new(node_modules_exclude.clone(), cwd.clone())];
-    if !cwd.starts_with(&config.base_path) {
-      exclude_node_module_patterns.push(GlobPattern::new(node_modules_exclude, config.base_path.clone()));
-    }
+    let exclude_node_module_patterns = [
+      GlobPattern::new(node_modules_exclude.clone(), cwd.clone()),
+      GlobPattern::new(node_modules_exclude, config.base_path.clone()),
+    ];
     for node_modules_exclude in exclude_node_module_patterns {
       if !file_patterns.contains(&node_modules_exclude) {
         file_patterns.push(node_modules_exclude);

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -218,7 +218,10 @@ fn get_config_exclude_file_patterns(
 
   // todo(THIS PR): document removing this flag in favour of a !**/node_modules pattern
   // and make this work with that
-  if !args.allow_node_modules {
+  // `--allow-node-modules` is implicit when the cwd is within a `node_modules` directory:
+  // changing into one is deliberate, so excluding everything there would leave nothing to
+  // format no matter what the user asked for
+  if !args.allow_node_modules && !is_in_node_modules(cwd.as_ref()) {
     // glob walker will not search the children of a directory once it's ignored like this
     //
     // A pattern only applies below its own base directory, so base it at both the cwd and
@@ -248,6 +251,11 @@ pub fn process_cli_path_args(paths: &[PathBuf], cwd: &CanonicalizedPathBuf, envi
     .iter()
     .map(|path| process_cli_pattern(&path.to_string_lossy(), cwd, environment))
     .collect()
+}
+
+/// Whether the directory is a `node_modules` directory or is inside one.
+fn is_in_node_modules(dir: &Path) -> bool {
+  dir.components().any(|component| component.as_os_str() == "node_modules")
 }
 
 fn process_file_pattern_slashes(file_pattern: &str) -> String {
@@ -353,6 +361,18 @@ mod test {
   use crate::environment::TestEnvironment;
 
   use super::*;
+
+  #[test]
+  fn should_get_if_in_node_modules() {
+    assert!(is_in_node_modules(Path::new("/node_modules")));
+    assert!(is_in_node_modules(Path::new("/node_modules/pkg")));
+    assert!(is_in_node_modules(Path::new("/a/node_modules/pkg/sub")));
+    assert!(!is_in_node_modules(Path::new("/")));
+    assert!(!is_in_node_modules(Path::new("/a/sub")));
+    // only a whole component counts
+    assert!(!is_in_node_modules(Path::new("/a/my_node_modules/pkg")));
+    assert!(!is_in_node_modules(Path::new("/a/node_modules_old")));
+  }
 
   #[test]
   fn should_process_cli_patterns() {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -334,7 +334,7 @@ pub fn process_config_patterns(file_patterns: &[String]) -> impl Iterator<Item =
   file_patterns.iter().map(|p| process_config_pattern(p))
 }
 
-fn process_config_pattern(file_pattern: &str) -> String {
+pub fn process_config_pattern(file_pattern: &str) -> String {
   let file_pattern = process_file_pattern_slashes(file_pattern);
   // make config patterns that start with `/` be relative
   if file_pattern.starts_with('/') {

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -651,15 +651,14 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
       return Ok(Vec::new());
     }
 
-    // group the paths by the config that governs them (keyed by the config's
-    // base directory)
-    let mut path_groups: IndexMap<CanonicalizedPathBuf, (OutsideScopeConfig, Vec<String>)> = IndexMap::new();
+    // group the paths by the config that governs them
+    let mut path_groups: IndexMap<OutsideScopeConfigKey, (OutsideScopeConfig, Vec<String>)> = IndexMap::new();
     for outside_path in outside_base_paths {
       let Some(scope_config) = self.resolve_outside_scope_config(&outside_path, config, config_discovery)? else {
         continue; // skipped with a warning
       };
       path_groups
-        .entry(scope_config.base_path().clone())
+        .entry(scope_config.group_key())
         .or_insert_with(|| (scope_config, Vec::new()))
         .1
         .push(outside_path.include_pattern);
@@ -923,12 +922,25 @@ enum OutsideScopeConfig {
 }
 
 impl OutsideScopeConfig {
-  fn base_path(&self) -> &CanonicalizedPathBuf {
+  fn group_key(&self) -> OutsideScopeConfigKey {
     match self {
-      Self::ConfigFile(config_path) => &config_path.base_path,
-      Self::RebasedCurrentConfig(base_path) => base_path,
+      Self::ConfigFile(config_path) => OutsideScopeConfigKey::ConfigFile(config_path.base_path.clone()),
+      Self::RebasedCurrentConfig(base_path) => OutsideScopeConfigKey::RebasedCurrentConfig(base_path.clone()),
     }
   }
+}
+
+/// Identifies the config governing a group of outside paths.
+///
+/// The base directory alone isn't enough because a config file could live in
+/// the same directory the current config gets rebased at (ex. a config file at
+/// a drive root), which would otherwise silently resolve some paths against the
+/// wrong config. The way the config is resolved rules that out today, but
+/// keying on the variant makes it impossible to get wrong.
+#[derive(PartialEq, Eq, Hash)]
+enum OutsideScopeConfigKey {
+  ConfigFile(CanonicalizedPathBuf),
+  RebasedCurrentConfig(CanonicalizedPathBuf),
 }
 
 pub async fn get_plugins_scope_from_args<TEnvironment: Environment>(

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -69,7 +69,7 @@ pub static PROCESS_PLUGIN_ZIP_BYTES: Lazy<Vec<u8>> = Lazy::new(|| {
     )
     .unwrap();
   let file_bytes = std::fs::read(&*TEST_PROCESS_PLUGIN_PATH).unwrap();
-  zip.write(&file_bytes).unwrap();
+  zip.write_all(&file_bytes).unwrap();
   zip.finish().unwrap().into_inner()
 });
 pub static PROCESS_PLUGIN_ZIP_CHECKSUM: Lazy<String> = Lazy::new(|| crate::utils::get_sha256_checksum(&PROCESS_PLUGIN_ZIP_BYTES));

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -128,6 +128,14 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
   // check the directories between the pattern base and the start directory the
   // same way a traversal descending from the pattern base would so matching
   // works the same regardless of the directory dprint is run from
+  //
+  // Note this chain includes the start directory itself, so a config file
+  // sitting in it hands the directory to the sub scope created for that config
+  // file. That's deliberate: it's what happens when running from the pattern
+  // base instead, where the traversal descends into the directory and finds it.
+  // The traversal below intentionally does the opposite for the start directory
+  // (see `ReadDirRunner::read_dir_entries`), which only matters when this check
+  // doesn't run because the start directory is the pattern base.
   if run_traversal && opts.start_dir != opts.pattern_base.as_ref() && opts.start_dir.starts_with(opts.pattern_base.as_ref()) {
     match check_dir_chain(
       &glob_matcher,
@@ -214,7 +222,12 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
     let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
     let results = glob_matching_processor.run()?;
     output.file_paths.extend(results.file_paths);
-    output.config_files.extend(results.config_files);
+    for config_file in results.config_files {
+      // the traversal skips the directories the checks above already handled,
+      // so this shouldn't overlap with them, but dedup anyway because a
+      // duplicate would resolve the same scope (and format its files) twice
+      push_dedup_config_file(&mut output.config_files, config_file);
+    }
   }
 
   log_debug!(environment, "File(s) matched: {:?}", output);
@@ -414,7 +427,10 @@ fn could_be_literal_path(pattern: &str) -> bool {
     if !was_last_escape && matches!(c, '*' | '?') {
       return false;
     }
-    was_last_escape = matches!(c, '\\');
+    // consume backslashes in pairs the same way `unescape_glob_text` does so
+    // an escaped backslash doesn't escape the character after it
+    // (ex. the `*` in `a\\*b` is a glob star)
+    was_last_escape = c == '\\' && !was_last_escape;
   }
   true
 }
@@ -715,6 +731,16 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     if entries.is_empty() {
       return Ok(None);
     }
+    // Note the start directory is exempt from config file detection because the
+    // traversal starts there, so a config file in it would take over the entire
+    // scope. Usually `current_config_path` already filters it out, but not when
+    // the config in use has no local path (ex. `--config https://host/x.json`,
+    // where the base path is the cwd) or when the directory holds a config file
+    // name other than the one in use (ex. both `dprint.json` and `.dprint.json`),
+    // because that filter only ever removes the one in use. Note that the start
+    // directory is not exempt when it's below the pattern base: the chain check
+    // in `glob` handles it there so the result doesn't depend on which
+    // directory dprint was run from.
     let maybe_config_file = if self.options.config_discovery.traverse_descendants() && current_dir != self.options.start_dir {
       entries
         .iter()
@@ -1646,5 +1672,17 @@ mod test {
     let mut result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
     result.sort();
     assert_eq!(result, vec!["/dir/b/b.txt"]);
+  }
+
+  #[test]
+  fn should_get_if_could_be_literal_path() {
+    assert!(could_be_literal_path("routes/[id].svelte"));
+    assert!(could_be_literal_path("{{myfile}}.yaml"));
+    assert!(!could_be_literal_path("**/*.txt"));
+    assert!(!could_be_literal_path("file?.txt"));
+    // an escaped glob character names a literal path
+    assert!(could_be_literal_path("a\\*b"));
+    // ...but an escaped backslash doesn't escape the star after it
+    assert!(!could_be_literal_path("a\\\\*b"));
   }
 }

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -253,6 +253,24 @@ impl GlobPattern {
         return covers_new_base.then(|| GlobPattern::new(build_pattern("**"), new_base_dir));
       }
 
+      // A pattern that isn't anchored and has no internal slash (ex. `dist`,
+      // `*.min.js`, `dist/`) matches its name at any depth below the base
+      // directory, so it matches at any depth below the new base too and
+      // survives the rebase unchanged. It never consumes prefix components,
+      // so the loop below would find no sub match and incorrectly drop it.
+      if !is_anchored && !pattern.trim_end_matches('/').contains('/') {
+        // an exclude naming any directory between the old and new base means
+        // the new base sits inside an excluded directory, which covers
+        // everything within it
+        if covers_new_base {
+          let name = pattern.trim_end_matches('/');
+          if name == "*" || prefix.iter().any(|part| unescape_glob_text(name) == *part) {
+            return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
+          }
+        }
+        return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
+      }
+
       loop {
         let mut found_sub_match = false;
         if pattern == "**" || pattern.starts_with("**/") {
@@ -491,6 +509,45 @@ mod test {
       let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
       let new_pattern = pattern.clone().into_new_base(child_dir.clone(), GlobPatternKind::Exclude).unwrap();
       assert_eq!(new_pattern.relative_pattern, "./**");
+      assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
+    }
+  }
+
+  /// A pattern that isn't anchored and has no slash matches its name at any
+  /// depth, so it survives being rebased into a descendant directory.
+  #[test]
+  fn should_handle_mapping_depth_floating_pattern_into_descendant_dir() {
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
+    let child_dir = CanonicalizedPathBuf::new_for_testing("/base/sub");
+    let descendant_dir = CanonicalizedPathBuf::new_for_testing("/base/sub/nested");
+    // kept as-is no matter how deep the new base is
+    for pattern_text in ["dist", "*.min.js", "dist/", "!dist"] {
+      for new_base_dir in [&child_dir, &descendant_dir] {
+        let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+        let new_pattern = into_new_base(pattern, new_base_dir.clone()).unwrap();
+        assert_eq!(new_pattern.base_dir, *new_base_dir);
+        assert_eq!(new_pattern.relative_pattern, pattern_text);
+      }
+    }
+    // an exclude naming a directory the new base is within covers everything in it
+    for pattern_text in ["sub", "sub/", "*", "\\[sub\\]"] {
+      let new_base_dir = if pattern_text.starts_with('\\') {
+        CanonicalizedPathBuf::new_for_testing("/base/[sub]/nested")
+      } else {
+        descendant_dir.clone()
+      };
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.clone().into_new_base(new_base_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.base_dir, new_base_dir);
+      assert_eq!(new_pattern.relative_pattern, "**");
+      // an include naming a directory says nothing about its contents, so it
+      // stays a name match at any depth below the new base
+      let new_pattern = pattern.into_new_base(new_base_dir, GlobPatternKind::Include).unwrap();
+      assert_eq!(new_pattern.relative_pattern, pattern_text);
+    }
+    // an anchored pattern is unaffected (it only matches at its own base)
+    {
+      let pattern = GlobPattern::new("./dist".to_string(), base_dir.clone());
       assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
     }
   }

--- a/crates/dprint/src/utils/glob/glob_pattern.rs
+++ b/crates/dprint/src/utils/glob/glob_pattern.rs
@@ -8,6 +8,7 @@ use super::escape_glob_text;
 use super::is_negated_glob;
 use super::is_pattern;
 use super::non_negated_glob;
+use super::pattern_names_dir;
 use super::unescape_glob_text;
 
 /// What a pattern does with the files it matches, which decides whether naming
@@ -262,11 +263,8 @@ impl GlobPattern {
         // an exclude naming any directory between the old and new base means
         // the new base sits inside an excluded directory, which covers
         // everything within it
-        if covers_new_base {
-          let name = pattern.trim_end_matches('/');
-          if name == "*" || prefix.iter().any(|part| unescape_glob_text(name) == *part) {
-            return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
-          }
+        if covers_new_base && names_ancestor_of_new_base(pattern.trim_end_matches('/'), &prefix) {
+          return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
         }
         return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
       }
@@ -274,6 +272,15 @@ impl GlobPattern {
       loop {
         let mut found_sub_match = false;
         if pattern == "**" || pattern.starts_with("**/") {
+          // a `**/name` pattern floats by depth just like a slashless one, so it
+          // also covers the new base when it names one of the directories above it
+          if covers_new_base
+            && let Some(name) = pattern.strip_prefix("**/")
+            && !name.trim_end_matches('/').contains('/')
+            && names_ancestor_of_new_base(name.trim_end_matches('/'), &prefix)
+          {
+            return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
+          }
           return Some(GlobPattern::new(build_pattern(pattern), new_base_dir));
         }
         // a final pattern component naming this directory means the pattern
@@ -282,7 +289,7 @@ impl GlobPattern {
         if covers_new_base
           && !pattern.contains('/')
           && let Some(first_item) = prefix.front()
-          && (pattern == "*" || unescape_glob_text(pattern) == *first_item)
+          && pattern_names_dir(pattern, first_item)
         {
           return Some(GlobPattern::new(build_pattern("**"), new_base_dir));
         }
@@ -296,11 +303,12 @@ impl GlobPattern {
           }
           found_sub_match = true;
         }
-        // check for a match for the name (unescaping so an escaped literal
-        // part like `\[a\]` matches the actual directory name)
+        // check for a match for the name (an escaped literal part like `\[a\]`
+        // matches the actual directory name, and a wildcard part like `su*`
+        // matches what it would match when the pattern is finally matched)
         let first_item = prefix.front().unwrap();
         if let Some((first_part, new_pattern)) = pattern.split_once('/')
-          && unescape_glob_text(first_part) == *first_item
+          && pattern_names_dir(first_part, first_item)
         {
           pattern = new_pattern;
           prefix.pop_front();
@@ -337,6 +345,13 @@ impl GlobPattern {
     }
     base
   }
+}
+
+/// Whether a single component pattern names any of the directories between the
+/// pattern's base directory and the new base, which for an exclude means the
+/// new base sits inside an excluded directory.
+fn names_ancestor_of_new_base(name: &str, prefix: &VecDeque<&str>) -> bool {
+  prefix.iter().any(|part| pattern_names_dir(name, part))
 }
 
 #[cfg(test)]
@@ -545,10 +560,56 @@ mod test {
       let new_pattern = pattern.into_new_base(new_base_dir, GlobPatternKind::Include).unwrap();
       assert_eq!(new_pattern.relative_pattern, pattern_text);
     }
+    // ...including when the name is a wildcard that matches the directory
+    for pattern_text in ["su*", "?ub", "[sd]ub", "s{ub,omething}"] {
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(descendant_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "**");
+    }
+    // ...and when the name is one of the directories above the new base rather
+    // than the first one below the old base
+    for pattern_text in ["nested", "neste*"] {
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(descendant_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "**");
+    }
+    // a wildcard that doesn't match any of them keeps floating by depth
+    for pattern_text in ["ot*", "[abc]ub"] {
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(descendant_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.relative_pattern, pattern_text);
+    }
     // an anchored pattern is unaffected (it only matches at its own base)
     {
       let pattern = GlobPattern::new("./dist".to_string(), base_dir.clone());
       assert_eq!(pattern.into_new_base(child_dir, GlobPatternKind::Include), None);
+    }
+  }
+
+  /// A `**/name` pattern floats by depth the same way a slashless one does, so
+  /// it also covers a new base that sits inside a directory it names.
+  #[test]
+  fn should_handle_mapping_depth_floating_glob_star_pattern_into_descendant_dir() {
+    let base_dir = CanonicalizedPathBuf::new_for_testing("/base");
+    let inside_dir = CanonicalizedPathBuf::new_for_testing("/base/node_modules/pkg");
+    // an exclude whose name is a directory the new base is within covers it all
+    for pattern_text in ["**/node_modules", "**/node_modules/", "**/node_module*"] {
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(inside_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.base_dir, inside_dir);
+      assert_eq!(new_pattern.relative_pattern, "**");
+    }
+    // an include says nothing about the contents, so it keeps floating by depth
+    {
+      let pattern = GlobPattern::new("**/node_modules".to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(inside_dir.clone(), GlobPatternKind::Include).unwrap();
+      assert_eq!(new_pattern.relative_pattern, "**/node_modules");
+    }
+    // one that names none of the directories above the new base is unaffected
+    for pattern_text in ["**/dist", "**/node_modules/dist", "**"] {
+      let pattern = GlobPattern::new(pattern_text.to_string(), base_dir.clone());
+      let new_pattern = pattern.into_new_base(inside_dir.clone(), GlobPatternKind::Exclude).unwrap();
+      assert_eq!(new_pattern.relative_pattern, pattern_text);
     }
   }
 

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use ignore::gitignore::GitignoreBuilder;
+
 pub fn is_negated_glob(pattern: &str) -> bool {
   let mut chars = pattern.chars();
   let first_char = chars.next();
@@ -29,6 +31,29 @@ pub fn is_pattern(pattern: &str) -> bool {
     was_last_escape = c == '\\' && !was_last_escape;
   }
   false
+}
+
+/// Whether a single path component pattern (ex. `dist`, `su*`, `[sd]ist`)
+/// names the given directory.
+///
+/// Matching goes through the same gitignore engine the exclude matcher uses so
+/// a wildcard means here what it means when the pattern is finally matched.
+pub fn pattern_names_dir(pattern: &str, dir_name: &str) -> bool {
+  if !is_pattern(pattern) {
+    return unescape_glob_text(pattern) == dir_name;
+  }
+  // a component pattern can't match a name containing a separator
+  if dir_name.contains('/') || dir_name.contains('\\') {
+    return false;
+  }
+  let mut builder = GitignoreBuilder::new("");
+  if builder.add_line(None, pattern).is_err() {
+    return false;
+  }
+  match builder.build() {
+    Ok(gitignore) => gitignore.matched(dir_name, true).is_ignore(),
+    Err(_) => false,
+  }
 }
 
 /// Escapes glob metacharacters so the text matches literally
@@ -145,6 +170,26 @@ mod tests {
     // ...while `a\*b` is an escaped star and so not a pattern
     assert!(!is_pattern("a\\*b"));
     assert_eq!(unescape_glob_text("a\\*b"), "a*b");
+  }
+
+  #[test]
+  fn should_get_if_pattern_names_dir() {
+    assert!(pattern_names_dir("dist", "dist"));
+    assert!(!pattern_names_dir("dist", "other"));
+    // wildcards mean what they mean when the pattern is finally matched
+    assert!(pattern_names_dir("su*", "sub"));
+    assert!(!pattern_names_dir("su*", "other"));
+    assert!(pattern_names_dir("?ub", "sub"));
+    assert!(pattern_names_dir("[sd]ist", "dist"));
+    assert!(!pattern_names_dir("[sd]ist", "list"));
+    assert!(pattern_names_dir("*", "anything"));
+    assert!(pattern_names_dir("*.min.js", "a.min.js"));
+    // both ways of escaping a glob character match the literal name
+    assert!(pattern_names_dir("\\[id\\]", "[id]"));
+    assert!(pattern_names_dir("[[]id[]]", "[id]"));
+    // a single component pattern never matches across a separator
+    assert!(!pattern_names_dir("dist", "dist/sub"));
+    assert!(!pattern_names_dir("*", "dist/sub"));
   }
 
   #[test]

--- a/crates/dprint/src/utils/glob/glob_utils.rs
+++ b/crates/dprint/src/utils/glob/glob_utils.rs
@@ -23,7 +23,10 @@ pub fn is_pattern(pattern: &str) -> bool {
       return true;
     }
 
-    was_last_escape = matches!(c, '\\');
+    // consume backslashes in pairs the same way `unescape_glob_text` does so
+    // an escaped backslash doesn't escape the character after it
+    // (ex. the `*` in `a\\*b` is a glob star)
+    was_last_escape = c == '\\' && !was_last_escape;
   }
   false
 }
@@ -134,6 +137,14 @@ mod tests {
     assert!(is_pattern("routes/[id].svelte"));
     assert!(!is_pattern(&escape_glob_text("routes/[id].svelte")));
     assert_eq!(unescape_glob_text(&escape_glob_text("a*b?c!d\\e[]{}")), "a*b?c!d\\e[]{}");
+
+    // an escaped backslash doesn't escape the character after it, so the
+    // star in `a\\*b` is a glob star (matching `unescape_glob_text`)
+    assert!(is_pattern("a\\\\*b"));
+    assert_eq!(unescape_glob_text("a\\\\*b"), "a\\*b");
+    // ...while `a\*b` is an escaped star and so not a pattern
+    assert!(!is_pattern("a\\*b"));
+    assert_eq!(unescape_glob_text("a\\*b"), "a*b");
   }
 
   #[test]


### PR DESCRIPTION
Follow-up fixes to #1207.

## ⚠️ Behavior change

`--allow-node-modules` is now **implicit when the cwd is within a `node_modules` directory**.

Basing the implicit exclude at the config's directory (below) means it reaches the directories the cwd sits inside, so running `dprint fmt` from inside `node_modules` would otherwise format nothing and require the flag. Changing into one is deliberate, so it is treated as the flag being passed. This behaves exactly like passing it, so a nested `node_modules` below the cwd is formatted too.

Covered by `should_allow_node_modules_implicitly_when_cwd_inside_one` and `should_allow_nested_node_modules_when_cwd_inside_one`.

## `**/node_modules` exclude in rebased scopes

The implicit `**/node_modules` exclude was only based at the config's directory when the cwd was outside it, so it could not reach paths resolved above the cwd (ex. `dprint fmt ..`) or outside the config's directory. It is now based at the config's directory as well.

## Depth-floating patterns when rebasing

`GlobPattern::into_new_base` dropped patterns that are not anchored and have no internal slash (ex. `dist`) when rebasing into a descendant. Those match their name at any depth, so they apply below the new base too and are now kept.

## Excludes that name an ancestor of the new base

`into_new_base` promotes an exclude to `**` when it names a directory the new base sits inside, but it only recognized literal names, missing two cases:

- **`**/name` patterns returned early without the check at all.** This showed up as an includes override changing whether the implicit `node_modules` exclude applied — the override moves the matcher's base to the cwd, and rebasing `**/node_modules` into a base inside `node_modules` left it matching only descendants. Whether the matcher's base is the config directory or a deeper cwd no longer changes the result.
- **Wildcards naming the directory** (ex. `su*`, `[sd]ist`) were not recognized, leaving the new base un-excluded.

Matching now goes through the same gitignore engine the exclude matcher uses (`pattern_names_dir`), so a wildcard means the same thing here as when the pattern is finally matched. The same helper replaces the literal comparison used when walking prefix components, so an anchored `su*/dist` rebases instead of being dropped.

## Inherited excludes were not normalized

`inherit_excludes` built its `GlobPattern`s from the raw config strings while every other producer routes them through `process_config_pattern` first, so a backslash separator was not recognized as one and a leading `/` did not anchor.

That mattered once an unanchored pattern with no internal slash started being retained: an ancestor exclude of `dist\sub` has no `/`, so it took the depth-floating branch and was copied verbatim into the inheriting config, where it was normalized as `dist/sub` relative to the nested base — a path the ancestor never excluded.

## Config discovery + path grouping

Documented why `check_dir_chain` detects a config file in the traversal's start directory while `ReadDirRunner` skips it: the chain check runs first and wins, and the reader's guard covers the cases the `current_config_path` filter cannot (a config with no local path like `--config <url>`, or a directory holding a config file name other than the one in use).

The traversal's config files now go through `push_dedup_config_file`, and outside path groups are keyed on the config variant as well as its base directory, making a duplicate scope impossible by construction.

`is_pattern` and `could_be_literal_path` now consume backslashes in pairs the way `unescape_glob_text` does. No pattern reaching them contains a double backslash today, so this only keeps the three in agreement.

## Test fix

Writing the test process plugin zip ignored the written amount. A short write would silently produce a corrupt zip, and `unused_io_amount` is deny-by-default, so this made `cargo clippy --all-targets` fail to compile the test target.
