### PR TITLE
ci: generate release notes changes from the previous tag

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -507,6 +507,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -508,6 +508,30 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Generate changelog
+        id: changelog
+        run: |-
+          previous_tag="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
+          if [ -n "$previous_tag" ]; then
+            echo "Collecting commits since $previous_tag"
+            range="$previous_tag..HEAD"
+          else
+            echo "No previous tag found -- using full history"
+            range=HEAD
+          fi
+          {
+            echo "changelog<<CHANGELOG_EOF"
+            git log --reverse --pretty=format:%s "$range" \
+              | grep -Ev '^(chore|refactor)(\([^)]*\))?!?: ' \
+              | grep -Ev '^[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sed 's/^/* /'
+            echo ""
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Download artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
       - name: Output checksums
@@ -576,7 +600,7 @@ jobs:
           body: |
             ## Changes
 
-            * TODO
+            ${{ steps.changelog.outputs.changelog }}
 
             ## Install
 

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run -A
 import $ from "jsr:@david/dax@0.45.0";
-import { conditions, defineMatrix, expr, type ExpressionValue, isLinting, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { conditions, defineMatrix, expr, type ExpressionValue, isLinting, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 enum OperatingSystem {
   Mac = "macOS-latest",
@@ -506,11 +506,13 @@ const draftReleaseJob = job("draft_release", {
   needs: [buildJob],
   if: isTag,
   // contents: drafting the release. id-token + attestations: signing the
-  // build provenance attestation.
+  // build provenance attestation. artifact-metadata: creating the artifact
+  // storage record, which actions/attest documents as required.
   permissions: {
     contents: "write",
     "id-token": "write",
     attestations: "write",
+    "artifact-metadata": "write",
   },
   steps: [
     // must come before the artifact download -- checkout wipes the workspace

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -472,6 +472,34 @@ const buildJob = job("build", {
 
 // === draft_release job ===
 
+// Builds the "## Changes" list from the commits between the previous release
+// tag and the tag being released. chore/refactor commits and the version bump
+// commit itself are noise in release notes, so they're filtered out.
+const changelog = step({
+  name: "Generate changelog",
+  id: "changelog",
+  run: [
+    `previous_tag="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"`,
+    `if [ -n "$previous_tag" ]; then`,
+    `  echo "Collecting commits since $previous_tag"`,
+    `  range="$previous_tag..HEAD"`,
+    `else`,
+    `  echo "No previous tag found -- using full history"`,
+    `  range=HEAD`,
+    `fi`,
+    `{`,
+    `  echo "changelog<<CHANGELOG_EOF"`,
+    `  git log --reverse --pretty=format:%s "$range" \\`,
+    `    | grep -Ev '^(chore|refactor)(\\([^)]*\\))?!?: ' \\`,
+    `    | grep -Ev '^[0-9]+\\.[0-9]+\\.[0-9]+$' \\`,
+    `    | sed 's/^/* /'`,
+    `  echo ""`,
+    `  echo "CHANGELOG_EOF"`,
+    `} >> "$GITHUB_OUTPUT"`,
+  ],
+  outputs: ["changelog"] as const,
+});
+
 const draftReleaseJob = job("draft_release", {
   name: "draft_release",
   runsOn: "ubuntu-latest",
@@ -485,6 +513,15 @@ const draftReleaseJob = job("draft_release", {
     attestations: "write",
   },
   steps: [
+    // must come before the artifact download -- checkout wipes the workspace
+    // when it isn't already a git repo. Full history so the changelog step can
+    // reach the previous tag.
+    step({
+      name: "Clone repository",
+      uses: "actions/checkout@v6",
+      with: { "fetch-depth": 0 },
+    }),
+    changelog,
     step({
       name: "Download artifacts",
       uses: "actions/download-artifact@v6",
@@ -544,7 +581,7 @@ const draftReleaseJob = job("draft_release", {
         ].join("\n"),
         body: `## Changes
 
-* TODO
+${changelog.outputs.changelog}
 
 ## Install
 

--- a/.github/workflows/publish.ts
+++ b/.github/workflows/publish.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { artifact, defineMatrix, expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { artifact, defineMatrix, expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 const isDprintRepo = "github.repository == 'dprint/dprint'";
 const npmDist = artifact("npm-dist");

--- a/.github/workflows/publish_crate_core-macros.ts
+++ b/.github/workflows/publish_crate_core-macros.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 workflow({
   name: "cargo publish core-macros crate",

--- a/.github/workflows/publish_crate_core.ts
+++ b/.github/workflows/publish_crate_core.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 workflow({
   name: "cargo publish core crate",

--- a/.github/workflows/publish_crate_dev.ts
+++ b/.github/workflows/publish_crate_dev.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 workflow({
   name: "cargo publish development crate",

--- a/.github/workflows/release.ts
+++ b/.github/workflows/release.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 workflow({
   name: "Release",

--- a/.github/workflows/website.ts
+++ b/.github/workflows/website.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { expr, job, step, workflow } from "jsr:@david/gagen@0.5.0";
+import { expr, job, step, workflow } from "jsr:@david/gagen@0.6.0";
 
 const buildSteps = step(
   { name: "Checkout", uses: "actions/checkout@v6", with: { "persist-credentials": false } },


### PR DESCRIPTION
Replaces the `* TODO` placeholder in the drafted release notes with a list generated from the commits between the previous release tag and the tag being released.

### Changes to `draft_release`

- **Added a `Clone repository` step** with `fetch-depth: 0`. The job previously had no checkout, and the changelog needs history plus tags. It must run *before* `Download artifacts` — `actions/checkout` wipes the workspace when it isn't already a git repo — so there's a comment on the step to keep it from being reordered.
- **Added a `Generate changelog` step** that collects `$(git describe --tags --abbrev=0 HEAD^)..HEAD`, falling back to full history when no previous tag exists.

Filtered out: `chore` and `refactor` commits (including scoped and `!` breaking variants), plus the bare version bump commit that carries the tag.

### Dry run

Against real history, simulating the 0.57.0 release:

```
Collecting commits since 0.56.1
* feat: add `dprint check --json` flag (#1231)
* feat: add `--diff-format unified` to `dprint check` and `dprint fmt --diff` (#1232)
* feat: add --minimum-dependency-age for config add/update/init (#1228)
* feat: add a shebangs config for routing extensionless scripts to a plugin (#1230)
* perf: cheaper per-file plugin resolution (#1233)
* perf: match glob patterns on the reader threads (#1234)
* docs(playground): ensure stable formatting output (#1235)
```

Also verified the all-filtered-out case (a release containing only chore commits): the pipeline still exits 0 under `bash -e` and writes a well-formed empty heredoc, so the step won't fail.

### Open question

That output is one line off the published 0.57.0 notes — the `docs(playground)` commit was excluded by hand. Recent releases look like they drop `docs:` and `ci:` as well, not just chore/refactor. Easy to add those to the filter if that's the intent.

### Note

Since this only affects the `draft_release` job, which is gated behind `if: isTag`, CI on this PR does not exercise it. The changelog step was validated by running its script directly against this repo's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115RfENz1eSydQGpfGx2oim
