### PR TITLE
feat: add `dprint check --json` flag

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -79,7 +79,12 @@ impl CliArgs {
     // these output json or other text that's read by stdout
     matches!(
       self.sub_command,
-      SubCommand::StdInFmt(..) | SubCommand::EditorInfo | SubCommand::OutputResolvedConfig(..) | SubCommand::IncrementalState | SubCommand::Completions(..)
+      SubCommand::StdInFmt(..)
+        | SubCommand::EditorInfo
+        | SubCommand::OutputResolvedConfig(..)
+        | SubCommand::IncrementalState
+        | SubCommand::Completions(..)
+        | SubCommand::Check(CheckSubCommand { json: true, .. })
     )
   }
 
@@ -183,6 +188,7 @@ pub struct CheckSubCommand {
   pub patterns: FilePatternArgs,
   pub incremental: Option<bool>,
   pub list_different: bool,
+  pub json: bool,
   pub allow_no_files: bool,
   pub only_staged: bool,
   pub only_dirty: bool,
@@ -403,6 +409,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         only_staged: matches.get_flag("staged"),
         only_dirty: matches.get_flag("dirty"),
         list_different: matches.get_flag("list-different"),
+        json: matches.get_flag("json"),
         allow_no_files: matches.get_flag("allow-no-files"),
         fail_fast,
       })
@@ -774,6 +781,13 @@ EXAMPLES:
             .long("list-different")
             .help("Only outputs file paths that aren't formatted and doesn't output diffs.")
             .num_args(0)
+        )
+        .arg(
+          Arg::new("json")
+            .long("json")
+            .help("Outputs a JSON object per line for each file that isn't formatted.")
+            .num_args(0)
+            .conflicts_with("list-different")
         )
         .arg(
           Arg::new("fail-fast")
@@ -1383,6 +1397,17 @@ mod test {
     assert_eq!(check_cmd.fail_fast, false);
     let check_cmd = parse_check_sub_command(vec!["check", "--fail-fast"]).unwrap();
     assert_eq!(check_cmd.fail_fast, true);
+  }
+
+  #[test]
+  fn check_json_arg() {
+    let check_cmd = parse_check_sub_command(vec!["check"]).unwrap();
+    assert!(!check_cmd.json);
+    let check_cmd = parse_check_sub_command(vec!["check", "--json"]).unwrap();
+    assert!(check_cmd.json);
+    assert!(test_args(vec!["check", "--json"]).unwrap().is_stdout_machine_readable());
+    assert!(!test_args(vec!["check"]).unwrap().is_stdout_machine_readable());
+    assert!(test_args(vec!["check", "--json", "--list-different"]).is_err());
   }
 
   #[test]

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -394,13 +394,15 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
       }
     }
     ("check", matches) => {
-      // when log level is silent, default fail_fast to true unless explicitly provided by user
+      let json = matches.get_flag("json");
+      // when log level is silent, default fail_fast to true unless explicitly provided by
+      // user or outputting json (which is still output when silent and should be complete)
       let fail_fast = if let Some(value) = matches.get_one::<String>("fail-fast") {
         value != "false"
       } else if matches.contains_id("fail-fast") {
         true
       } else {
-        log_level == LogLevel::Silent
+        log_level == LogLevel::Silent && !json
       };
 
       SubCommand::Check(CheckSubCommand {
@@ -409,7 +411,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         only_staged: matches.get_flag("staged"),
         only_dirty: matches.get_flag("dirty"),
         list_different: matches.get_flag("list-different"),
-        json: matches.get_flag("json"),
+        json,
         allow_no_files: matches.get_flag("allow-no-files"),
         fail_fast,
       })
@@ -1408,6 +1410,16 @@ mod test {
     assert!(test_args(vec!["check", "--json"]).unwrap().is_stdout_machine_readable());
     assert!(!test_args(vec!["check"]).unwrap().is_stdout_machine_readable());
     assert!(test_args(vec!["check", "--json", "--list-different"]).is_err());
+    let check_cmd = parse_check_sub_command(vec!["check", "--json", "--fail-fast"]).unwrap();
+    assert!(check_cmd.fail_fast);
+  }
+
+  #[test]
+  fn check_json_does_not_default_fail_fast_with_silent_log_level() {
+    let check_cmd = parse_check_sub_command(vec!["check", "--json", "--log-level=silent"]).unwrap();
+    assert!(!check_cmd.fail_fast);
+    let check_cmd = parse_check_sub_command(vec!["check", "--json", "--log-level=silent", "--fail-fast"]).unwrap();
+    assert!(check_cmd.fail_fast);
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -5,6 +5,7 @@ use dprint_core::plugins::HostFormatRequest;
 use dprint_core::plugins::NullCancellationToken;
 use parking_lot::Mutex;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -260,7 +261,7 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
 fn output_json_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], environment: &impl Environment) {
   #[derive(Serialize)]
   struct UnformattedFile<'a> {
-    file: &'a Path,
+    file: Cow<'a, str>,
     /// Unified diff of the file's text to its formatted text. `None` when
     /// either isn't valid utf-8.
     diff: Option<String>,
@@ -270,7 +271,12 @@ fn output_json_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: 
     (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text)),
     _ => None,
   };
-  let mut line = serde_json::to_vec(&UnformattedFile { file: file_path, diff }).unwrap();
+  // infallible because the struct only contains strings
+  let mut line = serde_json::to_vec(&UnformattedFile {
+    file: file_path.to_string_lossy(),
+    diff,
+  })
+  .unwrap();
   line.push(b'\n');
   environment.log_machine_readable(&line);
 }
@@ -498,6 +504,31 @@ mod test {
         "\n"
       )]
     );
+    assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+  }
+
+  #[test]
+  fn should_check_files_with_json_output_when_all_formatted() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/file1.txt", "text_formatted")
+      .build();
+    run_test_cli(vec!["check", "--json"], &environment).unwrap();
+    assert_eq!(environment.take_stdout_messages(), Vec::<String>::new());
+    assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+  }
+
+  #[test]
+  fn should_check_files_with_json_output_and_fail_fast() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/file1.txt", "text")
+      .write_file("/file2.txt", "text")
+      .build();
+    environment.set_max_threads(1);
+    let error_message = run_test_cli(vec!["check", "--json", "--fail-fast"], &environment).err().unwrap();
+    error_message.assert_exit_code(20);
+    let messages = environment.take_stdout_messages();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].starts_with(r#"{"file":"/file"#));
     assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
   }
 

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -4,6 +4,7 @@ use dprint_core::communication::AtomicFlag;
 use dprint_core::plugins::HostFormatRequest;
 use dprint_core::plugins::NullCancellationToken;
 use parking_lot::Mutex;
+use serde::Serialize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -30,6 +31,7 @@ use crate::resolution::resolve_plugins_scope;
 use crate::resolution::resolve_plugins_scope_and_paths;
 use crate::utils::AtomicCounter;
 use crate::utils::get_difference;
+use crate::utils::get_unified_difference;
 
 pub async fn stdin_fmt<TEnvironment: Environment>(
   cmd: &StdInFmtSubCommand,
@@ -158,6 +160,7 @@ pub async fn check<TEnvironment: Environment>(
   scopes.ensure_valid_for_cli_args(args)?;
   let not_formatted_files_count = Arc::new(AtomicCounter::default());
   let list_different = cmd.list_different;
+  let output_json = cmd.json;
   let fail_fast_flag = cmd.fail_fast.then(|| Arc::new(AtomicFlag::default()));
 
   for scope_and_paths in scopes.into_iter() {
@@ -174,7 +177,9 @@ pub async fn check<TEnvironment: Environment>(
       move |file_path, file_bytes, formatted_bytes, _, environment| {
         if formatted_bytes != file_bytes {
           not_formatted_files_count.inc();
-          if list_different {
+          if output_json {
+            output_json_difference(&file_path, &file_bytes, &formatted_bytes, &environment);
+          } else if list_different {
             log_stdout_info!(environment, "{}", file_path.display());
           } else {
             output_difference(&file_path, &file_bytes, &formatted_bytes, &environment);
@@ -211,7 +216,7 @@ pub async fn check<TEnvironment: Environment>(
     Ok(())
   } else {
     Err(
-      if list_different {
+      if list_different || output_json {
         CheckError::DisplayNone
       } else {
         CheckError::Files {
@@ -250,6 +255,24 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
   };
   let difference_text = get_difference(&file_text, &formatted_text);
   log_stdout_info!(environment, "{} {}:\n{}\n--", colors::red_bold("from"), file_path.display(), difference_text);
+}
+
+fn output_json_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], environment: &impl Environment) {
+  #[derive(Serialize)]
+  struct UnformattedFile<'a> {
+    file: &'a Path,
+    /// Unified diff of the file's text to its formatted text. `None` when
+    /// either isn't valid utf-8.
+    diff: Option<String>,
+  }
+
+  let diff = match (std::str::from_utf8(file_bytes), std::str::from_utf8(formatted_bytes)) {
+    (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text)),
+    _ => None,
+  };
+  let mut line = serde_json::to_vec(&UnformattedFile { file: file_path, diff }).unwrap();
+  line.push(b'\n');
+  environment.log_machine_readable(&line);
 }
 
 pub async fn format<TEnvironment: Environment>(
@@ -458,6 +481,24 @@ mod test {
       .unwrap();
     error_message.assert_exit_code(20);
     assert_eq!(environment.take_stdout_messages(), vec![file_path1.to_string()]);
+  }
+
+  #[test]
+  fn should_check_files_with_json_output() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/file1.txt", "text")
+      .write_file("/file2.txt", "text_formatted")
+      .build();
+    let error_message = run_test_cli(vec!["check", "--json"], &environment).err().unwrap();
+    error_message.assert_exit_code(20);
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![concat!(
+        r#"{"file":"/file1.txt","diff":"--- original\n+++ formatted\n@@ -1 +1 @@\n-text\n\\ No newline at end of file\n+text_formatted\n\\ No newline at end of file\n"}"#,
+        "\n"
+      )]
+    );
+    assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -179,7 +179,14 @@ pub async fn check<TEnvironment: Environment>(
         if formatted_bytes != file_bytes {
           not_formatted_files_count.inc();
           if output_json {
-            output_json_difference(&file_path, &file_bytes, &formatted_bytes, &environment);
+            output_json_difference(
+              OutputJsonDifferenceOptions {
+                file_path: &file_path,
+                file_bytes: &file_bytes,
+                formatted_bytes: &formatted_bytes,
+              },
+              &environment,
+            );
           } else if list_different {
             log_stdout_info!(environment, "{}", file_path.display());
           } else {
@@ -258,7 +265,13 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
   log_stdout_info!(environment, "{} {}:\n{}\n--", colors::red_bold("from"), file_path.display(), difference_text);
 }
 
-fn output_json_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], environment: &impl Environment) {
+struct OutputJsonDifferenceOptions<'a> {
+  file_path: &'a Path,
+  file_bytes: &'a [u8],
+  formatted_bytes: &'a [u8],
+}
+
+fn output_json_difference(options: OutputJsonDifferenceOptions, environment: &impl Environment) {
   #[derive(Serialize)]
   struct UnformattedFile<'a> {
     file: Cow<'a, str>,
@@ -267,13 +280,13 @@ fn output_json_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: 
     diff: Option<String>,
   }
 
-  let diff = match (std::str::from_utf8(file_bytes), std::str::from_utf8(formatted_bytes)) {
+  let diff = match (std::str::from_utf8(options.file_bytes), std::str::from_utf8(options.formatted_bytes)) {
     (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text)),
     _ => None,
   };
   // infallible because the struct only contains strings
   let mut line = serde_json::to_vec(&UnformattedFile {
-    file: file_path.to_string_lossy(),
+    file: options.file_path.to_string_lossy(),
     diff,
   })
   .unwrap();

--- a/crates/dprint/src/utils/get_difference.rs
+++ b/crates/dprint/src/utils/get_difference.rs
@@ -4,6 +4,14 @@ use deno_terminal::colors;
 use similar::ChangeTag;
 use similar::TextDiffConfig;
 
+/// Gets a plain unified diff (as `git diff` would output it) without any colours.
+pub fn get_unified_difference(old_text: &str, new_text: &str) -> String {
+  let mut config = TextDiffConfig::default();
+  config.timeout(Duration::from_millis(500));
+  let diff = config.diff_lines(old_text, new_text);
+  diff.unified_diff().header("original", "formatted").to_string()
+}
+
 /// Gets a string showing the difference between two strings.
 pub fn get_difference(old_text: &str, new_text: &str) -> String {
   debug_assert!(old_text != new_text);

--- a/crates/dprint/src/utils/get_difference.rs
+++ b/crates/dprint/src/utils/get_difference.rs
@@ -4,11 +4,9 @@ use deno_terminal::colors;
 use similar::ChangeTag;
 use similar::TextDiffConfig;
 
-/// Gets a plain unified diff (as `git diff` would output it) without any colours.
+/// Gets a plain unified diff (as `git diff` would output it) without any colors.
 pub fn get_unified_difference(old_text: &str, new_text: &str) -> String {
-  let mut config = TextDiffConfig::default();
-  config.timeout(Duration::from_millis(500));
-  let diff = config.diff_lines(old_text, new_text);
+  let diff = text_diff_config().diff_lines(old_text, new_text);
   diff.unified_diff().header("original", "formatted").to_string()
 }
 
@@ -24,10 +22,7 @@ pub fn get_difference(old_text: &str, new_text: &str) -> String {
     return String::from(" | Text differed by line endings.");
   }
 
-  let mut config = TextDiffConfig::default();
-  config.timeout(Duration::from_millis(500));
-
-  let diff = config.diff_lines(&old_text, &new_text);
+  let diff = text_diff_config().diff_lines(&old_text, &new_text);
 
   let mut output = String::new();
   for hunk in diff.unified_diff().iter_hunks() {
@@ -122,10 +117,26 @@ fn annotate_whitespace(text: &str) -> String {
   text.replace('\t', "\u{2192}").replace(' ', "\u{00B7}")
 }
 
+fn text_diff_config() -> TextDiffConfig {
+  let mut config = TextDiffConfig::default();
+  config.timeout(Duration::from_millis(500));
+  config
+}
+
 #[cfg(test)]
 mod test {
   use super::*;
   use pretty_assertions::assert_eq;
+
+  #[test]
+  fn should_get_unified_difference() {
+    assert_eq!(
+      get_unified_difference("a\nb\n", "a\nc\n"),
+      "--- original\n+++ formatted\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n"
+    );
+    // does not normalize line endings
+    assert_eq!(get_unified_difference("a\r\n", "a\n"), "--- original\n+++ formatted\n@@ -1 +1 @@\n-a\r\n+a\n");
+  }
 
   #[test]
   fn should_get_when_differs_by_line_endings() {

--- a/dprint.json
+++ b/dprint.json
@@ -22,12 +22,12 @@
   "plugins": [
     "npm:@dprint/typescript@0.96.1",
     "npm:@dprint/json@0.23.0",
-    "npm:@dprint/markdown@0.22.1",
-    "npm:@dprint/toml@0.7.0",
+    "npm:@dprint/markdown@0.23.0",
+    "npm:@dprint/toml@0.8.0",
     "npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67",
     "npm:dprint-plugin-malva@0.16.0",
     "npm:dprint-plugin-markup@0.27.3",
     "npm:dprint-plugin-yaml@0.6.0",
-    "npm:@dprint/dockerfile@0.5.0"
+    "npm:@dprint/dockerfile@0.6.0"
   ]
 }

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -129,6 +129,14 @@ Use the `--list-different` flag to display only the file paths that aren't forma
 dprint check --list-different
 ```
 
+### JSON output (dprint 0.57+)
+
+Use the `--json` flag to output a JSON object per line (newline-delimited JSON) for each file that isn't formatted. Each object has a `file` property with the file path and a `diff` property with a unified diff of the changes that would be made (or `null` if the file isn't valid utf-8).
+
+```sh
+dprint check --json
+```
+
 ### `--fail-fast` (dprint 0.51+)
 
 Instead of checking every file, you can have the CLI stop on the first failure:


### PR DESCRIPTION
Closes #1198

Adds a `--json` flag to `dprint check` that outputs newline-delimited JSON to stdout, one object per file that isn't formatted:

```json
{"file":"/path/to/file.ts","diff":"--- original\n+++ formatted\n@@ -1 +1 @@\n-const a=1\n+const a = 1;\n"}
```

- `file` — the file path
- `diff` — a plain unified diff (no colors) of the file's text to its formatted text, or `null` when the file isn't valid utf-8

Behaviour:
- Exit code 20 when any file isn't formatted (same as today); nothing is written for formatted files, and the "Found N not formatted files" message is suppressed like `--list-different`.
- stdout is treated as machine readable, so other info logging is suppressed; errors still go to stderr.
- Conflicts with `--list-different`. Works with `--fail-fast`, `--incremental`, `--log-level=silent` (the silent → fail-fast default is not applied when `--json` is set so tooling gets every file).
- Each record is written as a single write under the output lock, so lines from parallel workers don't interleave.

This is intentionally a minimal schema compared to the one proposed in the issue (no per-plugin/duration/ok records) since the format callback doesn't currently have that info; extra fields can be added later without breaking consumers.