### PR TITLE
docs: add install-dprint GitHub Action

### DIFF
--- a/website/src/ci.md
+++ b/website/src/ci.md
@@ -8,9 +8,13 @@ layout: layouts/documentation.njk
 
 You may desire to run `dprint check` as a step on your CI to ensure the code is formatted.
 
-## GitHub Action
+## GitHub Actions
 
 See `dprint/check`: https://github.com/marketplace/actions/dprint-check-action
+
+A third-party action is also available:
+
+- `kjanat/install-dprint` caches the dprint binary and compiled WASM plugins: https://github.com/kjanat/install-dprint
 
 ## GitLab
 


### PR DESCRIPTION
Documents [`kjanat/install-dprint`](https://github.com/kjanat/install-dprint) as a third-party GitHub Action that caches the dprint binary and compiled WASM plugins.

Addresses kjanat/install-dprint#1.