### PR TITLE
fix: recommend `--minimum-dependency-age=0` when an older version is selected

### DIFF
--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -1796,7 +1796,7 @@ mod test {
     let stderr = environment.take_stderr_messages();
     assert!(
       stderr.iter().any(|m| m
-        .contains("Using @dprint/test-plugin 0.2.0 instead of 0.3.0, which is newer than the minimum dependency age allows (min-release-age=3 in .npmrc).")),
+        .contains("Using @dprint/test-plugin 0.2.0 instead of 0.3.0, which is newer than the minimum dependency age allows (min-release-age=3 in .npmrc). Pass --minimum-dependency-age=0 to use the latest version.")),
       "got: {stderr:?}"
     );
     environment.take_stdout_messages();
@@ -4282,7 +4282,7 @@ text",
     let stderr = environment.take_stderr_messages();
     assert!(
       stderr.iter().any(|m| m
-        .contains("Using @dprint/test-plugin 0.2.0 instead of 0.3.0, which is newer than the minimum dependency age allows (min-release-age=3 in .npmrc).")),
+        .contains("Using @dprint/test-plugin 0.2.0 instead of 0.3.0, which is newer than the minimum dependency age allows (min-release-age=3 in .npmrc). Pass --minimum-dependency-age=0 to use the latest version.")),
       "got: {stderr:?}"
     );
     let _ = environment.take_stdout_messages();

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -1061,7 +1061,7 @@ mod test {
       // 1.1.0 landed the day before "now", so the release before it is written
       assert!(text.contains("\"npm:@dprint/a@1.0.0\""), "{text}");
       let mut expected_messages = get_standard_logged_messages_no_plugin_selection();
-      expected_messages.push("Using @dprint/a 1.0.0 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D).");
+      expected_messages.push("Using @dprint/a 1.0.0 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D). Pass --minimum-dependency-age=0 to use the latest version.");
       assert_eq!(environment.take_stderr_messages(), expected_messages);
     });
   }

--- a/crates/dprint/src/plugins/npm_resolution.rs
+++ b/crates/dprint/src/plugins/npm_resolution.rs
@@ -326,7 +326,7 @@ fn select_version_from_packument(
       }
       log_stderr_info!(
         environment,
-        "Using {} {} instead of {}, which is newer than the minimum dependency age allows ({}).",
+        "Using {} {} instead of {}, which is newer than the minimum dependency age allows ({}). Pass --minimum-dependency-age=0 to use the latest version.",
         name,
         version,
         latest,
@@ -1578,7 +1578,7 @@ mod tests {
     assert_eq!(version.unwrap(), "1.0.1");
     assert_eq!(
       logged,
-      vec!["Using foo 1.0.1 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D).".to_string()]
+      vec!["Using foo 1.0.1 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D). Pass --minimum-dependency-age=0 to use the latest version.".to_string()]
     );
   }
 
@@ -1619,7 +1619,7 @@ mod tests {
       logged,
       vec![
         "Could not check the age of foo@1.0.5 — its registry doesn't report when it was published. Using it anyway.".to_string(),
-        "Using foo 1.0.5 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D).".to_string(),
+        "Using foo 1.0.5 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age P3D). Pass --minimum-dependency-age=0 to use the latest version.".to_string(),
       ]
     );
   }
@@ -1767,7 +1767,7 @@ mod tests {
     assert_eq!(version.unwrap(), "1.0.0");
     assert_eq!(
       logged,
-      vec!["Using foo 1.0.0 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age 2024-05-05).".to_string()]
+      vec!["Using foo 1.0.0 instead of 1.1.0, which is newer than the minimum dependency age allows (--minimum-dependency-age 2024-05-05). Pass --minimum-dependency-age=0 to use the latest version.".to_string()]
     );
   }
 


### PR DESCRIPTION
When the minimum dependency age causes an older version to be resolved, the message now tells you how to override it:

> Using @dprint/markdown 0.23.2 instead of 0.23.3, which is newer than the minimum dependency age allows (min-release-age=3 in .npmrc). Pass --minimum-dependency-age=0 to use the latest version.