### PR TITLE
fix: format zero files when `--stdin-files` is empty

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -270,7 +270,12 @@ pub enum HiddenSubCommand {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FilePatternArgs {
-  pub include_patterns: Vec<String>,
+  /// File patterns specified on the command line or via `--stdin-files`.
+  ///
+  /// `None` means none were specified, which is different from specifying
+  /// an empty list (ex. `--stdin-files` with no lines) as that means there
+  /// are no files to format.
+  pub include_patterns: Option<Vec<String>>,
   pub include_pattern_overrides: Option<Vec<String>>,
   pub exclude_patterns: Vec<String>,
   pub exclude_pattern_overrides: Option<Vec<String>>,
@@ -485,13 +490,14 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
 
 fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_reader: &TStdInReader) -> Result<FilePatternArgs> {
   let plugins = maybe_values_to_vec(matches.get_many("plugins"));
-  let mut file_patterns = maybe_values_to_vec(matches.get_many("files"));
+  // these two are mutually exclusive, so only one of them provides the patterns
+  let file_patterns = if matches.get_flag("stdin-files") {
+    Some(std_in_reader.read_non_empty_lines()?)
+  } else {
+    matches.get_many("files").map(values_to_vec)
+  };
 
-  if matches.get_flag("stdin-files") {
-    file_patterns.extend(std_in_reader.read_non_empty_lines()?);
-  }
-
-  if !plugins.is_empty() && file_patterns.is_empty() {
+  if !plugins.is_empty() && file_patterns.as_ref().is_none_or(|p| p.is_empty()) {
     validate_plugin_args_when_no_files(&plugins)?;
   }
 
@@ -1193,7 +1199,27 @@ mod test {
     match args.sub_command {
       SubCommand::Fmt(cmd) => {
         // blank lines are skipped and paths with spaces are preserved
-        assert_eq!(cmd.patterns.include_patterns, vec!["/file1.txt".to_string(), "/sub dir/file 2.txt".to_string()]);
+        assert_eq!(
+          cmd.patterns.include_patterns,
+          Some(vec!["/file1.txt".to_string(), "/sub dir/file 2.txt".to_string()])
+        );
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  #[test]
+  fn stdin_files_arg_empty() {
+    let stdin_reader = TestStdInReader::from(
+      "
+
+",
+    );
+    let args = parse_args(vec!["".to_string(), "fmt".to_string(), "--stdin-files".to_string()], stdin_reader).unwrap();
+    match args.sub_command {
+      SubCommand::Fmt(cmd) => {
+        // an empty list of files is not the same as not specifying any files
+        assert_eq!(cmd.patterns.include_patterns, Some(Vec::new()));
       }
       _ => unreachable!(),
     }

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -772,7 +772,7 @@ pub async fn update_plugins_config_file<TEnvironment: Environment>(
   }
 
   let file_pattern_args = FilePatternArgs {
-    include_patterns: Vec::new(),
+    include_patterns: None,
     include_pattern_overrides: None,
     exclude_patterns: Vec::new(),
     exclude_pattern_overrides: None,

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -421,6 +421,32 @@ mod test {
   }
 
   #[test]
+  fn should_format_no_files_when_stdin_files_is_empty() {
+    let file_path1 = "/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(&file_path1, "text")
+      .build();
+    let test_std_in = TestStdInReader::from(
+      "
+",
+    );
+    run_test_cli_with_stdin(vec!["fmt", "--stdin-files"], &environment, test_std_in).unwrap();
+    assert_eq!(environment.take_stdout_messages(), Vec::<String>::new());
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text");
+  }
+
+  #[test]
+  fn should_check_no_files_when_stdin_files_is_empty() {
+    let file_path1 = "/file.txt";
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file(&file_path1, "text")
+      .build();
+    let test_std_in = TestStdInReader::from("");
+    run_test_cli_with_stdin(vec!["check", "--stdin-files"], &environment, test_std_in).unwrap();
+    assert_eq!(environment.read_file(&file_path1).unwrap(), "text");
+  }
+
+  #[test]
   fn should_check_files_from_stdin_files() {
     let file_path1 = "/file.txt";
     let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()

--- a/crates/dprint/src/configuration/resolve_config.rs
+++ b/crates/dprint/src/configuration/resolve_config.rs
@@ -102,7 +102,7 @@ pub async fn resolve_config_from_args(args: &CliArgs, environment: &impl Environ
       if resolved_config_path.is_global_config
         && let SubCommand::Fmt(fmt) = &args.sub_command
         && !fmt.allow_no_files
-        && fmt.patterns.include_patterns.is_empty()
+        && fmt.patterns.include_patterns.is_none()
         && fmt.patterns.include_pattern_overrides.is_none()
         && !(args.config_discovery_arg_set() && matches!(args.config_discovery(environment), ConfigDiscovery::Global))
       {

--- a/crates/dprint/src/patterns.rs
+++ b/crates/dprint/src/patterns.rs
@@ -155,12 +155,11 @@ pub fn get_patterns_as_glob_matcher(patterns: &[String], config_base_path: &Cano
 pub fn get_all_file_patterns(config: &ResolvedConfig, args: &FilePatternArgs, cwd: &CanonicalizedPathBuf, environment: &impl Environment) -> GlobPatterns {
   GlobPatterns {
     config_includes: get_config_includes_file_patterns(config, args, cwd, environment),
-    arg_includes: if args.include_patterns.is_empty() {
-      None
-    } else {
-      // resolve CLI patterns based on the current working directory
-      Some(args.include_patterns.iter().map(|p| process_cli_pattern(p, cwd, environment)).collect())
-    },
+    // resolve CLI patterns based on the current working directory
+    arg_includes: args
+      .include_patterns
+      .as_ref()
+      .map(|patterns| patterns.iter().map(|p| process_cli_pattern(p, cwd, environment)).collect()),
     config_excludes: get_config_exclude_file_patterns(config, args, cwd, environment),
     arg_excludes: if args.exclude_patterns.is_empty() {
       None

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -517,23 +517,29 @@ impl<TEnvironment: Environment> PluginsScopeAndPathsCollection<TEnvironment> {
 
     // ensure we found some files
     if !cli_args.sub_command.allow_no_files() {
-      let has_cli_file_patterns = cli_args.sub_command.file_patterns().map(|p| !p.include_patterns.is_empty()).unwrap_or(false);
-      // when the user specifies a pattern on the command line, just ensure that one scope matched
-      if has_cli_file_patterns {
-        let all_empty = self.iter().all(|s| s.file_paths_by_plugins.is_empty());
-        if all_empty {
-          return Err(
-            NoFilesFoundError {
-              base_path: self.environment.cwd(),
-            }
-            .into(),
-          );
+      let cli_file_patterns = cli_args.sub_command.file_patterns().and_then(|p| p.include_patterns.as_ref());
+      match cli_file_patterns {
+        // the user explicitly specified no files to format (ex. `--stdin-files`
+        // with no lines), so there's nothing to format and that's ok
+        Some(patterns) if patterns.is_empty() => {}
+        // when the user specifies a pattern on the command line, just ensure that one scope matched
+        Some(_) => {
+          let all_empty = self.iter().all(|s| s.file_paths_by_plugins.is_empty());
+          if all_empty {
+            return Err(
+              NoFilesFoundError {
+                base_path: self.environment.cwd(),
+              }
+              .into(),
+            );
+          }
         }
-      } else {
         // if no args specified then ensure all scopes have files
-        for scope in &self.inner {
-          if let Some(config) = scope.scope.config.as_ref() {
-            scope.file_paths_by_plugins.ensure_not_empty(&config.base_path)?;
+        None => {
+          for scope in &self.inner {
+            if let Some(config) = scope.scope.config.as_ref() {
+              scope.file_paths_by_plugins.ensure_not_empty(&config.base_path)?;
+            }
           }
         }
       }
@@ -737,13 +743,13 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
     // command line keep applying in the new scope, but only resolve the
     // grouped paths so files matched by the other args don't get formatted
     // a second time
-    include_patterns.extend(self.patterns.include_patterns.iter().filter(|p| is_negated_glob(p)).cloned());
+    include_patterns.extend(self.patterns.include_patterns.iter().flatten().filter(|p| is_negated_glob(p)).cloned());
     // the current scope already handles everything in the config's
     // directory (ex. a `dprint fmt ..` arg covers it with `**`), escaping
     // in case the directory path contains glob characters (ex. `[app]`)
     include_patterns.push(format!("!{}/**", escape_glob_text_for_cli(&config.base_path.to_string_lossy())));
     let patterns = Rc::new(FilePatternArgs {
-      include_patterns,
+      include_patterns: Some(include_patterns),
       only_staged: false,
       only_dirty: false,
       ..self.patterns.clone()

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -107,7 +107,7 @@ generate_files | dprint fmt --stdin-files
 
 Unlike piping through `xargs`, this handles file paths containing spaces since the only delimiter is the newline (blank lines are ignored). It also avoids the command line length limits that apply when passing many paths as arguments.
 
-The paths are resolved against the inclusion/exclusion rules of your dprint configuration file, the same way file patterns passed on the command line are. This flag is also available for the `check`, `file-paths`, and `format-times` subcommands.
+The paths are resolved against the inclusion/exclusion rules of your dprint configuration file, the same way file patterns passed on the command line are. When stdin provides no file paths, nothing is formatted (rather than falling back to the configuration file's includes). This flag is also available for the `check`, `file-paths`, and `format-times` subcommands.
 
 ## Checking What Files Aren't Formatted
 


### PR DESCRIPTION
Previously, `--stdin-files` with no file paths on stdin fell back to the configuration file's includes and formatted everything. Now an empty list means there are no files to format.

`FilePatternArgs::include_patterns` is now `Option<Vec<String>>` so "no file patterns specified" (`None`) is distinguishable from "an explicitly empty list" (`Some(vec![])`). `--stdin-files` always produces `Some(..)`, so empty stdin flows through as `arg_includes: Some(vec![])`, which globbing already short circuits to zero files (same as `--staged`/`--dirty` when nothing matches).

Related changes so the empty case behaves sensibly end to end:

- The "no files found" check treats an explicitly empty pattern list as a valid no-op instead of erroring.
- The "Did not format directory without configuration file" prompt only triggers when no patterns were specified at all, so an empty `--stdin-files` run doesn't require a config file.