### PR TITLE
perf: cheaper per-file plugin resolution

### DIFF
--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -75,12 +75,17 @@ impl FilesPathsByPlugins {
 pub fn get_file_paths_by_plugins(
   plugin_name_maps: &PluginNameResolutionMaps,
   file_paths: Vec<PathBuf>,
+  mut shebang_lines: HashMap<PathBuf, Vec<u8>>,
   environment: &impl Environment,
 ) -> Result<FilesPathsByPlugins> {
   let mut file_paths_by_plugin: HashMap<PluginNames, Vec<PathBuf>> = HashMap::new();
 
   for file_path in file_paths.into_iter() {
-    let plugin_names = get_plugin_names_for_file_on_disk(plugin_name_maps, &file_path, environment);
+    let plugin_names = match shebang_lines.remove(&file_path) {
+      // the traversal already read this file's shebang line, so don't read it again
+      Some(shebang_line) => plugin_name_maps.get_plugin_names_from_file_path_and_bytes(&file_path, &shebang_line),
+      None => get_plugin_names_for_file_on_disk(plugin_name_maps, &file_path, environment),
+    };
     if !plugin_names.is_empty() {
       let plugin_names_key = PluginNames::from_plugin_names(&plugin_names);
       let file_paths = file_paths_by_plugin.entry(plugin_names_key).or_default();

--- a/crates/dprint/src/paths.rs
+++ b/crates/dprint/src/paths.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use anyhow::Result;
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
@@ -33,12 +34,48 @@ pub struct PluginNames(String);
 impl PluginNames {
   const SEPARATOR: &'static str = "~~";
 
-  pub fn from_plugin_names(names: &[String]) -> Self {
-    Self(names.join(PluginNames::SEPARATOR))
-  }
-
   pub fn names(&self) -> Split<'_, &str> {
     self.0.split(PluginNames::SEPARATOR)
+  }
+}
+
+impl Borrow<str> for PluginNames {
+  fn borrow(&self) -> &str {
+    &self.0
+  }
+}
+
+/// Builds `PluginNames` keys in a buffer it reuses, so that resolving the
+/// plugins for many files doesn't allocate a key for every one of them.
+#[derive(Default)]
+struct PluginNamesBuilder {
+  buffer: String,
+}
+
+impl PluginNamesBuilder {
+  fn build(&mut self, names: &[&str]) -> PluginNamesKey<'_> {
+    self.buffer.clear();
+    for (i, name) in names.iter().enumerate() {
+      if i > 0 {
+        self.buffer.push_str(PluginNames::SEPARATOR);
+      }
+      self.buffer.push_str(name);
+    }
+    PluginNamesKey(&self.buffer)
+  }
+}
+
+/// A key borrowed from a `PluginNamesBuilder`, which can be looked up without
+/// allocating and only turned into a `PluginNames` when it's not in the map yet.
+struct PluginNamesKey<'a>(&'a str);
+
+impl PluginNamesKey<'_> {
+  fn as_str(&self) -> &str {
+    self.0
+  }
+
+  fn to_plugin_names(&self) -> PluginNames {
+    PluginNames(self.0.to_string())
   }
 }
 
@@ -79,6 +116,7 @@ pub fn get_file_paths_by_plugins(
   environment: &impl Environment,
 ) -> Result<FilesPathsByPlugins> {
   let mut file_paths_by_plugin: HashMap<PluginNames, Vec<PathBuf>> = HashMap::new();
+  let mut plugin_names_builder = PluginNamesBuilder::default();
 
   for file_path in file_paths.into_iter() {
     let plugin_names = match shebang_lines.remove(&file_path) {
@@ -87,9 +125,15 @@ pub fn get_file_paths_by_plugins(
       None => get_plugin_names_for_file_on_disk(plugin_name_maps, &file_path, environment),
     };
     if !plugin_names.is_empty() {
-      let plugin_names_key = PluginNames::from_plugin_names(&plugin_names);
-      let file_paths = file_paths_by_plugin.entry(plugin_names_key).or_default();
-      file_paths.push(file_path);
+      // only a handful of distinct keys exist no matter how many files there
+      // are, so allocate one only when the key hasn't been seen yet
+      let key = plugin_names_builder.build(&plugin_names);
+      match file_paths_by_plugin.get_mut(key.as_str()) {
+        Some(file_paths) => file_paths.push(file_path),
+        None => {
+          file_paths_by_plugin.insert(key.to_plugin_names(), vec![file_path]);
+        }
+      }
     }
   }
 
@@ -98,7 +142,7 @@ pub fn get_file_paths_by_plugins(
 
 /// Resolves the plugins for a file on disk, reading its shebang line when it's
 /// an extensionless file that didn't match a plugin by path.
-pub fn get_plugin_names_for_file_on_disk(plugin_name_maps: &PluginNameResolutionMaps, file_path: &Path, environment: &impl Environment) -> Vec<String> {
+pub fn get_plugin_names_for_file_on_disk<'a>(plugin_name_maps: &'a PluginNameResolutionMaps, file_path: &Path, environment: &impl Environment) -> Vec<&'a str> {
   let plugin_names = plugin_name_maps.get_plugin_names_from_file_path(file_path);
   if !plugin_names.is_empty() || !plugin_name_maps.may_match_shebang(file_path) {
     return plugin_names;

--- a/crates/dprint/src/plugins/name_resolution.rs
+++ b/crates/dprint/src/plugins/name_resolution.rs
@@ -69,12 +69,12 @@ impl PluginNameResolutionMaps {
     Ok(plugin_name_maps)
   }
 
-  pub fn get_plugin_names_from_file_path(&self, file_path: &Path) -> Vec<String> {
+  pub fn get_plugin_names_from_file_path<'a>(&'a self, file_path: &Path) -> Vec<&'a str> {
     let mut plugin_names = Vec::new();
 
     for (plugin_name, matcher) in self.association_matchers.iter() {
       if matcher.matches(file_path) {
-        plugin_names.push(plugin_name.to_owned());
+        plugin_names.push(plugin_name.as_str());
       }
     }
 
@@ -83,21 +83,21 @@ impl PluginNameResolutionMaps {
     }
 
     if let Some(file_name) = get_lowercase_file_name(file_path)
-      && let Some(plugin_names) = self.file_name_to_plugin_names_map.get(&file_name)
+      && let Some(plugin_names) = self.file_name_to_plugin_names_map.get(file_name.as_ref())
     {
       for plugin_name in plugin_names {
         if self.is_not_associations_excluded(plugin_name, file_path) {
-          return vec![plugin_name.clone()];
+          return vec![plugin_name.as_str()];
         }
       }
     }
 
     if let Some(ext) = get_lowercase_file_extension(file_path)
-      && let Some(plugin_names) = self.extension_to_plugin_names_map.get(&ext)
+      && let Some(plugin_names) = self.extension_to_plugin_names_map.get(ext.as_ref())
     {
       for plugin_name in plugin_names {
         if self.is_not_associations_excluded(plugin_name, file_path) {
-          return vec![plugin_name.clone()];
+          return vec![plugin_name.as_str()];
         }
       }
     }
@@ -108,7 +108,7 @@ impl PluginNameResolutionMaps {
   /// Resolves plugins for a file, falling back to its shebang line when it's
   /// extensionless and no plugin matched by path. `file_bytes_start` only
   /// needs to contain the start of the file.
-  pub fn get_plugin_names_from_file_path_and_bytes(&self, file_path: &Path, file_bytes_start: &[u8]) -> Vec<String> {
+  pub fn get_plugin_names_from_file_path_and_bytes<'a>(&'a self, file_path: &Path, file_bytes_start: &[u8]) -> Vec<&'a str> {
     let plugin_names = self.get_plugin_names_from_file_path(file_path);
     if !plugin_names.is_empty() {
       return plugin_names;
@@ -130,7 +130,7 @@ impl PluginNameResolutionMaps {
   /// A configured shebang matches when the file's shebang line equals it or
   /// starts with it followed by whitespace, so `#!/usr/bin/env deno run` matches
   /// `#!/usr/bin/env deno run --allow-read` but not `#!/usr/bin/env deno runtest`.
-  pub fn get_plugin_names_from_shebang(&self, file_path: &Path, file_bytes_start: &[u8]) -> Vec<String> {
+  pub fn get_plugin_names_from_shebang<'a>(&'a self, file_path: &Path, file_bytes_start: &[u8]) -> Vec<&'a str> {
     if !self.may_match_shebang(file_path) {
       return Vec::new();
     }
@@ -150,7 +150,7 @@ impl PluginNameResolutionMaps {
     };
     for plugin_name in plugin_names {
       if self.is_not_associations_excluded(plugin_name, file_path) {
-        return vec![plugin_name.clone()];
+        return vec![plugin_name.as_str()];
       }
     }
     Vec::new()

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -662,7 +662,7 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
       .resolve_outside_base_paths(&mut glob_output, &config, config_discovery, root_config_path.clone())
       .await?;
 
-    let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths, self.environment)?;
+    let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths, glob_output.shebang_lines, self.environment)?;
 
     let mut result = vec![PluginsScopeAndPaths { scope, file_paths_by_plugins }];
     // todo: parallelize?
@@ -941,7 +941,7 @@ impl<'a, TEnvironment: Environment> PluginsAndPathsResolver<'a, TEnvironment> {
     // paths outside this config's directory were already handled when
     // resolving the root scope
     glob_output.outside_base_paths.clear();
-    let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths, self.environment)?;
+    let file_paths_by_plugins = get_file_paths_by_plugins(&scope.plugin_name_maps, glob_output.file_paths, glob_output.shebang_lines, self.environment)?;
 
     let mut result = vec![PluginsScopeAndPaths { scope, file_paths_by_plugins }];
     // todo: parallelize?

--- a/crates/dprint/src/resolution.rs
+++ b/crates/dprint/src/resolution.rs
@@ -499,9 +499,13 @@ impl<TEnvironment: Environment> PluginsScope<TEnvironment> {
   }
 
   pub fn format(self: &Rc<Self>, request: HostFormatRequest) -> LocalBoxFuture<'static, FormatResult> {
+    // owned because they outlive this scope by moving into the future below
     let plugin_names = self
       .plugin_name_maps
-      .get_plugin_names_from_file_path_and_bytes(&request.file_path, &request.file_bytes);
+      .get_plugin_names_from_file_path_and_bytes(&request.file_path, &request.file_bytes)
+      .into_iter()
+      .map(ToOwned::to_owned)
+      .collect::<Vec<String>>();
     log_debug!(
       self.environment,
       "Host formatting {} - File length: {} - Plugins: [{}] - Range: {:?}",

--- a/crates/dprint/src/utils/file_path_utils.rs
+++ b/crates/dprint/src/utils/file_path_utils.rs
@@ -1,25 +1,33 @@
+use std::borrow::Cow;
 use std::path::Path;
 
-pub fn get_lowercase_file_extension(file_path: &Path) -> Option<String> {
-  file_path
-    .extension()
-    .and_then(|e| e.to_str())
-    .map(|ext| String::from(ext).to_lowercase())
-    .or_else(|| {
-      if file_path.components().count() == 1 {
-        let text = file_path.to_string_lossy();
-        if let Some(index) = text.rfind('.')
-          && index == 0
-        {
-          return Some(text[1..].to_lowercase());
-        }
-      }
-      None
-    })
+pub fn get_lowercase_file_extension(file_path: &Path) -> Option<Cow<'_, str>> {
+  if let Some(ext) = file_path.extension().and_then(|e| e.to_str()) {
+    return Some(to_lowercase_cow(ext));
+  }
+  // a path that's only a file name like `.txt` has no extension as far as
+  // `Path` is concerned, but dprint treats the text after the dot as one
+  if file_path.components().count() == 1 {
+    let text = file_path.to_string_lossy();
+    if text.rfind('.') == Some(0) {
+      return Some(Cow::Owned(text[1..].to_lowercase()));
+    }
+  }
+  None
 }
 
-pub fn get_lowercase_file_name(file_path: &Path) -> Option<String> {
-  file_path.file_name().and_then(|s| s.to_str()).map(|s| s.to_lowercase())
+pub fn get_lowercase_file_name(file_path: &Path) -> Option<Cow<'_, str>> {
+  file_path.file_name().and_then(|s| s.to_str()).map(to_lowercase_cow)
+}
+
+/// Lowercases the text without allocating when it's already lowercase ascii,
+/// which is the common case for a file name or extension.
+fn to_lowercase_cow(text: &str) -> Cow<'_, str> {
+  if text.is_ascii() && !text.bytes().any(|b| b.is_ascii_uppercase()) {
+    Cow::Borrowed(text)
+  } else {
+    Cow::Owned(text.to_lowercase())
+  }
 }
 
 #[cfg(test)]
@@ -35,5 +43,23 @@ mod test {
     assert!(get_lowercase_file_extension(Path::new("txt")).is_none());
     assert!(get_lowercase_file_extension(Path::new("/path/.txt")).is_none());
     assert_eq!(get_lowercase_file_extension(Path::new("/path/test.txt")).unwrap(), "txt");
+  }
+
+  #[test]
+  fn test_get_lowercase_file_name() {
+    assert_eq!(get_lowercase_file_name(Path::new("/path/Test.TXT")).unwrap(), "test.txt");
+    assert_eq!(get_lowercase_file_name(Path::new("/path/test.txt")).unwrap(), "test.txt");
+    assert!(get_lowercase_file_name(Path::new("/")).is_none());
+  }
+
+  #[test]
+  fn test_to_lowercase_cow() {
+    // already lowercase ascii, so it shouldn't allocate
+    assert!(matches!(to_lowercase_cow("test.txt"), Cow::Borrowed(_)));
+    assert!(matches!(to_lowercase_cow(""), Cow::Borrowed(_)));
+    assert!(matches!(to_lowercase_cow("Test.txt"), Cow::Owned(_)));
+    // non-ascii always goes through `to_lowercase` so nothing it handles is missed
+    assert_eq!(to_lowercase_cow("\u{00c9}t\u{00c9}"), "\u{00e9}t\u{00e9}");
+    assert!(matches!(to_lowercase_cow("\u{00e9}"), Cow::Owned(_)));
   }
 }

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -16,11 +16,11 @@ use crate::environment::CanonicalizedPathBuf;
 use crate::environment::DirEntry;
 use crate::environment::Environment;
 use crate::environment::PathKind;
-use crate::utils::file_has_matching_shebang;
 use crate::utils::gitignore::DirEntriesHint;
 use crate::utils::gitignore::GitIgnoreTree;
 use crate::utils::gitignore::GitIgnoreTreeOptions;
 use crate::utils::gitignore::resolve_global_gitignore_lines;
+use crate::utils::read_matching_shebang_line;
 
 use super::ExcludeMatchDetail;
 use super::GlobMatcher;
@@ -36,6 +36,9 @@ use super::unescape_glob_text;
 #[derive(Debug, Default, Clone)]
 pub struct GlobOutput {
   pub file_paths: Vec<PathBuf>,
+  /// The shebang lines read while traversing, keyed by file path, so that
+  /// resolving the plugin for a shebang file doesn't have to read it again.
+  pub shebang_lines: HashMap<PathBuf, Vec<u8>>,
   pub config_files: Vec<PathBuf>,
   /// CLI paths and patterns that are outside the pattern base directory.
   /// The caller resolves the config file to use for these separately.
@@ -225,6 +228,7 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
     let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
     let results = glob_matching_processor.run()?;
     output.file_paths.extend(results.file_paths);
+    output.shebang_lines.extend(results.shebang_lines);
     for config_file in results.config_files {
       // the traversal skips the directories the checks above already handled,
       // so this shouldn't overlap with them, but dedup anyway because a
@@ -633,9 +637,12 @@ struct DirEntries {
 
 enum DirOrConfigEntry {
   Dir(PathBuf),
-  File(PathBuf),
-  /// An extensionless file whose first line matches a configured shebang.
-  ShebangFile(PathBuf),
+  File {
+    path: PathBuf,
+    /// The first line of an extensionless file when it matches a configured
+    /// shebang, which the matching thread hands to plugin resolution.
+    shebang_line: Option<Vec<u8>>,
+  },
   // todo: get rid of this from here probably
   Config(PathBuf),
 }
@@ -648,7 +655,7 @@ fn dir_entries_hint(entries: &[DirOrConfigEntry]) -> DirEntriesHint {
   };
   for entry in entries {
     match entry {
-      DirOrConfigEntry::Dir(path) | DirOrConfigEntry::File(path) | DirOrConfigEntry::ShebangFile(path) => {
+      DirOrConfigEntry::Dir(path) | DirOrConfigEntry::File { path, .. } => {
         match path.file_name().and_then(|f| f.to_str()) {
           // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
           Some(".gitignore") => hint.has_gitignore = true,
@@ -779,11 +786,8 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
             DirEntry::File { path, .. } => {
               // check for a shebang here since these threads run in parallel
               // and reading the file is I/O bound
-              if self.should_check_shebang(&path) && file_has_matching_shebang(&self.environment, &path, &self.options.shebangs) {
-                DirOrConfigEntry::ShebangFile(path)
-              } else {
-                DirOrConfigEntry::File(path)
-              }
+              let shebang_line = self.maybe_read_shebang_line(&path);
+              DirOrConfigEntry::File { path, shebang_line }
             }
           })
           .collect::<Vec<_>>(),
@@ -791,8 +795,11 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     }
   }
 
-  fn should_check_shebang(&self, path: &Path) -> bool {
-    !self.options.shebangs.is_empty() && path.extension().is_none()
+  fn maybe_read_shebang_line(&self, path: &Path) -> Option<Vec<u8>> {
+    if self.options.shebangs.is_empty() || path.extension().is_some() {
+      return None;
+    }
+    read_matching_shebang_line(&self.environment, path, &self.options.shebangs)
   }
 
   /// Waits for directories to read, returning a chunk of them or `None` once the
@@ -922,13 +929,8 @@ impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
                     pending_dirs.push(path);
                   }
                 }
-                DirOrConfigEntry::File(_) | DirOrConfigEntry::ShebangFile(_) => {
-                  let (path, has_matching_shebang) = match entry {
-                    DirOrConfigEntry::File(path) => (path, false),
-                    DirOrConfigEntry::ShebangFile(path) => (path, true),
-                    DirOrConfigEntry::Dir(_) | DirOrConfigEntry::Config(_) => unreachable!(),
-                  };
-                  let is_matched = match self.glob_matcher.matches_detail_with_shebang_checked(&path, has_matching_shebang) {
+                DirOrConfigEntry::File { path, shebang_line } => {
+                  let is_matched = match self.glob_matcher.matches_detail_with_shebang_checked(&path, shebang_line.is_some()) {
                     GlobMatchesDetail::Excluded => false,
                     GlobMatchesDetail::Matched => match &gitignore {
                       Some(gitignore) => {
@@ -940,6 +942,9 @@ impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
                     GlobMatchesDetail::NotMatched => false,
                   };
                   if is_matched {
+                    if let Some(shebang_line) = shebang_line {
+                      output.shebang_lines.insert(path.clone(), shebang_line);
+                    }
                     output.file_paths.push(path);
                   }
                 }
@@ -1093,6 +1098,44 @@ mod test {
     result.sort();
     expected_matches.sort();
     assert_eq!(result, expected_matches);
+  }
+
+  #[tokio::test]
+  async fn should_keep_shebang_lines_of_matched_files() {
+    let mut builder = TestEnvironmentBuilder::new();
+    builder.write_file("/a.txt", "");
+    builder.write_file("/scripts/build", "#!/bin/sh\ntext");
+    builder.write_file("/scripts/notes", "text");
+    builder.write_file("/scripts/other", "#!/usr/bin/env node\ntext");
+    let environment = builder.build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        current_config_path: None,
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          shebangs: vec!["#!/bin/sh".to_string()],
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+    let mut file_paths = result.file_paths.iter().map(|p| p.to_string_lossy().to_string()).collect::<Vec<_>>();
+    file_paths.sort();
+    assert_eq!(file_paths, vec!["/a.txt".to_string(), "/scripts/build".to_string()]);
+    // the line is kept around so that resolving the plugin for the file
+    // doesn't have to read it a second time
+    assert_eq!(
+      result.shebang_lines,
+      HashMap::from([(PathBuf::from("/scripts/build"), b"#!/bin/sh\n".to_vec())])
+    );
   }
 
   #[tokio::test]

--- a/crates/dprint/src/utils/shebang.rs
+++ b/crates/dprint/src/utils/shebang.rs
@@ -8,15 +8,18 @@ use sys_traits::OpenOptions;
 
 use crate::environment::Environment;
 
-/// Whether the file's first line is a shebang matching one of the configured shebangs.
-pub fn file_has_matching_shebang(environment: &impl Environment, file_path: &Path, shebangs: &[String]) -> bool {
-  let Ok(Some(shebang_line)) = read_file_shebang_line(environment, file_path) else {
-    return false;
+/// Reads the file's first line when it's a shebang matching one of the
+/// configured shebangs, otherwise returns `None`.
+///
+/// The line is returned rather than a bool so the caller can hand it to plugin
+/// resolution instead of the file having to be read a second time.
+pub fn read_matching_shebang_line(environment: &impl Environment, file_path: &Path, shebangs: &[String]) -> Option<Vec<u8>> {
+  let line = read_file_shebang_line(environment, file_path).ok()??;
+  let has_match = match get_shebang_line(&line) {
+    Some(shebang_line) => shebangs.iter().any(|shebang| is_shebang_prefix_match(shebang_line, shebang)),
+    None => false,
   };
-  let Some(shebang_line) = get_shebang_line(&shebang_line) else {
-    return false;
-  };
-  shebangs.iter().any(|shebang| is_shebang_prefix_match(shebang_line, shebang))
+  if has_match { Some(line) } else { None }
 }
 
 /// Reads the first line of a file when it starts with a shebang (`#!`),


### PR DESCRIPTION
Two independent perf changes on the plugin resolution path. The second stacks on the first because both touch `get_file_paths_by_plugins`; happy to split it out if you'd rather review them separately.

All numbers below are hyperfine, 20 runs, warm page cache, `dprint output-file-paths` piped to `/dev/null`, on a synthetic tree of 200 directories × 100 files.

## 1. Only read a shebang file once (`a84cc4b7`)

Follow-up to #1230. An extensionless file that matches a configured shebang was read twice: once on the reader threads to decide whether it matched, and again in `get_plugin_names_for_file_on_disk` to map the shebang to a plugin. The traversal already had the line and discarded it in favour of a bool. The second read is also on the serial path (`get_file_paths_by_plugins`) rather than the parallel reader threads.

The line is now kept in `GlobOutput::shebang_lines` and handed to `get_file_paths_by_plugins`, which still falls back to reading from disk for any path that didn't come from the traversal (ex. outside-base paths).

It also collapses `DirOrConfigEntry::File`/`ShebangFile` into one `File { path, shebang_line }` variant, which removes the `unreachable!()` re-match in the matching processor.

| | before | after |
| --- | --- | --- |
| 20,200 extensionless scripts, all matching a shebang | 68.0 ms ± 0.7 | **42.8 ms ± 0.5** (1.59×) |
| none matching (control) | 16.6 ms ± 0.6 | 16.7 ms ± 0.4 |

`openat` count for the matching case: 40,227 → 20,227.

`should_keep_shebang_lines_of_matched_files` is worth calling out. The first cut of this forgot to merge `results.shebang_lines` into the outer `GlobOutput` in `glob()`, and every existing test still passed — the code silently fell back to re-reading the file. The new test fails without that line.

## 2. Don't allocate per file when resolving plugin names (`c6e1ac43`)

Independent of the shebang feature. Resolving the plugin for a file allocated five times per file, none of which outlive the loop iteration: a `String` for the lowercased file name, another for the lowercased extension, a `Vec` plus a cloned `String` for the plugin name, and a joined `String` for the `FilesPathsByPlugins` key.

- `get_lowercase_file_name`/`get_lowercase_file_extension` return a `Cow` that borrows when the text is already lowercase ascii.
- `get_plugin_names_from_file_path` and friends return `Vec<&str>` borrowed from the resolution maps.
- `PluginNamesBuilder` holds a buffer it reuses to build the map key, handing out a borrowed `PluginNamesKey` that's only turned into an owned `PluginNames` when the key isn't in the map yet.

That leaves one allocation per file (the `Vec`).

| | before | after |
| --- | --- | --- |
| 20,000 `.json` files (resolved by extension) | 29.4 ms ± 0.8 | 28.1 ms ± 0.8 (1.04×) |
| 20,200 shebang scripts (resolved by shebang) | 44.8 ms ± 0.5 | 43.8 ms ± 0.6 (1.02×) |

## Verification

`output-file-paths` output is byte-identical to `main` across configs with no shebangs, non-matching shebangs, file-level excludes, all-matching shebangs, and this repo itself.

`cargo test -p dprint`: 885 passed, 1 failed — `extract_tarball_preserves_exec_bits_via_env_set_permissions`, which is umask-dependent and also fails on a clean `main` here.

## Considered and rejected

`should_check_shebang` gates only on `!shebangs.is_empty() && extension().is_none()`, so the reader threads open extensionless files that the excludes or arg-includes will reject anyway. Gating on `glob_matcher.matches(path)` (sharing the matcher with the readers via `Arc`) measured:

- with file-level excludes: 13.3 → 12.2 ms, `openat` 20,226 → 226
- with nothing excluded: 15.9 → **18.9 ms**

The extra globset match on the reader threads costs more than the saved open/read in the common case, so it's not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgq1v8LsRfYEUaq1qYsoP
