### PR TITLE
perf: match glob patterns on the reader threads

### DIFF
--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -69,7 +69,7 @@ fn global_gitignore_enabled(environment: &impl Environment) -> bool {
 /// Whether `.gitignore` and `.git` are present in a directory the caller has
 /// already listed. Providing this lets resolution skip file system calls for
 /// files it can already tell are absent.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct DirEntriesHint {
   pub has_gitignore: bool,
   pub has_git: bool,

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -808,7 +808,11 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     // derive this before filtering, because the `.gitignore` that the hint is
     // about is itself usually not a file that matches the patterns
     let hint = dir_entries_hint(&entries);
-    let entries = entries.into_iter().filter_map(|e| self.match_entry(e)).collect::<Vec<_>>();
+    // `filter_map` has no useful size hint, so reserve up front rather than
+    // letting the vec grow a directory's worth of entries a few bytes at a time
+    let mut matched = Vec::with_capacity(entries.len());
+    matched.extend(entries.into_iter().filter_map(|e| self.match_entry(e)));
+    let entries = matched;
     if entries.is_empty() {
       return Ok(None); // no directories to descend into and nothing matched
     }

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -640,9 +640,8 @@ struct DirEntries {
   entries: Vec<DirOrConfigEntry>,
 }
 
-/// An entry that made it past the pattern matching done on the reader threads.
-/// All that's left for the matching thread to do is apply the gitignore, which
-/// it resolves lazily and so can't be shared with them.
+/// An entry that made it past the pattern matching done on the reader threads,
+/// leaving only the gitignore for the matching thread to apply.
 enum DirOrConfigEntry {
   Dir {
     path: PathBuf,
@@ -717,8 +716,10 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
       let mut all_entries = Vec::new();
       for current_dir in pending_dirs {
         match self.read_dir_entries(current_dir) {
-          Ok(Some(dir_entries)) => {
-            pending_count += dir_entries.entries.len();
+          Ok(Some((entries_read, dir_entries))) => {
+            // count what was read rather than what matched so that narrow
+            // includes don't stop the readers from handing work over
+            pending_count += entries_read;
             all_entries.push(dir_entries);
             // it is much faster to batch these than to hit the lock every time
             if pending_count > PUSH_DIR_ENTRIES_BATCH_COUNT {
@@ -747,7 +748,7 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
   /// `Ok(None)` means the directory contributed nothing and should be skipped
   /// (it was empty, nothing in it matched, or it couldn't be read for a
   /// non-fatal reason).
-  fn read_dir_entries(&self, current_dir: PathBuf) -> Result<Option<DirEntries>> {
+  fn read_dir_entries(&self, current_dir: PathBuf) -> Result<Option<(usize, DirEntries)>> {
     let entries = match self.environment.dir_info(&current_dir) {
       Ok(entries) => entries,
       Err(err) => {
@@ -764,6 +765,10 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     if entries.is_empty() {
       return Ok(None);
     }
+    let entries_read = entries.len();
+    // derive this before filtering, because the `.gitignore` that the hint is
+    // about is itself usually not a file that matches the patterns
+    let hint = dir_entries_hint(&entries);
     // Note the start directory is exempt from config file detection because the
     // traversal starts there, so a config file in it would take over the entire
     // scope. Usually `current_config_path` already filters it out, but not when
@@ -796,35 +801,33 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     };
     if let Some(config_file) = maybe_config_file {
       let config_file = config_file.clone();
-      return Ok(Some(DirEntries {
-        path: current_dir,
-        // the directory is handed to the scope the config file creates, so
-        // nothing here needs a gitignore
-        hint: DirEntriesHint::default(),
-        entries: vec![DirOrConfigEntry::Config(config_file)],
-      }));
+      return Ok(Some((
+        entries_read,
+        DirEntries {
+          path: current_dir,
+          hint,
+          entries: vec![DirOrConfigEntry::Config(config_file)],
+        },
+      )));
     }
 
-    // derive this before filtering, because the `.gitignore` that the hint is
-    // about is itself usually not a file that matches the patterns
-    let hint = dir_entries_hint(&entries);
-    // `filter_map` has no useful size hint, so reserve up front rather than
-    // letting the vec grow a directory's worth of entries a few bytes at a time
-    let mut matched = Vec::with_capacity(entries.len());
-    matched.extend(entries.into_iter().filter_map(|e| self.match_entry(e)));
-    let entries = matched;
-    if entries.is_empty() {
-      return Ok(None); // no directories to descend into and nothing matched
+    let mut matched_entries = Vec::with_capacity(entries.len());
+    matched_entries.extend(entries.into_iter().filter_map(|e| self.match_entry(e)));
+    if matched_entries.is_empty() {
+      // nothing matched means no `Dir` entry was produced either, so nothing
+      // below this directory is ever traversed and its gitignore is never needed
+      return Ok(None);
     }
-    Ok(Some(DirEntries {
-      path: current_dir,
-      hint,
-      entries,
-    }))
+    Ok(Some((
+      entries_read,
+      DirEntries {
+        path: current_dir,
+        hint,
+        entries: matched_entries,
+      },
+    )))
   }
 
-  /// Matches a directory entry against the patterns, returning `None` when it's
-  /// excluded or doesn't match.
   fn match_entry(&self, entry: DirEntry) -> Option<DirOrConfigEntry> {
     match entry {
       DirEntry::Directory(path) => {
@@ -1191,12 +1194,21 @@ mod test {
     // order dependency) this would catch it.
     let mut builder = TestEnvironmentBuilder::new();
     builder.write_file("/.git/HEAD", "");
-    builder.write_file("/.gitignore", "ignored\n");
+    // `keep.txt` is gitignored so that opting it back in has to beat the
+    // gitignore as well as the exclude
+    builder.write_file("/.gitignore", "ignored\nkeep.txt\n");
     for i in 0..200 {
       builder.write_file(format!("/dir{}/a.txt", i), "");
       builder.write_file(format!("/dir{}/nested/deep/b.txt", i), "");
       // excluded by the root .gitignore
       builder.write_file(format!("/dir{}/ignored/c.txt", i), "");
+      // excluded by the config excludes
+      builder.write_file(format!("/dir{}/skip/d.txt", i), "");
+      // opted back in, which has to beat both the exclude and the gitignore
+      builder.write_file(format!("/dir{}/skip/keep.txt", i), "");
+      // resolved by its shebang rather than by the includes
+      builder.write_file(format!("/dir{}/script", i), "#!/bin/sh\n");
+      builder.write_file(format!("/dir{}/notes", i), "not a script\n");
     }
     let environment = builder.build();
     let root_dir = environment.canonicalize("/").unwrap();
@@ -1209,11 +1221,14 @@ mod test {
           start_dir: PathBuf::from("/"),
           config_discovery: ConfigDiscovery::Default,
           file_patterns: GlobPatterns {
-            shebangs: Vec::new(),
+            shebangs: vec!["#!/bin/sh".to_string()],
             arg_includes: None,
             config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
             arg_excludes: None,
-            config_excludes: Vec::new(),
+            config_excludes: vec![
+              GlobPattern::new("**/skip/**".to_string(), root_dir.clone()),
+              GlobPattern::new("!**/skip/keep.txt".to_string(), root_dir.clone()),
+            ],
           },
           pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
           no_gitignore: false,
@@ -1228,10 +1243,49 @@ mod test {
     let serial = run("1");
     let parallel = run("16");
     assert_eq!(serial, parallel);
-    // sanity: matched a.txt and nested/deep/b.txt for each dir, and the
-    // gitignored files were excluded
-    assert_eq!(serial.len(), 400);
+    // a.txt, nested/deep/b.txt, skip/keep.txt and the shebang script per dir
+    assert_eq!(serial.len(), 800);
     assert!(serial.iter().all(|p| !p.contains("ignored")));
+    assert_eq!(serial.iter().filter(|p| p.ends_with("/skip/keep.txt")).count(), 200);
+    assert_eq!(serial.iter().filter(|p| p.ends_with("/skip/d.txt")).count(), 0);
+    assert_eq!(serial.iter().filter(|p| p.ends_with("/script")).count(), 200);
+    assert_eq!(serial.iter().filter(|p| p.ends_with("/notes")).count(), 0);
+  }
+
+  #[tokio::test]
+  async fn should_skip_a_directory_where_nothing_matched() {
+    // `/sub` yields no entries at all after matching: the gitignore doesn't
+    // match the includes, the binary doesn't either, and `skip` is excluded. it
+    // gets dropped on the reader thread, which is only safe because dropping it
+    // also means nothing below it is ever traversed.
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/a.txt", "")
+      .write_file("/sub/.gitignore", "whatever\n")
+      .write_file("/sub/only.bin", "")
+      .write_file("/sub/skip/b.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        current_config_path: None,
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          shebangs: Vec::new(),
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir.clone())]),
+          arg_excludes: None,
+          config_excludes: vec![GlobPattern::new("**/skip".to_string(), root_dir)],
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+
+    let result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    assert_eq!(result, vec!["/a.txt"]);
   }
 
   #[tokio::test]

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -113,14 +113,14 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
     ))
   };
   let shebangs = opts.file_patterns.shebangs.clone();
-  let glob_matcher = GlobMatcher::new(
+  let glob_matcher = Arc::new(GlobMatcher::new(
     opts.file_patterns,
     &GlobMatcherOptions {
       // make it work the same way on every operating system
       case_sensitive: true,
       base_dir: opts.pattern_base.clone(),
     },
-  )?;
+  )?);
 
   let mut output = GlobOutput {
     outside_base_paths: literal_arg_paths.outside_base_paths,
@@ -211,6 +211,7 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
     let read_dir_runner = Arc::new(ReadDirRunner::new(
       environment.clone(),
       shared_state.clone(),
+      glob_matcher.clone(),
       ReadDirRunnerOptions {
         start_dir: opts.start_dir,
         config_discovery: opts.config_discovery,
@@ -225,7 +226,7 @@ pub fn glob(environment: &impl Environment, mut opts: GlobOptions) -> Result<Glo
     }
 
     // run the glob matching on the current thread (it communicates with the reader threads)
-    let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, glob_matcher, git_ignore_tree);
+    let mut glob_matching_processor = GlobMatchingProcessor::new(shared_state, git_ignore_tree);
     let results = glob_matching_processor.run()?;
     output.file_paths.extend(results.file_paths);
     output.shebang_lines.extend(results.shebang_lines);
@@ -632,13 +633,24 @@ fn resolve_read_dir_thread_count(environment: &impl Environment) -> usize {
 
 struct DirEntries {
   path: PathBuf,
+  /// Derived from the full directory listing on the reader thread, since the
+  /// entries below have already had the non-matching ones (usually including
+  /// the `.gitignore` itself) filtered out.
+  hint: DirEntriesHint,
   entries: Vec<DirOrConfigEntry>,
 }
 
+/// An entry that made it past the pattern matching done on the reader threads.
+/// All that's left for the matching thread to do is apply the gitignore, which
+/// it resolves lazily and so can't be shared with them.
 enum DirOrConfigEntry {
-  Dir(PathBuf),
+  Dir {
+    path: PathBuf,
+    check_gitignore: bool,
+  },
   File {
     path: PathBuf,
+    check_gitignore: bool,
     /// The first line of an extensionless file when it matches a configured
     /// shebang, which the matching thread hands to plugin resolution.
     shebang_line: Option<Vec<u8>>,
@@ -648,22 +660,21 @@ enum DirOrConfigEntry {
 }
 
 /// Derives a gitignore resolution hint from an already-read directory listing.
-fn dir_entries_hint(entries: &[DirOrConfigEntry]) -> DirEntriesHint {
+fn dir_entries_hint(entries: &[DirEntry]) -> DirEntriesHint {
   let mut hint = DirEntriesHint {
     has_git: false,
     has_gitignore: false,
   };
   for entry in entries {
-    match entry {
-      DirOrConfigEntry::Dir(path) | DirOrConfigEntry::File { path, .. } => {
-        match path.file_name().and_then(|f| f.to_str()) {
-          // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
-          Some(".gitignore") => hint.has_gitignore = true,
-          Some(".git") => hint.has_git = true,
-          _ => continue,
-        }
-      }
-      DirOrConfigEntry::Config(_) => continue,
+    let name = match entry {
+      // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
+      DirEntry::Directory(path) => path.file_name().and_then(|f| f.to_str()),
+      DirEntry::File { name, .. } => name.to_str(),
+    };
+    match name {
+      Some(".gitignore") => hint.has_gitignore = true,
+      Some(".git") => hint.has_git = true,
+      _ => continue,
     }
     if hint.has_gitignore && hint.has_git {
       break; // nothing left to learn
@@ -686,14 +697,16 @@ struct ReadDirRunnerOptions {
 struct ReadDirRunner<TEnvironment: Environment> {
   environment: TEnvironment,
   shared_state: Arc<SharedState>,
+  glob_matcher: Arc<GlobMatcher>,
   options: ReadDirRunnerOptions,
 }
 
 impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
-  pub fn new(environment: TEnvironment, shared_state: Arc<SharedState>, options: ReadDirRunnerOptions) -> Self {
+  pub fn new(environment: TEnvironment, shared_state: Arc<SharedState>, glob_matcher: Arc<GlobMatcher>, options: ReadDirRunnerOptions) -> Self {
     Self {
       environment,
       shared_state,
+      glob_matcher,
       options,
     }
   }
@@ -703,10 +716,10 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
       let mut pending_count = 0;
       let mut all_entries = Vec::new();
       for current_dir in pending_dirs {
-        match self.read_dir_entries(&current_dir) {
-          Ok(Some(entries)) => {
-            pending_count += entries.len();
-            all_entries.push(DirEntries { path: current_dir, entries });
+        match self.read_dir_entries(current_dir) {
+          Ok(Some(dir_entries)) => {
+            pending_count += dir_entries.entries.len();
+            all_entries.push(dir_entries);
             // it is much faster to batch these than to hit the lock every time
             if pending_count > PUSH_DIR_ENTRIES_BATCH_COUNT {
               self.push_entries(std::mem::take(&mut all_entries));
@@ -724,15 +737,21 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     }
   }
 
-  /// Reads a single directory, returning its entries to be matched.
+  /// Reads a single directory and matches its entries against the patterns.
+  ///
+  /// The matching happens here rather than on the thread that consumes these
+  /// because these threads run in parallel and it's the bulk of the per entry
+  /// work. Only the gitignore is left to the consumer, since resolving one
+  /// caches lazily up the directory tree and so can't be shared.
   ///
   /// `Ok(None)` means the directory contributed nothing and should be skipped
-  /// (it was empty or couldn't be read for a non-fatal reason).
-  fn read_dir_entries(&self, current_dir: &Path) -> Result<Option<Vec<DirOrConfigEntry>>> {
-    let entries = match self.environment.dir_info(current_dir) {
+  /// (it was empty, nothing in it matched, or it couldn't be read for a
+  /// non-fatal reason).
+  fn read_dir_entries(&self, current_dir: PathBuf) -> Result<Option<DirEntries>> {
+    let entries = match self.environment.dir_info(&current_dir) {
       Ok(entries) => entries,
       Err(err) => {
-        if is_system_volume_error(current_dir, &err) {
+        if is_system_volume_error(&current_dir, &err) {
           return Ok(None);
         }
         if err.kind() == std::io::ErrorKind::PermissionDenied {
@@ -776,22 +795,61 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
       None
     };
     if let Some(config_file) = maybe_config_file {
-      Ok(Some(vec![DirOrConfigEntry::Config(config_file.clone())]))
-    } else {
-      Ok(Some(
-        entries
-          .into_iter()
-          .map(|e| match e {
-            DirEntry::Directory(path) => DirOrConfigEntry::Dir(path),
-            DirEntry::File { path, .. } => {
-              // check for a shebang here since these threads run in parallel
-              // and reading the file is I/O bound
-              let shebang_line = self.maybe_read_shebang_line(&path);
-              DirOrConfigEntry::File { path, shebang_line }
-            }
-          })
-          .collect::<Vec<_>>(),
-      ))
+      let config_file = config_file.clone();
+      return Ok(Some(DirEntries {
+        path: current_dir,
+        // the directory is handed to the scope the config file creates, so
+        // nothing here needs a gitignore
+        hint: DirEntriesHint::default(),
+        entries: vec![DirOrConfigEntry::Config(config_file)],
+      }));
+    }
+
+    // derive this before filtering, because the `.gitignore` that the hint is
+    // about is itself usually not a file that matches the patterns
+    let hint = dir_entries_hint(&entries);
+    let entries = entries.into_iter().filter_map(|e| self.match_entry(e)).collect::<Vec<_>>();
+    if entries.is_empty() {
+      return Ok(None); // no directories to descend into and nothing matched
+    }
+    Ok(Some(DirEntries {
+      path: current_dir,
+      hint,
+      entries,
+    }))
+  }
+
+  /// Matches a directory entry against the patterns, returning `None` when it's
+  /// excluded or doesn't match.
+  fn match_entry(&self, entry: DirEntry) -> Option<DirOrConfigEntry> {
+    match entry {
+      DirEntry::Directory(path) => {
+        if path.file_name().map(|f| f == ".git").unwrap_or(false) {
+          return None;
+        }
+        let check_gitignore = match self.glob_matcher.is_dir_ignored(&path) {
+          ExcludeMatchDetail::Excluded => return None,
+          // an explicitly opted out exclude takes precedence over the gitignore
+          ExcludeMatchDetail::OptedOutExclude => false,
+          ExcludeMatchDetail::NotExcluded => true,
+        };
+        Some(DirOrConfigEntry::Dir { path, check_gitignore })
+      }
+      DirEntry::File { path, .. } => {
+        // read the shebang here too since these threads run in parallel and
+        // reading the file is I/O bound
+        let shebang_line = self.maybe_read_shebang_line(&path);
+        let check_gitignore = match self.glob_matcher.matches_detail_with_shebang_checked(&path, shebang_line.is_some()) {
+          GlobMatchesDetail::Excluded | GlobMatchesDetail::NotMatched => return None,
+          GlobMatchesDetail::Matched => true,
+          GlobMatchesDetail::MatchedOptedOutExclude => false,
+        };
+        Some(DirOrConfigEntry::File {
+          path,
+          check_gitignore,
+          shebang_line,
+        })
+      }
     }
   }
 
@@ -882,17 +940,12 @@ fn is_system_volume_error(dir_path: &Path, err: &std::io::Error) -> bool {
 
 struct GlobMatchingProcessor<TEnvironment: Environment> {
   shared_state: Arc<SharedState>,
-  glob_matcher: GlobMatcher,
   git_ignore_tree: Option<GitIgnoreTree<TEnvironment>>,
 }
 
 impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
-  pub fn new(shared_state: Arc<SharedState>, glob_matcher: GlobMatcher, git_ignore_tree: Option<GitIgnoreTree<TEnvironment>>) -> Self {
-    Self {
-      shared_state,
-      glob_matcher,
-      git_ignore_tree,
-    }
+  pub fn new(shared_state: Arc<SharedState>, git_ignore_tree: Option<GitIgnoreTree<TEnvironment>>) -> Self {
+    Self { shared_state, git_ignore_tree }
   }
 
   pub fn run(&mut self) -> Result<GlobOutput> {
@@ -907,41 +960,27 @@ impl<TEnvironment: Environment> GlobMatchingProcessor<TEnvironment> {
         Ok(Some(entries)) => {
           for dir in entries.into_iter().flatten() {
             // reuse the directory listing we already have to avoid extra file system calls
-            let dir_hint = dir_entries_hint(&dir.entries);
             let gitignore = self
               .git_ignore_tree
               .as_mut()
-              .and_then(|t| t.get_resolved_git_ignore_for_dir_children(&dir.path, dir_hint));
+              .and_then(|t| t.get_resolved_git_ignore_for_dir_children(&dir.path, dir.hint));
+            let is_gitignored = |path: &Path, check_gitignore: bool, is_dir: bool| match &gitignore {
+              Some(gitignore) if check_gitignore => gitignore.is_ignored(path, is_dir),
+              _ => false,
+            };
             for entry in dir.entries {
               match entry {
-                DirOrConfigEntry::Dir(path) => {
-                  let is_ignored = match self.glob_matcher.is_dir_ignored(&path) {
-                    ExcludeMatchDetail::Excluded => true,
-                    ExcludeMatchDetail::OptedOutExclude => false,
-                    ExcludeMatchDetail::NotExcluded => match &gitignore {
-                      Some(gitignore) => {
-                        gitignore.is_ignored(&path, /* is dir */ true)
-                      }
-                      None => false,
-                    },
-                  } || path.file_name().map(|f| f == ".git").unwrap_or(false);
-                  if !is_ignored {
+                DirOrConfigEntry::Dir { path, check_gitignore } => {
+                  if !is_gitignored(&path, check_gitignore, /* is dir */ true) {
                     pending_dirs.push(path);
                   }
                 }
-                DirOrConfigEntry::File { path, shebang_line } => {
-                  let is_matched = match self.glob_matcher.matches_detail_with_shebang_checked(&path, shebang_line.is_some()) {
-                    GlobMatchesDetail::Excluded => false,
-                    GlobMatchesDetail::Matched => match &gitignore {
-                      Some(gitignore) => {
-                        !gitignore.is_ignored(&path, /* is dir */ false)
-                      }
-                      None => true,
-                    },
-                    GlobMatchesDetail::MatchedOptedOutExclude => true,
-                    GlobMatchesDetail::NotMatched => false,
-                  };
-                  if is_matched {
+                DirOrConfigEntry::File {
+                  path,
+                  check_gitignore,
+                  shebang_line,
+                } => {
+                  if !is_gitignored(&path, check_gitignore, /* is dir */ false) {
                     if let Some(shebang_line) = shebang_line {
                       output.shebang_lines.insert(path.clone(), shebang_line);
                     }
@@ -1189,6 +1228,40 @@ mod test {
     // gitignored files were excluded
     assert_eq!(serial.len(), 400);
     assert!(serial.iter().all(|p| !p.contains("ignored")));
+  }
+
+  #[tokio::test]
+  async fn should_respect_gitignore_that_doesnt_match_the_patterns() {
+    // the `.gitignore` itself doesn't match the includes, so it's filtered out
+    // before the matching thread sees the directory listing. its presence still
+    // has to be reported so the gitignore gets read.
+    let environment = TestEnvironmentBuilder::new()
+      .write_file("/sub/.gitignore", "ignored\n")
+      .write_file("/sub/ignored/a.txt", "")
+      .write_file("/sub/keep/b.txt", "")
+      .build();
+    let root_dir = environment.canonicalize("/").unwrap();
+    let result = glob(
+      &environment,
+      GlobOptions {
+        current_config_path: None,
+        start_dir: PathBuf::from("/"),
+        config_discovery: ConfigDiscovery::Default,
+        file_patterns: GlobPatterns {
+          shebangs: Vec::new(),
+          arg_includes: None,
+          config_includes: Some(vec![GlobPattern::new("**/*.txt".to_string(), root_dir)]),
+          arg_excludes: None,
+          config_excludes: Vec::new(),
+        },
+        pattern_base: CanonicalizedPathBuf::new_for_testing("/"),
+        no_gitignore: false,
+      },
+    )
+    .unwrap();
+
+    let result = result.file_paths.into_iter().map(|r| r.to_string_lossy().to_string()).collect::<Vec<_>>();
+    assert_eq!(result, vec!["/sub/keep/b.txt"]);
   }
 
   #[tokio::test]

--- a/crates/dprint/src/utils/shebang.rs
+++ b/crates/dprint/src/utils/shebang.rs
@@ -44,7 +44,6 @@ pub fn read_file_shebang_line(environment: &impl Environment, file_path: &Path) 
   // (ex. a binary file that happens to start with `#!`). This is well above
   // the kernel's shebang line limit.
   const MAX_SHEBANG_LINE_LEN: usize = 4096;
-  // sized to fit a typical shebang line so `read_until` doesn't grow it
   let mut line = Vec::with_capacity(64);
   line.extend_from_slice(&start);
   reader


### PR DESCRIPTION
The reader threads only listed directories; everything else ran on the single matching thread, which made it the bottleneck. Reading is I/O bound, so the readers had spare capacity while the matching thread ran the include/exclude patterns for every entry in the tree.

This moves the pattern matching into `ReadDirRunner`, sharing the `GlobMatcher` across the readers with an `Arc` (it's immutable once built). Entries that don't match are dropped there, so they never cross the lock. What's left for the matching thread is resolving the gitignore, which caches lazily up the directory tree and so has to stay single threaded.

Two things had to move with it:

- The gitignore hint now comes from the full directory listing rather than from the entries that survived matching, because the `.gitignore` the hint is about is usually not a file that matches the patterns. `should_respect_gitignore_that_doesnt_match_the_patterns` covers this — it fails if the hint is derived after filtering.
- `DirOrConfigEntry` carries a `check_gitignore` flag rather than the matcher's `GlobMatchesDetail`/`ExcludeMatchDetail`, since an explicitly opted-out exclude takes precedence over the gitignore.

## DefinitelyTyped

60,530 matched files across 13,727 directories, `--config` with the typescript, json and markdown plugins. hyperfine, 20 runs, warm page cache:

| | before | after |
| --- | --- | --- |
| `dprint output-file-paths` | 120.3 ms ± 0.9 | **90.5 ms ± 0.9** (1.33×) |

Scaling over `DPRINT_GLOB_READ_THREADS` on the same repo shows where the bottleneck was — before this change, adding readers past 2 bought nothing at all:

| readers | before | after |
| --- | --- | --- |
| 1 | 140.3 ms | 172.3 ms |
| 2 | 119.5 ms | 122.5 ms |
| 4 | 119.7 ms | 94.7 ms |
| 8 (default) | 120.4 ms | 90.1 ms |
| 16 | 123.8 ms | 94.5 ms |

## Synthetic trees

Same method:

| tree | before | after |
| --- | --- | --- |
| 20,000 `.json` in 200 dirs | 28.3 ms ± 1.0 | **20.0 ms ± 0.2** (1.41×) |
| 20,000 `.json` in 1 dir | 41.6 ms ± 3.5 | 36.9 ms ± 1.7 (1.13×) |
| 20,200 extensionless, no shebang match | 16.7 ms ± 0.8 | **13.3 ms ± 0.3** (1.26×) |
| 20,200 extensionless, all matching a shebang | 43.9 ms ± 0.5 | **35.1 ms ± 0.7** (1.25×) |

Unlike the previous two PRs this isn't specific to the shebangs feature — it speeds up every glob.

## Caveat: `DPRINT_GLOB_READ_THREADS=1`

Forcing a single reader is ~23% slower. It isn't extra work — total cpu is unchanged (117.5 user + 79.9 sys before, 117.6 + 82.0 after) — it's lost overlap. With one reader, `main` had two threads busy: the reader in `read_dir` while the matching thread ran globset over the previous batch. Now one thread does both stages and the matching thread has almost nothing left, since DefinitelyTyped has 3 `.gitignore` files in 13,727 directories. Average threads busy drops from 1.40 to 1.16; at 8 readers it rises from 1.67 to 2.38, which is where the win comes from.

It's break-even at 2 readers and wins from 4 up. The default is a fixed 8 regardless of core count, so a single reader is only reachable by setting the env var explicitly, and I didn't think it was worth branching the code to special-case. Shout if you'd rather it did.

## Verification

`output-file-paths` output is byte-identical to `main` on DefinitelyTyped, on this repo with its real `.gitignore`s, on 20k `.json` in 200 dirs and in 1 dir, and on the extensionless tree under four configs (no shebangs / non-matching shebangs / file-level excludes / all matching). Also identical at `DPRINT_GLOB_READ_THREADS=1` and `=8`.

`cargo test -p dprint`: 886 passed, 1 failed — `extract_tarball_preserves_exec_bits_via_env_set_permissions`, which is umask-dependent and also fails on a clean `main` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZgq1v8LsRfYEUaq1qYsoP
