### PR TITLE
feat: add path completion hints to CLI args

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -585,7 +585,12 @@ pub fn create_cli_parser(kind: CliArgParserKind) -> clap::Command {
   fn add_command() -> Command {
     Command::new("add")
       .about("Adds a plugin to the configuration file.")
-      .arg(Arg::new("url-or-plugin-name").required(false).num_args(1..))
+      .arg(
+        Arg::new("url-or-plugin-name")
+          .required(false)
+          .num_args(1..)
+          .value_hint(clap::ValueHint::AnyPath),
+      )
       .arg(
         Arg::new("global")
           .long("global")
@@ -720,6 +725,7 @@ EXAMPLES:
             .long("stdin")
             .value_name("extension/file-name/file-path")
             .help("Format stdin and output the result to stdout. Provide an absolute file path to apply the inclusion and exclusion rules or an extension or file name to always format the text.")
+            .value_hint(clap::ValueHint::AnyPath)
             .conflicts_with("stdin-files")
             .required(false)
             .num_args(1)
@@ -841,6 +847,7 @@ EXAMPLES:
             .long("file")
             .value_name("file")
             .help("Limit the output to only the plugins that would format this file.")
+            .value_hint(clap::ValueHint::AnyPath)
             .num_args(1)
             .required(false)
         )
@@ -901,6 +908,7 @@ EXAMPLES:
         .long("config")
         .short('c')
         .help("Path or url to JSON configuration file. Defaults to dprint.json(c) or .dprint.json(c) in current or ancestor directory when not provided.")
+        .value_hint(clap::ValueHint::AnyPath)
         .global(true)
         .num_args(1)
     )
@@ -920,6 +928,7 @@ EXAMPLES:
         .long("plugins")
         .value_name("urls/files")
         .help("List of urls or file paths of plugins to use. This overrides what is specified in the config file.")
+        .value_hint(clap::ValueHint::AnyPath)
         .global(true)
         .num_args(1..)
     )
@@ -947,8 +956,8 @@ EXAMPLES:
     app = app.subcommand(
       Command::new("hidden")
         .hide(true)
-        .subcommand(Command::new("windows-install").arg(Arg::new("install-path").num_args(1).required(true)))
-        .subcommand(Command::new("windows-uninstall").arg(Arg::new("install-path").num_args(1).required(true))),
+        .subcommand(Command::new("windows-install").arg(Arg::new("install-path").num_args(1).required(true).value_hint(clap::ValueHint::AnyPath)))
+        .subcommand(Command::new("windows-uninstall").arg(Arg::new("install-path").num_args(1).required(true).value_hint(clap::ValueHint::AnyPath))),
     );
   }
 
@@ -970,6 +979,7 @@ impl ClapExtensions for clap::Command {
       .arg(
         Arg::new("files")
           .help("List of files, directories, or file patterns to format. This can be a subset of what is found in the config file.")
+          .value_hint(clap::ValueHint::AnyPath)
           .num_args(1..),
       )
       .arg(

--- a/crates/dprint/src/commands/general.rs
+++ b/crates/dprint/src/commands/general.rs
@@ -855,6 +855,18 @@ SOFTWARE.
   }
 
   #[test]
+  fn should_complete_file_paths_for_positional_args() {
+    let environment = TestEnvironment::new();
+    run_test_cli(vec!["completions", "zsh"], &environment).unwrap();
+    let logged_messages = environment.take_stdout_messages();
+    assert_eq!(logged_messages.len(), 1);
+    // the `files` positional on the `fmt` subcommand should have a file completion
+    // action so that `dprint fmt f<TAB>` completes to `dprint fmt foo.py`
+    let fmt_section = logged_messages[0].split("(fmt)").nth(1).unwrap().split("(check)").next().unwrap();
+    assert!(fmt_section.lines().any(|line| line.contains("*::files -- ") && line.contains(":_files")));
+  }
+
+  #[test]
   fn should_output_incremental_state() {
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_and_process_plugin().build();
     run_test_cli(vec!["incremental-state"], &environment).unwrap();


### PR DESCRIPTION
This PR adds `ValueHint::AnyPath` to CLI arguments that expect a path, so the shell can provide completion hints.

Fixes https://github.com/dprint/dprint/issues/1216