### PR TITLE
docs: keep linked headings from hiding under the sticky nav

### DIFF
--- a/website/src/scripts.js
+++ b/website/src/scripts.js
@@ -1,5 +1,7 @@
+import { restoreAnchorScroll } from "./scripts/anchor-scroll.js";
 import { setupDocMenu } from "./scripts/doc-menu-toggle.js";
 import { addInstallTabsEvent } from "./scripts/install-tabs.js";
+import { setupNavHeight } from "./scripts/nav-height.js";
 import { replaceConfigTable } from "./scripts/plugin-config-table-replacer.js";
 import { replacePluginUrls } from "./scripts/plugin-url-replacer.js";
 
@@ -10,6 +12,8 @@ if (document.readyState === "complete" || document.readyState === "interactive")
 }
 
 function onLoad() {
+  setupNavHeight();
+  restoreAnchorScroll();
   replacePluginUrls();
   replaceConfigTable();
   addInstallTabsEvent();

--- a/website/src/scripts/anchor-scroll.js
+++ b/website/src/scripts/anchor-scroll.js
@@ -1,0 +1,28 @@
+/**
+ * Re-runs the browser's jump to `location.hash` once the page has settled.
+ *
+ * The browser scrolls to the anchor before the web font finishes loading, so
+ * swapping the font in reflows the content out from under the target and leaves
+ * the heading scrolled off the top of the viewport.
+ */
+export function restoreAnchorScroll() {
+  const target = getHashTarget();
+  if (target == null || document.fonts == null) {
+    return;
+  }
+
+  const scrollYBefore = window.scrollY;
+  document.fonts.ready.then(() => {
+    // don't yank the page around if the reader already scrolled somewhere else
+    if (window.scrollY === scrollYBefore && getHashTarget() === target) {
+      target.scrollIntoView();
+    }
+  });
+}
+
+function getHashTarget() {
+  if (location.hash.length <= 1) {
+    return null;
+  }
+  return document.getElementById(decodeURIComponent(location.hash.slice(1)));
+}

--- a/website/src/scripts/nav-height.js
+++ b/website/src/scripts/nav-height.js
@@ -1,0 +1,27 @@
+/**
+ * Keeps the `--nav-h` custom property in sync with the sticky nav's real height.
+ *
+ * The stylesheet uses it for `scroll-padding-top` so that linking to a heading
+ * (ex. /cli/#formatting-a-list-of-files-from-standard-input) doesn't leave the
+ * heading hidden underneath the nav. A static value can't work because the nav
+ * wraps to two or three rows on narrow screens.
+ */
+export function setupNavHeight() {
+  const nav = document.querySelector(".site-nav");
+  if (nav == null) {
+    return;
+  }
+
+  update();
+
+  if (typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(update).observe(nav);
+  } else {
+    window.addEventListener("resize", update);
+  }
+
+  function update() {
+    const height = Math.round(nav.getBoundingClientRect().height);
+    document.documentElement.style.setProperty("--nav-h", `${height}px`);
+  }
+}

--- a/website/src/style.scss
+++ b/website/src/style.scss
@@ -9,6 +9,8 @@
   --accent: #8b93a1;
   --glow: 0.22;
   --max: 1200px;
+  /* height of the sticky nav; kept exact by scripts/nav-height.js */
+  --nav-h: 74px;
 }
 
 * {
@@ -23,6 +25,8 @@ body {
 
 html {
   min-height: 100%;
+  /* keep anchor targets (e.g. /cli/#some-heading) out from under the sticky nav */
+  scroll-padding-top: calc(var(--nav-h) + 24px);
 }
 
 body {
@@ -163,6 +167,9 @@ a {
 }
 
 @media (max-width: 768px) {
+  :root {
+    --nav-h: 145px;
+  }
   .nav-inner {
     flex-wrap: wrap;
     gap: 14px;
@@ -690,10 +697,10 @@ a {
 }
 .doc-sidebar {
   position: sticky;
-  top: 73px;
+  top: var(--nav-h);
   align-self: start;
   padding: 36px 0 60px;
-  max-height: calc(100vh - 73px);
+  max-height: calc(100vh - var(--nav-h));
   overflow-y: auto;
   scrollbar-width: none; /* firefox */
   -ms-overflow-style: none; /* legacy edge */


### PR DESCRIPTION
Linking to a heading — ex. https://dprint.dev/cli/#formatting-a-list-of-files-from-standard-input — scrolled past the heading, so the page landed on the section body with the title nowhere in sight.

Two separate things were causing it:

1. **The sticky nav has no scroll offset.** `.site-nav` is `position: sticky; top: 0` and 74px tall, so the browser scrolls the heading to y=0 and the nav paints right over it.
2. **The web font reflows the page after the jump.** IBM Plex Mono loads from Google Fonts with `display=swap`. The browser jumps to the anchor using the fallback font, then the real font swaps in and the text above the target rewraps — on `/cli/` that shifted the heading a further 35px off. This is why the anchor was wrong even in the region the nav didn't cover.

## Changes

`style.scss` gets a `--nav-h` custom property driving `scroll-padding-top`, which the browser applies to hash navigation, in-page permalink clicks, and `scrollIntoView` alike:

```scss
:root { --nav-h: 74px; }
html { scroll-padding-top: calc(var(--nav-h) + 24px); }
```

`scripts/nav-height.js` keeps `--nav-h` exact with a `ResizeObserver`. A static value can't work because the nav wraps to two or three rows on narrow screens (74px → ~145px). The stylesheet carries a `145px` fallback under `@media (max-width: 768px)` so a no-JS load over-offsets rather than hiding the heading.

`scripts/anchor-scroll.js` redoes the hash jump after `document.fonts.ready`, skipping it if the reader already scrolled elsewhere in the meantime.

`--nav-h` also replaces the hardcoded `73px` the doc sidebar used for its sticky `top`/`max-height`, which was a pixel off the nav's real height.

## Verification

Checked in Chrome against `deno task serve`:

| case | heading top (nav bottom is 74px) |
| --- | --- |
| `/cli/#formatting-a-list-of-files-from-standard-input` (h3) | 98px |
| `/cli/#checking-what-files-aren't-formatted` (h2) | 98px |
| clicking an in-page heading permalink | 98px |
| nav forced to 186px tall | 210px (`--nav-h` tracked to 186px) |

Before the fix the h3 landed at ~25px, fully hidden. With `scroll-padding-top` alone but the font handling still running at `DOMContentLoaded`, it landed at 63px — still half hidden, which is what isolated the font swap as the second cause.
