### PR TITLE
perf(core): keep value resolutions when a separated values group only moves down the page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.68.4"
+version = "0.68.5"
 dependencies = [
  "async-trait",
  "bumpalo",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.68.4"
+version = "0.68.5"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"

--- a/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
+++ b/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
@@ -455,7 +455,6 @@ pub fn gen_separated_values(
 fn clear_resolutions_on_position_change(value_datas: Rc<RefCell<Vec<GeneratedValueData>>>, end_line_number: LineNumber) -> PrintItems {
   let mut items = PrintItems::new();
   let column_number = ColumnNumber::new("clearer");
-  // todo: use anchors instead of taking line number into account here
   let line_number = LineNumber::new("clearer");
   items.push_condition(Condition::new(
     "clearWhenPositionChanges",
@@ -463,14 +462,31 @@ fn clear_resolutions_on_position_change(value_datas: Rc<RefCell<Vec<GeneratedVal
       condition: Rc::new(move |condition_context| {
         let column_number = condition_context.resolved_column_number(column_number)?;
         let line_number = condition_context.resolved_line_number(line_number)?;
-        // when the position changes, clear all the infos so they get re-evaluated again
-        if column_number != condition_context.writer_info.column_number || line_number != condition_context.writer_info.line_number {
+        if column_number != condition_context.writer_info.column_number {
+          // The values now begin at a different column, so they may break differently and nothing
+          // recorded about them can be trusted. Clear it all so it gets worked out again.
           for value_data in value_datas.borrow().iter() {
             condition_context.clear_info(value_data.line_number);
             condition_context.clear_info(value_data.is_start_of_line);
             condition_context.clear_info(value_data.line_start_indent_level);
           }
           condition_context.clear_info(end_line_number);
+        } else {
+          let delta = condition_context.writer_info.line_number as isize - line_number as isize;
+          if delta != 0 {
+            // The values only moved up or down the page. Beginning at the same column they break the
+            // same way, so every line number within moved by the same amount, and only the distances
+            // between them are ever compared. Shifting them keeps them usable.
+            //
+            // Clearing here instead would be correct but ruinously slow: each value would have to be
+            // worked out again, along with every value nested inside it, so a group nested n deep
+            // would be printed 2^n times. Whether the values start at the start of a line, and at
+            // what indent, does not depend on which line they are on, so those stay as they are.
+            for value_data in value_datas.borrow().iter() {
+              condition_context.shift_line_number(value_data.line_number, delta);
+            }
+            condition_context.shift_line_number(end_line_number, delta);
+          }
         }
 
         None

--- a/crates/core/src/formatting/print_items.rs
+++ b/crates/core/src/formatting/print_items.rs
@@ -1075,6 +1075,14 @@ impl<'a, 'b> ConditionResolverContext<'a, 'b> {
     self.printer.clear_info(info.into())
   }
 
+  /// Moves an already resolved line number by `delta` lines.
+  ///
+  /// Use this instead of clearing when the text the line number refers to has only moved up or down
+  /// the page, so that it stays correct relative to everything around it.
+  pub fn shift_line_number(&mut self, info: LineNumber, delta: isize) {
+    self.printer.shift_line_number(info, delta)
+  }
+
   /// Gets if the printer is currently forcing no newlines.
   pub fn is_forcing_no_newlines(&self) -> bool {
     self.printer.is_forcing_no_newlines()

--- a/crates/core/src/formatting/printer.rs
+++ b/crates/core/src/formatting/printer.rs
@@ -271,6 +271,17 @@ impl<'a> Printer<'a> {
     }
   }
 
+  /// Moves an already resolved line number by `delta` lines.
+  ///
+  /// This keeps a resolution usable when whatever it refers to has shifted up or down the page
+  /// without otherwise changing, leaving it correct relative to everything around it.
+  pub fn shift_line_number(&mut self, info: LineNumber, delta: isize) {
+    let id = info.unique_id();
+    if let Some(value) = self.resolved_line_numbers.get(id) {
+      self.resolved_line_numbers.insert(id, (value as isize + delta) as u32);
+    }
+  }
+
   pub fn resolved_condition(&mut self, condition_reference: &ConditionReference) -> Option<bool> {
     if !self.resolved_conditions.contains_key(&condition_reference.id) && !self.look_ahead_condition_save_points.contains_key(&condition_reference.id) {
       let save_point = self.get_save_point_for_restoring_condition(condition_reference.name());

--- a/crates/core/tests/nested_separated_values_test.rs
+++ b/crates/core/tests/nested_separated_values_test.rs
@@ -1,0 +1,112 @@
+use dprint_core::formatting::PrintItems;
+use dprint_core::formatting::PrintOptions;
+use dprint_core::formatting::ir_helpers;
+
+/// Builds `depth` groups of separated values inside one another, each surrounded by brackets the way
+/// a plugin writes an array, with the innermost group written over several lines.
+///
+/// Every group above the innermost one therefore has to be multi-line as well, which it only finds
+/// out after printing its values.
+fn print_nested(depth: usize) -> String {
+  dprint_core::formatting::format(
+    || {
+      let mut inner = {
+        let mut items = PrintItems::new();
+        items.push_str("innermost");
+        items
+      };
+      for i in 0..depth {
+        let value = inner;
+        let group = ir_helpers::gen_separated_values(
+          |_| {
+            vec![
+              ir_helpers::GeneratedValue {
+                items: value,
+                lines_span: None,
+                allow_inline_multi_line: false,
+                allow_inline_single_line: false,
+              },
+              ir_helpers::GeneratedValue {
+                items: {
+                  let mut items = PrintItems::new();
+                  items.push_str("second");
+                  items
+                },
+                lines_span: None,
+                allow_inline_multi_line: false,
+                allow_inline_single_line: false,
+              },
+            ]
+          },
+          ir_helpers::GenSeparatedValuesOptions {
+            prefer_hanging: false,
+            // the innermost group is the one already written over several lines
+            force_use_new_lines: i == 0,
+            allow_blank_lines: false,
+            single_line_options: ir_helpers::SingleLineOptions::separated_same_line(", ".into()),
+            indent_width: 2,
+            multi_line_options: ir_helpers::MultiLineOptions::surround_newlines_indented(),
+            force_possible_newline_at_start: false,
+          },
+        )
+        .items;
+        inner = {
+          let mut items = PrintItems::new();
+          items.push_str("[");
+          items.extend(group);
+          items.push_str("]");
+          items
+        };
+      }
+      inner
+    },
+    PrintOptions {
+      indent_width: 2,
+      max_width: 80,
+      use_tabs: false,
+      new_line_text: "\n",
+    },
+  )
+}
+
+#[test]
+fn should_print_nested_groups_over_multiple_lines() {
+  // the separator is only used when a group fits on one line, so a caller that wants trailing
+  // commas appends them to each value itself
+  assert_eq!(print_nested(1), "[\n  innermost\n  second\n]");
+  assert_eq!(
+    print_nested(3),
+    concat!(
+      "[\n",
+      "  [\n",
+      "    [\n",
+      "      innermost\n",
+      "      second\n",
+      "    ]\n",
+      "    second\n",
+      "  ]\n",
+      "  second\n",
+      "]",
+    )
+  );
+}
+
+/// Printing this is exponential in the nesting depth either way, so it is a question of how large
+/// the base is. Each group assumes it fits on one line and only finds out otherwise once its values
+/// have been printed, and finding out moves them.
+///
+/// Discarding what was already known about the values whenever they moved, rather than only when
+/// they moved to a different column, doubled that base, because every group then printed its values
+/// twice. Depth 24 took over 15 seconds in a release build and now takes under one.
+///
+/// Not run by default because it measures elapsed time, which depends on the machine and on whether
+/// optimisations are on. Run it with `cargo test --release -- --ignored`.
+#[test]
+#[ignore = "measures elapsed time; run explicitly and in release"]
+fn should_not_print_values_twice_per_level() {
+  let start = std::time::Instant::now();
+  let text = print_nested(24);
+  let elapsed = start.elapsed();
+  assert!(text.contains("innermost"));
+  assert!(elapsed.as_secs() < 5, "took {elapsed:?}, so the base of the growth has gone up again");
+}

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -23,7 +23,7 @@ crossterm = "=0.27.0" # manually retest everything when bumping this crate
 deno_npmrc = "=0.9.0"
 deno_terminal = "=0.2.3"
 dirs = "=6.0.0"
-dprint-core = { path = "../core", version = "=0.68.4", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "=0.68.5", features = ["process", "wasm"] }
 dunce = "=1.0.4"
 flate2 = "=1.1.9"
 fs3 = "=0.5.0"


### PR DESCRIPTION
## The problem

A separated values group assumes it fits on one line, prints its values, and only then discovers it doesn't. Discovering that moves the values, and `clear_resolutions_on_position_change` discarded everything already known about them so it would all be worked out again.

It discarded them whenever the group's position changed **at all** — including when the group had only moved up or down the page.

So each group printed its values twice: once before finding out it was multi-line, once after. A group nested inside another repeated that, and one nested `n` deep printed `2^n` times. A few dozen characters was enough to make formatting take minutes:

```toml
z = [[[[[[[[[[[[[[[[[[[[[[
1]]]]]]]]]]]]]]]]]]]]]]
```

## The fix

The line numbers recorded for the values are only ever asked how far apart they are — `last_ln < value_start_ln`, and `last_ln < end_ln`. Nothing reads them as absolute positions.

So when the group has only moved up or down the page, beginning at the same column, the values break exactly as before and every line number within moved by the same amount. Shifting them keeps them usable rather than throwing them away, which is what `LineNumberAnchor` already does for a single line number in `surround_with_newlines_indented_if_multi_line`.

Whether a value starts at the beginning of a line, and at what indent, doesn't depend on which line it is on, so those resolutions stay as they are.

Clearing still happens when the **column** changes, where the values may break differently and nothing recorded about them can be relied on.

## Results

| | before | after |
| --- | ---: | ---: |
| nesting 24 deep (the new test, release build) | 15.04 s | **0.63 s** |
| `z = [` × 22, TOML plugin | 1526 ms | **126 ms** |
| `z = [` × 24, TOML plugin | 8.5 s | **396 ms** |

Formatting is unaffected for ordinary input: a 287 KB `Cargo.lock` takes 3.28 ms against 3.33 ms before.

## Output is unchanged

- All existing `dprint-core` tests pass.
- The TOML plugin's spec suite passes, and its output is **byte-identical across 4,478 real `.toml` files** from `~/.cargo/registry` and local checkouts.

## A note on what this doesn't fix

Deep nesting is still exponential, with a smaller base — around 3.9 s at depth 28. The remaining cost is the legitimate half: when a group becomes multi-line its values move to a different **column**, where they really may break differently, so discarding what was known about them is correct.

Getting rid of that needs the first guess to be right rather than corrected afterwards. The information exists at the point the IR is built — a group with `force_use_new_lines` is known to be multi-line, and `allow_inline_multi_line: false` already says "if this value is multi-line then the group must be" — but `gen_separated_values` only receives values as opaque `PrintItems` and can currently learn it by printing them. A field on `GeneratedValue` letting the caller declare a value as known-multi-line would let the whole chain resolve without guessing. That changes the API for every plugin building separated values, so it isn't attempted here.