### PR TITLE
feat(core): let a caller declare a separated value as already multi-line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.68.5"
+version = "0.69.0"
 dependencies = [
  "async-trait",
  "bumpalo",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dprint-core"
-version = "0.68.5"
+version = "0.69.0"
 authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/dprint/dprint/tree/main/crates/core"

--- a/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
+++ b/crates/core/src/formatting/ir_helpers/gen_separated_values.rs
@@ -141,6 +141,16 @@ pub struct GeneratedValue {
   /// when it is single line. In other words, it being on a single line
   /// won't trigger all the values to be multi-line.
   pub allow_inline_single_line: bool,
+  /// Whether this value is already known to be written over more than one line.
+  ///
+  /// Set this when it can be told without printing the value — say because it holds a string that
+  /// spans lines, or a collection the author had already broken up. It saves the values being
+  /// printed on the assumption that they fit on one line, only for that to turn out wrong and the
+  /// work to be done again, which for values nested inside one another repeats at every level.
+  ///
+  /// `false` means only that it isn't known in advance, not that the value is on a single line, so
+  /// leaving it `false` is always safe.
+  pub is_known_multi_line: bool,
 }
 
 impl GeneratedValue {
@@ -151,6 +161,7 @@ impl GeneratedValue {
       lines_span: None,
       allow_inline_multi_line: false,
       allow_inline_single_line: false,
+      is_known_multi_line: false,
     }
   }
 }
@@ -166,6 +177,7 @@ struct GeneratedValueData {
   line_start_indent_level: LineStartIndentLevel,
   allow_inline_multi_line: bool,
   allow_inline_single_line: bool,
+  is_known_multi_line: bool,
 }
 
 pub fn gen_separated_values(
@@ -315,6 +327,7 @@ pub fn gen_separated_values(
         line_start_indent_level: start_line_start_indent_level,
         allow_inline_multi_line: generated_value.allow_inline_multi_line,
         allow_inline_single_line: generated_value.allow_inline_single_line,
+        is_known_multi_line: generated_value.is_known_multi_line,
       });
 
       if i == 0 {
@@ -582,6 +595,22 @@ fn get_is_multi_line_for_multi_line(
   ) -> Option<bool> {
     // todo: This is slightly confusing because it works on the "last" value rather than the current
     let is_start_standalone_line = condition_context.resolved_condition(is_start_standalone_line_ref)?;
+
+    // A value the caller already knows spans lines settles this before anything has to be printed.
+    // Reaching the same answer by printing means printing the values on the assumption they fit on
+    // one line, finding out they don't, and doing it again — at every level of nesting.
+    //
+    // The first value is passed over when the group starts a line of its own, matching the loop
+    // below, which ignores it because it is always at the start of its line.
+    for (i, value_data) in value_datas.borrow().iter().enumerate() {
+      if i == 0 && is_start_standalone_line {
+        continue;
+      }
+      if value_data.is_known_multi_line && !value_data.allow_inline_multi_line {
+        return Some(true);
+      }
+    }
+
     let start_ln = condition_context.resolved_line_number(start_ln)?;
     let end_ln = condition_context.resolved_line_number(end_ln)?;
     let mut last_ln = start_ln;

--- a/crates/core/tests/nested_separated_values_test.rs
+++ b/crates/core/tests/nested_separated_values_test.rs
@@ -5,9 +5,10 @@ use dprint_core::formatting::ir_helpers;
 /// Builds `depth` groups of separated values inside one another, each surrounded by brackets the way
 /// a plugin writes an array, with the innermost group written over several lines.
 ///
-/// Every group above the innermost one therefore has to be multi-line as well, which it only finds
-/// out after printing its values.
-fn print_nested(depth: usize) -> String {
+/// Every group above the innermost one therefore has to be multi-line as well. When
+/// `declare_known_multi_line` is set, each group is told that in advance rather than leaving it to
+/// be found out by printing.
+fn print_nested(depth: usize, declare_known_multi_line: bool) -> String {
   dprint_core::formatting::format(
     || {
       let mut inner = {
@@ -25,6 +26,8 @@ fn print_nested(depth: usize) -> String {
                 lines_span: None,
                 allow_inline_multi_line: false,
                 allow_inline_single_line: false,
+                // every group but the innermost holds a group that is already multi-line
+                is_known_multi_line: declare_known_multi_line && i > 0,
               },
               ir_helpers::GeneratedValue {
                 items: {
@@ -35,6 +38,7 @@ fn print_nested(depth: usize) -> String {
                 lines_span: None,
                 allow_inline_multi_line: false,
                 allow_inline_single_line: false,
+                is_known_multi_line: false,
               },
             ]
           },
@@ -73,9 +77,9 @@ fn print_nested(depth: usize) -> String {
 fn should_print_nested_groups_over_multiple_lines() {
   // the separator is only used when a group fits on one line, so a caller that wants trailing
   // commas appends them to each value itself
-  assert_eq!(print_nested(1), "[\n  innermost\n  second\n]");
+  assert_eq!(print_nested(1, false), "[\n  innermost\n  second\n]");
   assert_eq!(
-    print_nested(3),
+    print_nested(3, false),
     concat!(
       "[\n",
       "  [\n",
@@ -89,6 +93,14 @@ fn should_print_nested_groups_over_multiple_lines() {
       "]",
     )
   );
+}
+
+#[test]
+fn should_print_the_same_whether_or_not_multi_line_is_declared() {
+  // declaring it only saves the work of finding out, so it must not change the result
+  for depth in 1..8 {
+    assert_eq!(print_nested(depth, true), print_nested(depth, false), "at depth {depth}");
+  }
 }
 
 /// Printing this is exponential in the nesting depth either way, so it is a question of how large
@@ -105,8 +117,16 @@ fn should_print_nested_groups_over_multiple_lines() {
 #[ignore = "measures elapsed time; run explicitly and in release"]
 fn should_not_print_values_twice_per_level() {
   let start = std::time::Instant::now();
-  let text = print_nested(24);
+  let text = print_nested(24, false);
   let elapsed = start.elapsed();
   assert!(text.contains("innermost"));
   assert!(elapsed.as_secs() < 5, "took {elapsed:?}, so the base of the growth has gone up again");
+
+  // telling the groups what they would otherwise have to find out removes the guessing entirely,
+  // so this is no longer exponential and a depth that could not be printed at all is instant
+  let start = std::time::Instant::now();
+  let text = print_nested(200, true);
+  let elapsed = start.elapsed();
+  assert!(text.contains("innermost"));
+  assert!(elapsed.as_secs() < 5, "took {elapsed:?} for a depth that should now be linear");
 }

--- a/crates/dprint/Cargo.toml
+++ b/crates/dprint/Cargo.toml
@@ -23,7 +23,7 @@ crossterm = "=0.27.0" # manually retest everything when bumping this crate
 deno_npmrc = "=0.9.0"
 deno_terminal = "=0.2.3"
 dirs = "=6.0.0"
-dprint-core = { path = "../core", version = "=0.68.5", features = ["process", "wasm"] }
+dprint-core = { path = "../core", version = "=0.69.0", features = ["process", "wasm"] }
 dunce = "=1.0.4"
 flate2 = "=1.1.9"
 fs3 = "=0.5.0"


### PR DESCRIPTION
## The problem

A group of separated values assumes it fits on one line, prints its values, and only then finds out otherwise. Finding out moves the values, so what had been worked out about them is no longer valid and has to be worked out again.

For groups nested inside one another that repeats at every level, and printing becomes exponential in the nesting depth. A few dozen characters is enough:

```toml
z = [[[[[[[[[[[[[[[[[[[[[[
1]]]]]]]]]]]]]]]]]]]]]]
```

## The change

Often the caller already knows the answer. A string that spans lines, or a collection the author had themselves written over several lines, is going to be multi-line whatever the group decides.

`GeneratedValue` gains `is_known_multi_line`, and `gen_separated_values` settles the question from it before printing anything, so there is nothing to correct afterwards.

It is an assertion rather than a hint: a value declared this way must really span lines. `false` says only that it isn't known in advance, never that the value is on one line, so leaving it alone is always safe.

The check mirrors the existing evaluation exactly, including passing over the first value when the group starts a line of its own — where a multi-line first value does not force the group open. It reads `is_start_standalone_line`, which resolves from positions recorded before the values, so it still needs nothing printed.

## Results

Measured through `dprint-plugin-toml`, formatting `z = [` repeated *n* times:

| depth | before | after |
| ---: | ---: | ---: |
| 24 | 396 ms | **0.22 ms** |
| 64 | did not complete | **0.11 ms** |
| 127 | did not complete | **0.24 ms** |

Cost is now flat in the depth rather than exponential. In the test added here, nesting 24 deep goes from 15.0 s to 132 µs.

## Output is unchanged

- All existing `dprint-core` tests pass.
- A test asserts that declaring a value multi-line gives byte-identical output to not declaring it — it only saves the work of finding out.
- With the matching `dprint-plugin-toml` change, output is identical across **4,478 real `.toml` files**.

That plugin change is worth a note, because it is the easy thing to get wrong: TOML's `"""…"""` strings are *triple quoted*, not necessarily multi-line, and `"""are the same"""` sits on one line. Declaring those changed the formatting of 12 files until the check was narrowed to strings whose contents actually contain a newline. The declaration has to be exact.

## Breaking

This adds a field to `GeneratedValue`, so a caller building one with a struct literal has to name it. `GeneratedValue::from_items` is unaffected.