### PR TITLE
docs: fix broken 'Editing Config via CLI' link in global config docs

### DIFF
--- a/website/src/global-config.md
+++ b/website/src/global-config.md
@@ -44,7 +44,7 @@ Edit your global configuration file:
 dprint config edit --global
 ```
 
-The editor to use for the global config follows the same rules as [Editing Config via CLI](config/#updating-config-via-cli) (set the `DPRINT_EDITOR` environment variable to customize it)
+The editor to use for the global config follows the same rules as [Editing Config via CLI](/config#editing-config-via-cli) (set the `DPRINT_EDITOR` environment variable to customize it)
 
 ## Using the Global Configuration
 


### PR DESCRIPTION
The "Editing Config via CLI" link in `website/src/global-config.md` points at `config/#updating-config-via-cli`, but there is no "Updating Config via CLI" heading in the docs. The intended target is the `### Editing Config via CLI` section in `config.md`, which matches the link's own text.

This changes the link to `/config#editing-config-via-cli` — correcting the anchor and using the absolute `/page#anchor` form that every other cross-page link in the docs already uses (e.g. `/cli#ignoring-gitignore`, `/cli#changing-config-discovery`).

Verified against the live site: the config page has "Adding Plugins via CLI", "Updating Plugins via CLI", and "Editing Config via CLI" — there is no "Updating Config via CLI".

---
AI disclosure: this one-line docs fix was prepared with AI assistance (Claude Code) and reviewed before submitting.
