### PR TITLE
docs: add Panache plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Repos:
 - [pretty_graphql](https://github.com/g-plane/pretty_graphql) - GraphQL formatter.
 - [pretty_yaml](https://github.com/g-plane/pretty_yaml) - YAML formatter.
 - [dprint-plugin-gofumpt](https://github.com/jakebailey/dprint-plugin-gofumpt) - Go (gofumpt) formatter.
+- [panache](https://github.com/jolars/dprint-plugin-panache) - Quarto, Pandoc, R Markdown, and Markdown formatter.
 
 ## Notes
 

--- a/website/src/_includes/partials/doc-menu.njk
+++ b/website/src/_includes/partials/doc-menu.njk
@@ -30,6 +30,7 @@
     ["Ruff (Python)", "/plugins/ruff"],
     ["Jupyter", "/plugins/jupyter"],
     ["Gofumpt (Go)", "/plugins/gofumpt"],
+    ["Panache (Quarto/Pandoc/Markdown)", "/plugins/panache"],
     ["Exec (Many CLIs)", "/plugins/exec"],
     ["Creating a Plugin", "/plugin-dev"]
   ]

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -162,6 +162,9 @@ layout: layouts/base.njk
         >.yaml</span></span></a>
     <a class="plugin-card wrapper" href="/plugins/mago"><span class="swatch"></span><span class="meta"><span class="name">Mago</span><span class="ext"
         >PHP</span></span></a>
+    <a class="plugin-card wrapper" href="/plugins/panache"><span class="swatch"></span><span class="meta"><span class="name">Panache</span><span
+          class="ext"
+        >Quarto · Pandoc · R Markdown · Markdown</span></span></a>
   </div>
 
   <div class="plugins-label">Everything else</div>

--- a/website/src/plugins.md
+++ b/website/src/plugins.md
@@ -34,6 +34,7 @@ For the latest version and copy-paste URL of every plugin, see [plugins.dprint.d
 - [Ruff](/plugins/ruff) (Python)
 - [Jupyter](/plugins/jupyter)
 - [Gofumpt](/plugins/gofumpt) (Go)
+- [Panache](/plugins/panache) (Quarto/Pandoc/R Markdown/Markdown)
 
 ## Process Plugins
 

--- a/website/src/plugins/panache.md
+++ b/website/src/plugins/panache.md
@@ -1,0 +1,43 @@
+---
+title: Panache Plugin
+description: Documentation on the Panache code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/panache">Panache</a></li>
+  </ul>
+</nav>
+
+# Panache Plugin
+
+Adapter plugin that formats Quarto, Pandoc, R Markdown, and Markdown files via [Panache](https://panache.bz).
+
+Formats .md, .qmd, .Rmd, and related files.
+
+## Install and Setup
+
+In your project's directory with a dprint.json file, run:
+
+```shellsession
+dprint add jolars/panache
+```
+
+This will update your config file to have an entry for the plugin. Then optionally specify a `"panache"` property to add configuration:
+
+```json
+{
+  "panache": {
+    // panache config goes here
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/jolars/panache-x.x.x.wasm"
+  ]
+}
+```
+
+## Configuration
+
+See [Configuration](/plugins/panache/config).

--- a/website/src/plugins/panache/config.md
+++ b/website/src/plugins/panache/config.md
@@ -1,0 +1,19 @@
+---
+title: Configuration - Panache
+description: Documentation on the configuration file for the Panache code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/panache">Panache</a></li>
+    <li><a href="/plugins/panache/config">Configuration</a></li>
+  </ul>
+</nav>
+
+# Panache - Configuration
+
+<div class="plugin-config-table" data-url="https://plugins.dprint.dev/jolars/panache/latest/schema.json">
+  Loading...
+</div>

--- a/website/src/scripts/plugin-url-replacer.js
+++ b/website/src/scripts/plugin-url-replacer.js
@@ -18,6 +18,7 @@ const pluginPlaceholders = new Map([
   ["\"https://plugins.dprint.dev/g-plane/pretty_yaml-vx.x.x.wasm\"", "g-plane/pretty_yaml"],
   ["\"https://plugins.dprint.dev/g-plane/pretty_graphql-vx.x.x.wasm\"", "g-plane/pretty_graphql"],
   ["\"https://plugins.dprint.dev/jakebailey/gofumpt-vx.x.x.wasm\"", "jakebailey/dprint-plugin-gofumpt"],
+  ["\"https://plugins.dprint.dev/jolars/panache-x.x.x.wasm\"", "jolars/panache"],
 ]);
 
 export function replacePluginUrls() {


### PR DESCRIPTION
Document the jolars/panache Wasm plugin (Quarto, Pandoc, R Markdown, and Markdown formatter) on the website and add it to the plugin listings.