### PR TITLE
feat: add `--diff-format unified` to `dprint check` and `dprint fmt --diff`

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -390,7 +390,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         let enable_stable_format = !matches.get_flag("skip-stable-format");
         SubCommand::Fmt(FmtSubCommand {
           diff: matches.get_flag("diff"),
-          diff_format: parse_diff_format(matches),
+          diff_format: parse_diff_format(matches, DiffFormat::Pretty),
           patterns: parse_file_patterns(matches, &std_in_reader)?,
           incremental: if enable_stable_format { parse_incremental(matches) } else { Some(false) },
           enable_stable_format,
@@ -424,7 +424,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         only_dirty: matches.get_flag("dirty"),
         list_different: matches.get_flag("list-different"),
         json,
-        diff_format: parse_diff_format(matches),
+        diff_format: parse_diff_format(matches, if json { DiffFormat::Unified } else { DiffFormat::Pretty }),
         allow_no_files: matches.get_flag("allow-no-files"),
         fail_fast,
       })
@@ -535,10 +535,11 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
   })
 }
 
-fn parse_diff_format(matches: &ArgMatches) -> DiffFormat {
+fn parse_diff_format(matches: &ArgMatches, default: DiffFormat) -> DiffFormat {
   match matches.get_one::<String>("diff-format").map(|s| s.as_str()) {
     Some("unified") => DiffFormat::Unified,
-    _ => DiffFormat::Pretty,
+    Some("pretty") => DiffFormat::Pretty,
+    _ => default,
   }
 }
 
@@ -1102,10 +1103,9 @@ impl ClapExtensions for clap::Command {
     self.arg(
       Arg::new("diff-format")
         .long("diff-format")
-        .help("The format to output diffs in. Use `unified` to output a standard unified diff that can be piped to other tools or applied with `patch`.")
+        .help("The format to output diffs in. Use `unified` to output a standard unified diff that can be piped to other tools or applied with `patch`. Defaults to `pretty`, or `unified` when outputting json.")
         .num_args(1)
         .value_parser(["pretty", "unified"])
-        .default_value("pretty")
         .required(false),
     )
   }
@@ -1459,6 +1459,11 @@ mod test {
     let check_cmd = parse_check_sub_command(vec!["check", "--diff-format=pretty"]).unwrap();
     assert_eq!(check_cmd.diff_format, DiffFormat::Pretty);
     assert!(test_args(vec!["check", "--diff-format", "other"]).is_err());
+    // defaults to unified with --json
+    let check_cmd = parse_check_sub_command(vec!["check", "--json"]).unwrap();
+    assert_eq!(check_cmd.diff_format, DiffFormat::Unified);
+    let check_cmd = parse_check_sub_command(vec!["check", "--json", "--diff-format", "pretty"]).unwrap();
+    assert_eq!(check_cmd.diff_format, DiffFormat::Pretty);
 
     match test_args(vec!["fmt", "--diff", "--diff-format", "unified"]).unwrap().sub_command {
       SubCommand::Fmt(cmd) => assert_eq!(cmd.diff_format, DiffFormat::Unified),

--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -183,12 +183,22 @@ impl SubCommand {
   }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiffFormat {
+  /// dprint's own human readable diff with line numbers and colors.
+  #[default]
+  Pretty,
+  /// Standard unified diff that can be piped to other tools or applied with `patch`.
+  Unified,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct CheckSubCommand {
   pub patterns: FilePatternArgs,
   pub incremental: Option<bool>,
   pub list_different: bool,
   pub json: bool,
+  pub diff_format: DiffFormat,
   pub allow_no_files: bool,
   pub only_staged: bool,
   pub only_dirty: bool,
@@ -198,6 +208,7 @@ pub struct CheckSubCommand {
 #[derive(Debug, PartialEq, Eq)]
 pub struct FmtSubCommand {
   pub diff: bool,
+  pub diff_format: DiffFormat,
   pub patterns: FilePatternArgs,
   pub incremental: Option<bool>,
   pub enable_stable_format: bool,
@@ -379,6 +390,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         let enable_stable_format = !matches.get_flag("skip-stable-format");
         SubCommand::Fmt(FmtSubCommand {
           diff: matches.get_flag("diff"),
+          diff_format: parse_diff_format(matches),
           patterns: parse_file_patterns(matches, &std_in_reader)?,
           incremental: if enable_stable_format { parse_incremental(matches) } else { Some(false) },
           enable_stable_format,
@@ -412,6 +424,7 @@ fn inner_parse_args<TStdInReader: StdInReader>(args: Vec<String>, std_in_reader:
         only_dirty: matches.get_flag("dirty"),
         list_different: matches.get_flag("list-different"),
         json,
+        diff_format: parse_diff_format(matches),
         allow_no_files: matches.get_flag("allow-no-files"),
         fail_fast,
       })
@@ -520,6 +533,13 @@ fn parse_file_patterns<TStdInReader: StdInReader>(matches: &ArgMatches, std_in_r
     exclude_patterns: maybe_values_to_vec(matches.get_many("excludes")),
     exclude_pattern_overrides: matches.get_many("excludes-override").map(values_to_vec),
   })
+}
+
+fn parse_diff_format(matches: &ArgMatches) -> DiffFormat {
+  match matches.get_one::<String>("diff-format").map(|s| s.as_str()) {
+    Some("unified") => DiffFormat::Unified,
+    _ => DiffFormat::Pretty,
+  }
 }
 
 fn parse_incremental(matches: &ArgMatches) -> Option<bool> {
@@ -752,6 +772,7 @@ EXAMPLES:
             .num_args(0)
             .required(false)
         )
+        .add_diff_format_arg()
         .add_only_staged_arg()
         .add_only_dirty_arg()
         .add_allow_no_files_arg()
@@ -791,6 +812,7 @@ EXAMPLES:
             .num_args(0)
             .conflicts_with("list-different")
         )
+        .add_diff_format_arg()
         .arg(
           Arg::new("fail-fast")
             .long("fail-fast")
@@ -990,6 +1012,7 @@ trait ClapExtensions {
   fn add_resolve_file_path_args(self) -> Self;
   fn add_incremental_arg(self) -> Self;
   fn add_allow_no_files_arg(self) -> Self;
+  fn add_diff_format_arg(self) -> Self;
   fn add_only_staged_arg(self) -> Self;
   fn add_only_dirty_arg(self) -> Self;
 }
@@ -1070,6 +1093,19 @@ impl ClapExtensions for clap::Command {
         .long("allow-no-files")
         .help("Causes dprint to exit with exit code 0 when no files are found instead of exit code 14.")
         .num_args(0)
+        .required(false),
+    )
+  }
+
+  fn add_diff_format_arg(self) -> Self {
+    use clap::Arg;
+    self.arg(
+      Arg::new("diff-format")
+        .long("diff-format")
+        .help("The format to output diffs in. Use `unified` to output a standard unified diff that can be piped to other tools or applied with `patch`.")
+        .num_args(1)
+        .value_parser(["pretty", "unified"])
+        .default_value("pretty")
         .required(false),
     )
   }
@@ -1412,6 +1448,26 @@ mod test {
     assert!(test_args(vec!["check", "--json", "--list-different"]).is_err());
     let check_cmd = parse_check_sub_command(vec!["check", "--json", "--fail-fast"]).unwrap();
     assert!(check_cmd.fail_fast);
+  }
+
+  #[test]
+  fn diff_format_arg() {
+    let check_cmd = parse_check_sub_command(vec!["check"]).unwrap();
+    assert_eq!(check_cmd.diff_format, DiffFormat::Pretty);
+    let check_cmd = parse_check_sub_command(vec!["check", "--diff-format", "unified"]).unwrap();
+    assert_eq!(check_cmd.diff_format, DiffFormat::Unified);
+    let check_cmd = parse_check_sub_command(vec!["check", "--diff-format=pretty"]).unwrap();
+    assert_eq!(check_cmd.diff_format, DiffFormat::Pretty);
+    assert!(test_args(vec!["check", "--diff-format", "other"]).is_err());
+
+    match test_args(vec!["fmt", "--diff", "--diff-format", "unified"]).unwrap().sub_command {
+      SubCommand::Fmt(cmd) => assert_eq!(cmd.diff_format, DiffFormat::Unified),
+      _ => unreachable!(),
+    }
+    match test_args(vec!["fmt"]).unwrap().sub_command {
+      SubCommand::Fmt(cmd) => assert_eq!(cmd.diff_format, DiffFormat::Pretty),
+      _ => unreachable!(),
+    }
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 use crate::arg_parser::CheckSubCommand;
 use crate::arg_parser::CliArgs;
+use crate::arg_parser::DiffFormat;
 use crate::arg_parser::FmtSubCommand;
 use crate::arg_parser::OutputFormatTimesSubCommand;
 use crate::arg_parser::StdInFmtSubCommand;
@@ -162,6 +163,7 @@ pub async fn check<TEnvironment: Environment>(
   let not_formatted_files_count = Arc::new(AtomicCounter::default());
   let list_different = cmd.list_different;
   let output_json = cmd.json;
+  let diff_format = cmd.diff_format;
   let fail_fast_flag = cmd.fail_fast.then(|| Arc::new(AtomicFlag::default()));
 
   for scope_and_paths in scopes.into_iter() {
@@ -190,7 +192,7 @@ pub async fn check<TEnvironment: Environment>(
           } else if list_different {
             log_stdout_info!(environment, "{}", file_path.display());
           } else {
-            output_difference(&file_path, &file_bytes, &formatted_bytes, &environment);
+            output_difference(&file_path, &file_bytes, &formatted_bytes, diff_format, &environment);
           }
           if let Some(fail_fast_flag) = &fail_fast_flag {
             fail_fast_flag.raise();
@@ -236,7 +238,7 @@ pub async fn check<TEnvironment: Environment>(
   }
 }
 
-fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], environment: &impl Environment) {
+fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], diff_format: DiffFormat, environment: &impl Environment) {
   let file_text = match String::from_utf8(file_bytes.to_vec()) {
     Ok(text) => text,
     Err(err) => {
@@ -261,8 +263,25 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
       return;
     }
   };
-  let difference_text = get_difference(&file_text, &formatted_text);
-  log_stdout_info!(environment, "{} {}:\n{}\n--", colors::red_bold("from"), file_path.display(), difference_text);
+  match diff_format {
+    DiffFormat::Pretty => {
+      let difference_text = get_difference(&file_text, &formatted_text);
+      log_stdout_info!(environment, "{} {}:\n{}\n--", colors::red_bold("from"), file_path.display(), difference_text);
+    }
+    DiffFormat::Unified => {
+      let display_path = get_unified_diff_display_path(file_path, environment);
+      let difference_text = get_unified_difference(&file_text, &formatted_text, &format!("a/{}", display_path), &format!("b/{}", display_path));
+      // the logger adds a trailing newline
+      log_stdout_info!(environment, "{}", difference_text.strip_suffix('\n').unwrap_or(&difference_text));
+    }
+  }
+}
+
+/// Gets the path relative to the cwd with forward slashes so the diff can
+/// be applied with `patch -p1` or `git apply` from the cwd.
+fn get_unified_diff_display_path(file_path: &Path, environment: &impl Environment) -> String {
+  let path = file_path.strip_prefix(environment.cwd()).unwrap_or(file_path);
+  path.to_string_lossy().replace('\\', "/")
 }
 
 struct OutputJsonDifferenceOptions<'a> {
@@ -281,7 +300,7 @@ fn output_json_difference(options: OutputJsonDifferenceOptions, environment: &im
   }
 
   let diff = match (std::str::from_utf8(options.file_bytes), std::str::from_utf8(options.formatted_bytes)) {
-    (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text)),
+    (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text, "original", "formatted")),
     _ => None,
   };
   // infallible because the struct only contains strings
@@ -319,6 +338,7 @@ pub async fn format<TEnvironment: Environment>(
       .and_then(|config| get_incremental_file(cmd.incremental, config, &scope_and_paths.scope, environment))
       .map(Arc::new);
     let output_diff = cmd.diff;
+    let diff_format = cmd.diff_format;
 
     run_parallelized(
       scope_and_paths,
@@ -335,7 +355,7 @@ pub async fn format<TEnvironment: Environment>(
 
           if formatted_bytes != file_bytes {
             if output_diff {
-              output_difference(&file_path, &file_bytes, &formatted_bytes, &environment);
+              output_difference(&file_path, &file_bytes, &formatted_bytes, diff_format, &environment);
             }
 
             formatted_files_count.inc();
@@ -518,6 +538,37 @@ mod test {
       )]
     );
     assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+  }
+
+  #[test]
+  fn should_check_files_with_unified_diff_format() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/sub/file1.txt", "text\n")
+      .write_file("/file2.txt", "text_formatted")
+      .build();
+    let error_message = run_test_cli(vec!["check", "--diff-format", "unified"], &environment).err().unwrap();
+    error_message.assert_exit_code(20);
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec!["--- a/sub/file1.txt\n+++ b/sub/file1.txt\n@@ -1 +1,2 @@\n text\n+_formatted\n\\ No newline at end of file"]
+    );
+    assert_eq!(error_message.to_string(), get_singular_check_text());
+  }
+
+  #[test]
+  fn should_format_with_unified_diff_format() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/file.txt", "text\n")
+      .build();
+    run_test_cli(vec!["fmt", "--diff", "--diff-format", "unified"], &environment).unwrap();
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![
+        "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1,2 @@\n text\n+_formatted\n\\ No newline at end of file".to_string(),
+        get_singular_formatted_text()
+      ]
+    );
+    assert_eq!(environment.read_file("/file.txt").unwrap(), "text\n_formatted");
   }
 
   #[test]

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -32,6 +32,7 @@ use crate::resolution::ResolvePluginsScopeAndPathsOptions;
 use crate::resolution::resolve_plugins_scope;
 use crate::resolution::resolve_plugins_scope_and_paths;
 use crate::utils::AtomicCounter;
+use crate::utils::UnifiedDifferenceOptions;
 use crate::utils::get_difference;
 use crate::utils::get_unified_difference;
 
@@ -186,13 +187,22 @@ pub async fn check<TEnvironment: Environment>(
                 file_path: &file_path,
                 file_bytes: &file_bytes,
                 formatted_bytes: &formatted_bytes,
+                diff_format,
               },
               &environment,
             );
           } else if list_different {
             log_stdout_info!(environment, "{}", file_path.display());
           } else {
-            output_difference(&file_path, &file_bytes, &formatted_bytes, diff_format, &environment);
+            output_difference(
+              OutputDifferenceOptions {
+                file_path: &file_path,
+                file_bytes: &file_bytes,
+                formatted_bytes: &formatted_bytes,
+                diff_format,
+              },
+              &environment,
+            );
           }
           if let Some(fail_fast_flag) = &fail_fast_flag {
             fail_fast_flag.raise();
@@ -238,8 +248,16 @@ pub async fn check<TEnvironment: Environment>(
   }
 }
 
-fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8], diff_format: DiffFormat, environment: &impl Environment) {
-  let file_text = match String::from_utf8(file_bytes.to_vec()) {
+struct OutputDifferenceOptions<'a> {
+  file_path: &'a Path,
+  file_bytes: &'a [u8],
+  formatted_bytes: &'a [u8],
+  diff_format: DiffFormat,
+}
+
+fn output_difference(options: OutputDifferenceOptions, environment: &impl Environment) {
+  let file_path = options.file_path;
+  let file_text = match String::from_utf8(options.file_bytes.to_vec()) {
     Ok(text) => text,
     Err(err) => {
       log_warn!(
@@ -251,7 +269,7 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
       return;
     }
   };
-  let formatted_text = match String::from_utf8(formatted_bytes.to_vec()) {
+  let formatted_text = match String::from_utf8(options.formatted_bytes.to_vec()) {
     Ok(text) => text,
     Err(err) => {
       log_warn!(
@@ -263,14 +281,19 @@ fn output_difference(file_path: &Path, file_bytes: &[u8], formatted_bytes: &[u8]
       return;
     }
   };
-  match diff_format {
+  match options.diff_format {
     DiffFormat::Pretty => {
       let difference_text = get_difference(&file_text, &formatted_text);
       log_stdout_info!(environment, "{} {}:\n{}\n--", colors::red_bold("from"), file_path.display(), difference_text);
     }
     DiffFormat::Unified => {
       let display_path = get_unified_diff_display_path(file_path, environment);
-      let difference_text = get_unified_difference(&file_text, &formatted_text, &format!("a/{}", display_path), &format!("b/{}", display_path));
+      let difference_text = get_unified_difference(UnifiedDifferenceOptions {
+        old_text: &file_text,
+        new_text: &formatted_text,
+        old_header: &format!("a/{}", display_path),
+        new_header: &format!("b/{}", display_path),
+      });
       // the logger adds a trailing newline
       log_stdout_info!(environment, "{}", difference_text.strip_suffix('\n').unwrap_or(&difference_text));
     }
@@ -288,19 +311,28 @@ struct OutputJsonDifferenceOptions<'a> {
   file_path: &'a Path,
   file_bytes: &'a [u8],
   formatted_bytes: &'a [u8],
+  diff_format: DiffFormat,
 }
 
 fn output_json_difference(options: OutputJsonDifferenceOptions, environment: &impl Environment) {
   #[derive(Serialize)]
   struct UnformattedFile<'a> {
     file: Cow<'a, str>,
-    /// Unified diff of the file's text to its formatted text. `None` when
-    /// either isn't valid utf-8.
+    /// Diff of the file's text to its formatted text in the requested
+    /// format. `None` when either isn't valid utf-8.
     diff: Option<String>,
   }
 
   let diff = match (std::str::from_utf8(options.file_bytes), std::str::from_utf8(options.formatted_bytes)) {
-    (Ok(file_text), Ok(formatted_text)) => Some(get_unified_difference(file_text, formatted_text, "original", "formatted")),
+    (Ok(file_text), Ok(formatted_text)) => Some(match options.diff_format {
+      DiffFormat::Pretty => get_difference(file_text, formatted_text),
+      DiffFormat::Unified => get_unified_difference(UnifiedDifferenceOptions {
+        old_text: file_text,
+        new_text: formatted_text,
+        old_header: "original",
+        new_header: "formatted",
+      }),
+    }),
     _ => None,
   };
   // infallible because the struct only contains strings
@@ -355,7 +387,15 @@ pub async fn format<TEnvironment: Environment>(
 
           if formatted_bytes != file_bytes {
             if output_diff {
-              output_difference(&file_path, &file_bytes, &formatted_bytes, diff_format, &environment);
+              output_difference(
+                OutputDifferenceOptions {
+                  file_path: &file_path,
+                  file_bytes: &file_bytes,
+                  formatted_bytes: &formatted_bytes,
+                  diff_format,
+                },
+                &environment,
+              );
             }
 
             formatted_files_count.inc();
@@ -538,6 +578,20 @@ mod test {
       )]
     );
     assert_eq!(environment.take_stderr_messages(), Vec::<String>::new());
+  }
+
+  #[test]
+  fn should_check_files_with_json_output_and_pretty_diff_format() {
+    let environment = TestEnvironmentBuilder::with_initialized_remote_wasm_plugin()
+      .write_file("/file1.txt", "text")
+      .build();
+    let error_message = run_test_cli(vec!["check", "--json", "--diff-format", "pretty"], &environment).err().unwrap();
+    error_message.assert_exit_code(20);
+    let expected = serde_json::json!({
+      "file": "/file1.txt",
+      "diff": get_difference("text", "text_formatted"),
+    });
+    assert_eq!(environment.take_stdout_messages(), vec![format!("{}\n", expected)]);
   }
 
   #[test]

--- a/crates/dprint/src/utils/get_difference.rs
+++ b/crates/dprint/src/utils/get_difference.rs
@@ -4,10 +4,19 @@ use deno_terminal::colors;
 use similar::ChangeTag;
 use similar::TextDiffConfig;
 
+pub struct UnifiedDifferenceOptions<'a> {
+  pub old_text: &'a str,
+  pub new_text: &'a str,
+  /// Text shown after `---` in the header.
+  pub old_header: &'a str,
+  /// Text shown after `+++` in the header.
+  pub new_header: &'a str,
+}
+
 /// Gets a plain unified diff (as `git diff` would output it) without any colors.
-pub fn get_unified_difference(old_text: &str, new_text: &str, old_header: &str, new_header: &str) -> String {
-  let diff = text_diff_config().diff_lines(old_text, new_text);
-  diff.unified_diff().header(old_header, new_header).to_string()
+pub fn get_unified_difference(options: UnifiedDifferenceOptions) -> String {
+  let diff = text_diff_config().diff_lines(options.old_text, options.new_text);
+  diff.unified_diff().header(options.old_header, options.new_header).to_string()
 }
 
 /// Gets a string showing the difference between two strings.
@@ -131,12 +140,22 @@ mod test {
   #[test]
   fn should_get_unified_difference() {
     assert_eq!(
-      get_unified_difference("a\nb\n", "a\nc\n", "a/file.txt", "b/file.txt"),
+      get_unified_difference(UnifiedDifferenceOptions {
+        old_text: "a\nb\n",
+        new_text: "a\nc\n",
+        old_header: "a/file.txt",
+        new_header: "b/file.txt",
+      }),
       "--- a/file.txt\n+++ b/file.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n"
     );
     // does not normalize line endings
     assert_eq!(
-      get_unified_difference("a\r\n", "a\n", "original", "formatted"),
+      get_unified_difference(UnifiedDifferenceOptions {
+        old_text: "a\r\n",
+        new_text: "a\n",
+        old_header: "original",
+        new_header: "formatted",
+      }),
       "--- original\n+++ formatted\n@@ -1 +1 @@\n-a\r\n+a\n"
     );
   }

--- a/crates/dprint/src/utils/get_difference.rs
+++ b/crates/dprint/src/utils/get_difference.rs
@@ -5,9 +5,9 @@ use similar::ChangeTag;
 use similar::TextDiffConfig;
 
 /// Gets a plain unified diff (as `git diff` would output it) without any colors.
-pub fn get_unified_difference(old_text: &str, new_text: &str) -> String {
+pub fn get_unified_difference(old_text: &str, new_text: &str, old_header: &str, new_header: &str) -> String {
   let diff = text_diff_config().diff_lines(old_text, new_text);
-  diff.unified_diff().header("original", "formatted").to_string()
+  diff.unified_diff().header(old_header, new_header).to_string()
 }
 
 /// Gets a string showing the difference between two strings.
@@ -131,11 +131,14 @@ mod test {
   #[test]
   fn should_get_unified_difference() {
     assert_eq!(
-      get_unified_difference("a\nb\n", "a\nc\n"),
-      "--- original\n+++ formatted\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n"
+      get_unified_difference("a\nb\n", "a\nc\n", "a/file.txt", "b/file.txt"),
+      "--- a/file.txt\n+++ b/file.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n"
     );
     // does not normalize line endings
-    assert_eq!(get_unified_difference("a\r\n", "a\n"), "--- original\n+++ formatted\n@@ -1 +1 @@\n-a\r\n+a\n");
+    assert_eq!(
+      get_unified_difference("a\r\n", "a\n", "original", "formatted"),
+      "--- original\n+++ formatted\n@@ -1 +1 @@\n-a\r\n+a\n"
+    );
   }
 
   #[test]

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -131,7 +131,7 @@ dprint check --list-different
 
 ### JSON output (dprint 0.57+)
 
-Use the `--json` flag to output a JSON object per line (newline-delimited JSON) for each file that isn't formatted. Each object has a `file` property with the file path and a `diff` property with a unified diff of the changes that would be made (or `null` if the file isn't valid utf-8).
+Use the `--json` flag to output a JSON object per line (newline-delimited JSON) for each file that isn't formatted. Each object has a `file` property with the file path and a `diff` property with a unified diff of the changes that would be made (or `null` if the file isn't valid utf-8). Specify `--diff-format pretty` to get dprint's human readable diff in the `diff` property instead.
 
 ```sh
 dprint check --json

--- a/website/src/cli.md
+++ b/website/src/cli.md
@@ -137,6 +137,15 @@ Use the `--json` flag to output a JSON object per line (newline-delimited JSON) 
 dprint check --json
 ```
 
+### Unified diff output (dprint 0.57+)
+
+By default, `dprint check` and `dprint fmt --diff` output a human readable diff with line numbers and colours. Use `--diff-format unified` to output a standard unified diff instead, which can be piped to tools like [delta](https://github.com/dandavison/delta) or applied with `patch`/`git apply` from the current directory:
+
+```sh
+dprint check --diff-format unified
+dprint fmt --diff --diff-format unified
+```
+
 ### `--fail-fast` (dprint 0.51+)
 
 Instead of checking every file, you can have the CLI stop on the first failure:


### PR DESCRIPTION
Closes #1092

Adds a `--diff-format <pretty|unified>` option to `dprint check` and `dprint fmt --diff`. The default `pretty` is the existing colored, line-numbered output. `unified` outputs a standard unified diff with no colors:

```
$ dprint check --diff-format unified
--- a/src/x.json
+++ b/src/x.json
@@ -1,2 +1 @@
-{"a":1,
-"b":[1,2]}
\ No newline at end of file
+{ "a": 1, "b": [1, 2] }
```

- Paths in the headers are relative to the cwd with forward slashes and `a/`/`b/` prefixes, so the output can be piped to `delta`/`difftastic` or applied with `git apply` / `patch -p1` from the cwd (verified end-to-end: `dprint check --diff-format unified > out.diff && git apply out.diff` leaves `dprint check` clean).
- Diffs go to stdout; the "Found N not formatted files" summary still goes to stderr as an error, so stdout is a clean patch.
- `get_unified_difference` (added in #1231) now takes the header names so it's shared with the `--json` output.