### PR TITLE
fix: keep a duplicate plugin's checksum when deduping plugin sources

### DIFF
--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -3727,6 +3727,61 @@ mod test {
   }
 
   #[test]
+  fn should_use_extended_config_checksum_for_wasm_plugin_specified_without_one() {
+    // the plugin is deduped down to the local config's entry, which specifies no
+    // checksum, so the extended config's checksum must carry over to it
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_remote_config("https://dprint.dev/shared.json", |c| {
+        c.add_remote_wasm_plugin_with_checksum("asdf");
+      })
+      .with_default_config(|c| {
+        c.add_config_section("extends", r#""https://dprint.dev/shared.json""#).add_remote_wasm_plugin();
+      })
+      .write_file("/test.txt", "")
+      .build();
+    let actual_plugin_file_checksum = test_helpers::get_test_wasm_plugin_checksum();
+    let err = run_test_cli(vec!["fmt", "*.*"], &environment).err().unwrap();
+    err.assert_exit_code(12);
+
+    assert_eq!(
+      err.to_string(),
+      format!(
+        concat!(
+          "Error resolving plugin https://plugins.dprint.dev/test-plugin.wasm: Invalid checksum specified ",
+          "in configuration file. Check the plugin's release notes for what the expected checksum is.\n\n",
+          "The checksum did not match the expected checksum.\n\n",
+          "Actual: {}\n",
+          "Expected: asdf"
+        ),
+        actual_plugin_file_checksum,
+      )
+    );
+  }
+
+  #[test]
+  fn should_use_extended_config_checksum_for_process_plugin_specified_without_one() {
+    // a process plugin requires a checksum, so dropping the extended config's
+    // checksum when deduping would fail this outright
+    let environment = TestEnvironmentBuilder::new()
+      .add_remote_process_plugin()
+      .with_local_config("/shared.json", |c| {
+        c.add_remote_process_plugin();
+      })
+      .with_default_config(|c| {
+        c.add_config_section("extends", r#""./shared.json""#)
+          .add_plugin("https://plugins.dprint.dev/test-process.json");
+      })
+      .write_file("/test.txt_ps", "text")
+      .build();
+
+    run_test_cli(vec!["fmt", "*.*"], &environment).unwrap();
+
+    environment.take_stdout_messages();
+    environment.take_stderr_messages();
+    assert_eq!(environment.read_file("/test.txt_ps").unwrap(), "text_formatted_process");
+  }
+
+  #[test]
   fn should_error_if_process_plugin_has_wrong_checksum_in_config() {
     let environment = TestEnvironmentBuilder::with_remote_process_plugin()
       .with_default_config(|c| {

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -7,6 +7,7 @@ use deno_terminal::colors;
 use dprint_core::async_runtime::FutureExt;
 use dprint_core::async_runtime::LocalBoxFuture;
 use dprint_core::configuration::ConfigKeyValue;
+use indexmap::IndexMap;
 use thiserror::Error;
 
 use crate::arg_parser::CliArgs;
@@ -613,12 +614,28 @@ fn get_warn_non_wasm_plugins_message() -> String {
   )
 }
 
+/// Removes plugins that specify the same source, keeping the highest precedence
+/// (earliest) entry.
+///
+/// A discarded duplicate's checksum is kept when the entry that wins doesn't
+/// specify one. Otherwise a config that specifies a plugin without a checksum
+/// would discard the checksum specified for it by a lower precedence config
+/// (ex. a shared config being extended), which either silently drops the
+/// integrity check for a Wasm plugin or fails outright for a process plugin
+/// because those require a checksum.
 fn filter_duplicate_plugin_sources(plugin_sources: Vec<PluginSourceReference>) -> Vec<PluginSourceReference> {
-  let mut path_source_set = std::collections::HashSet::new();
+  let mut checksums_by_path_source: IndexMap<PathSource, Option<String>> = IndexMap::with_capacity(plugin_sources.len());
 
-  plugin_sources
+  for plugin_source in plugin_sources {
+    let checksum = checksums_by_path_source.entry(plugin_source.path_source).or_default();
+    if checksum.is_none() {
+      *checksum = plugin_source.checksum;
+    }
+  }
+
+  checksums_by_path_source
     .into_iter()
-    .filter(|source| path_source_set.insert(source.path_source.clone()))
+    .map(|(path_source, checksum)| PluginSourceReference { path_source, checksum })
     .collect()
 }
 
@@ -956,6 +973,72 @@ mod tests {
           overrides: Vec::new(),
           properties: ConfigKeyMap::from([(String::from("prop"), ConfigKeyValue::from_i32(6))]),
         }))
+      );
+    });
+  }
+
+  #[test]
+  fn should_keep_extended_config_checksum_for_plugin_specified_without_one() {
+    // deduping the plugin must not discard the checksum the extended config
+    // specified for it, otherwise the integrity check is silently dropped
+    let environment = TestEnvironment::new();
+    environment.add_remote_file(
+      "https://dprint.dev/test.json",
+      r#"{
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm@checksum"]
+        }"#
+        .as_bytes(),
+    );
+    environment
+      .write_file(
+        &PathBuf::from("/test.json"),
+        r#"{
+            "extends": "https://dprint.dev/test.json",
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm"]
+        }"#,
+      )
+      .unwrap();
+
+    environment.clone().run_in_runtime(async move {
+      let result = get_result("/test.json", &environment).await.unwrap();
+      assert_eq!(
+        result.plugins,
+        vec![PluginSourceReference {
+          path_source: PathSource::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
+          checksum: Some(String::from("checksum")),
+        }]
+      );
+    });
+  }
+
+  #[test]
+  fn should_use_own_checksum_over_extended_config_checksum() {
+    let environment = TestEnvironment::new();
+    environment.add_remote_file(
+      "https://dprint.dev/test.json",
+      r#"{
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm@extended-checksum"]
+        }"#
+        .as_bytes(),
+    );
+    environment
+      .write_file(
+        &PathBuf::from("/test.json"),
+        r#"{
+            "extends": "https://dprint.dev/test.json",
+            "plugins": ["https://plugins.dprint.dev/test-plugin.wasm@local-checksum"]
+        }"#,
+      )
+      .unwrap();
+
+    environment.clone().run_in_runtime(async move {
+      let result = get_result("/test.json", &environment).await.unwrap();
+      assert_eq!(
+        result.plugins,
+        vec![PluginSourceReference {
+          path_source: PathSource::new_remote_from_str("https://plugins.dprint.dev/test-plugin.wasm"),
+          checksum: Some(String::from("local-checksum")),
+        }]
       );
     });
   }


### PR DESCRIPTION
Follow-up to #1208.

## Problem

`filter_duplicate_plugin_sources` keeps the highest precedence (earliest) entry for a given plugin source and drops the rest, checksum and all. So when a config specifies a plugin *without* a checksum and a lower precedence config specifies the same source *with* one, the checksum is discarded:

```jsonc
// dprint.json
{
  "extends": "https://dprint.dev/shared.json",
  "plugins": ["https://plugins.dprint.dev/test-plugin.wasm"]
}
```
```jsonc
// shared.json
{
  "plugins": ["https://plugins.dprint.dev/test-plugin.wasm@<checksum>"]
}
```

Depending on the plugin kind that is either a silent security downgrade or a hard failure:

- **Wasm** — a checksum is optional, so the plugin is fetched and run with no integrity check at all, even though a config in the chain asked for one.
- **Process** — a checksum is required (`cache.rs`), so this fails with "The plugin must have a checksum specified for security reasons", even though the checksum is right there in the config being extended.

This applies to all three places that combine plugin lists: a single config's own `plugins` array, `extends`, and `inherit`.

## Fix

Keep the discarded duplicate's checksum when the entry that wins doesn't specify one. A checksum specified by the winning entry still takes precedence, so the existing precedence semantics are unchanged — this only fills in a checksum where there wasn't one.

## Tests

- `should_keep_extended_config_checksum_for_plugin_specified_without_one` and `should_use_own_checksum_over_extended_config_checksum` (`resolve_config.rs`) cover the resolution and the precedence.
- `should_use_extended_config_checksum_for_wasm_plugin_specified_without_one` (`commands/formatting.rs`) points the extended config at a deliberately wrong checksum and asserts `fmt` fails verification, proving the adopted checksum is actually enforced rather than just carried along.
- `should_use_extended_config_checksum_for_process_plugin_specified_without_one` asserts the process plugin case now formats instead of erroring.

Each fails without the change.
