### PR TITLE
fix: scan hidden directories with `dprint init`

### DIFF
--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -16,7 +16,11 @@ use crate::plugins::ResolveNpmLatestOptions;
 use crate::plugins::read_info_file;
 use crate::plugins::resolve_dependency_age_cutoff;
 use crate::utils::DependencyAgeCutoff;
+use crate::utils::DirEntriesHint;
+use crate::utils::GitIgnoreTree;
+use crate::utils::GitIgnoreTreeOptions;
 use crate::utils::MinimumDependencyAgeArg;
+use crate::utils::resolve_global_gitignore_lines;
 
 /// Maximum number of files to look at when scanning the current directory to
 /// decide which plugins to pre-select. Keeps `dprint init` fast in large repos.
@@ -404,14 +408,23 @@ fn deep_merge(base: &mut serde_json::Value, other: serde_json::Value) {
 }
 
 /// Scans the current directory for files in order to decide which plugins to
-/// pre-select. The scan is bounded by [`MAX_SCAN_FILES`] and [`MAX_SCAN_DIRS`]
-/// to stay fast in large repositories and best-effort ignores errors.
+/// pre-select. Files and directories the gitignore excludes are skipped, as
+/// are the directories in [`is_ignored_dir`]. The scan is bounded by
+/// [`MAX_SCAN_FILES`] and [`MAX_SCAN_DIRS`] to stay fast in large repositories
+/// and best-effort ignores errors.
 fn scan_project_files(environment: &impl Environment) -> ProjectFiles {
   let mut extensions = HashSet::new();
   let mut file_names = HashSet::new();
   let mut files_remaining = MAX_SCAN_FILES;
   let mut dirs_remaining = MAX_SCAN_DIRS;
   let mut pending_dirs = VecDeque::from([environment.cwd().into_path_buf()]);
+  let mut gitignores = GitIgnoreTree::new(
+    environment.clone(),
+    GitIgnoreTreeOptions {
+      include_paths: Vec::new(),
+      global_gitignore_lines: resolve_global_gitignore_lines(environment),
+    },
+  );
 
   'outer: while let Some(dir) = pending_dirs.pop_front() {
     if dirs_remaining == 0 {
@@ -421,14 +434,22 @@ fn scan_project_files(environment: &impl Environment) -> ProjectFiles {
     let Ok(entries) = environment.dir_info(&dir) else {
       continue; // best-effort: skip directories we can't read
     };
+    let gitignore = gitignores.get_resolved_git_ignore_for_dir_children(&dir, DirEntriesHint::from_dir_entries(&entries));
+    let is_ignored = |path: &PathBuf, is_dir: bool| gitignore.as_ref().is_some_and(|gitignore| gitignore.is_ignored(path, is_dir));
     for entry in entries {
       match entry {
         DirEntry::Directory(path) => {
-          if path.file_name().and_then(|name| name.to_str()).is_some_and(|name| !is_ignored_dir(name)) {
+          let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+          };
+          if !is_ignored_dir(name) && !is_ignored(&path, true) {
             pending_dirs.push_back(path);
           }
         }
         DirEntry::File { name, path } => {
+          if is_ignored(&path, false) {
+            continue;
+          }
           if files_remaining == 0 {
             break 'outer;
           }
@@ -445,10 +466,11 @@ fn scan_project_files(environment: &impl Environment) -> ProjectFiles {
   ProjectFiles { extensions, file_names }
 }
 
-/// Directories that are skipped while scanning. Hidden directories (those
-/// starting with a dot) are always skipped.
+/// Directories that are skipped while scanning. Hidden directories other than
+/// `.git` are scanned because they may hold files worth formatting (ex.
+/// `.github/workflows`), and the ones that don't are usually gitignored.
 fn is_ignored_dir(name: &str) -> bool {
-  name.starts_with('.') || matches!(name, "node_modules" | "target" | "vendor" | "dist" | "build" | "out" | "bin" | "obj")
+  matches!(name, ".git" | "node_modules" | "target" | "vendor" | "dist" | "build" | "out" | "bin" | "obj")
 }
 
 /// Gets the unique items in the vector in the same order
@@ -1282,6 +1304,53 @@ mod test {
       // matching files only exist within ignored directories
       .write_file("/node_modules/dep/app.ts", "")
       .write_file("/.git/hooks/config.json", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
+      assert_eq!(
+        text,
+        r#"{
+  "excludes": [],
+  "plugins": [
+    // specify plugin urls here
+  ]
+}
+"#
+      );
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_scan_files_in_hidden_directories() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      // hidden directories other than `.git` may hold files worth formatting
+      .write_file("/.github/renovate.json", "")
+      .build();
+    environment.clone().run_in_runtime(async move {
+      let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();
+      assert!(text.contains("https://plugins.dprint.dev/json-0.2.3.wasm"), "{text}");
+      assert_eq!(environment.take_stderr_messages(), get_standard_logged_messages());
+    });
+  }
+
+  #[test]
+  fn should_not_scan_gitignored_files() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        for plugin in get_multi_plugins_config() {
+          info.add_plugin(plugin);
+        }
+      })
+      .write_file("/.gitignore", "generated/\nlock.json\n")
+      // matching files only exist where the gitignore excludes them
+      .write_file("/generated/app.ts", "")
+      .write_file("/lock.json", "")
       .build();
     environment.clone().run_in_runtime(async move {
       let text = get_init_config_file_text(&environment, Default::default()).await.unwrap();

--- a/crates/dprint/src/utils/gitignore.rs
+++ b/crates/dprint/src/utils/gitignore.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use crate::environment::DirEntry;
 use crate::environment::Environment;
 use crate::utils::escape_glob_text;
 
@@ -73,6 +74,32 @@ fn global_gitignore_enabled(environment: &impl Environment) -> bool {
 pub struct DirEntriesHint {
   pub has_gitignore: bool,
   pub has_git: bool,
+}
+
+impl DirEntriesHint {
+  /// Derives a hint from an already-read directory listing.
+  pub fn from_dir_entries(entries: &[DirEntry]) -> Self {
+    let mut hint = DirEntriesHint {
+      has_git: false,
+      has_gitignore: false,
+    };
+    for entry in entries {
+      let name = match entry {
+        // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
+        DirEntry::Directory(path) => path.file_name().and_then(|f| f.to_str()),
+        DirEntry::File { name, .. } => name.to_str(),
+      };
+      match name {
+        Some(".gitignore") => hint.has_gitignore = true,
+        Some(".git") => hint.has_git = true,
+        _ => continue,
+      }
+      if hint.has_gitignore && hint.has_git {
+        break; // nothing left to learn
+      }
+    }
+    hint
+  }
 }
 
 #[derive(Default)]

--- a/crates/dprint/src/utils/glob/glob.rs
+++ b/crates/dprint/src/utils/glob/glob.rs
@@ -658,30 +658,6 @@ enum DirOrConfigEntry {
   Config(PathBuf),
 }
 
-/// Derives a gitignore resolution hint from an already-read directory listing.
-fn dir_entries_hint(entries: &[DirEntry]) -> DirEntriesHint {
-  let mut hint = DirEntriesHint {
-    has_git: false,
-    has_gitignore: false,
-  };
-  for entry in entries {
-    let name = match entry {
-      // `.gitignore` is a file and `.git` is usually a directory (a file in worktrees)
-      DirEntry::Directory(path) => path.file_name().and_then(|f| f.to_str()),
-      DirEntry::File { name, .. } => name.to_str(),
-    };
-    match name {
-      Some(".gitignore") => hint.has_gitignore = true,
-      Some(".git") => hint.has_git = true,
-      _ => continue,
-    }
-    if hint.has_gitignore && hint.has_git {
-      break; // nothing left to learn
-    }
-  }
-  hint
-}
-
 const PUSH_DIR_ENTRIES_BATCH_COUNT: usize = 500;
 
 struct ReadDirRunnerOptions {
@@ -768,7 +744,7 @@ impl<TEnvironment: Environment> ReadDirRunner<TEnvironment> {
     let entries_read = entries.len();
     // derive this before filtering, because the `.gitignore` that the hint is
     // about is itself usually not a file that matches the patterns
-    let hint = dir_entries_hint(&entries);
+    let hint = DirEntriesHint::from_dir_entries(&entries);
     // Note the start directory is exempt from config file detection because the
     // traversal starts there, so a config file in it would take over the entire
     // scope. Usually `current_config_path` already filters it out, but not when


### PR DESCRIPTION
Closes #1237

`dprint init` scans the current directory to pre-select plugins, but skipped every directory starting with a dot, so files like `.github/workflows/ci.yml` or `.vscode/settings.json` never counted.

- `is_ignored_dir` now only skips `.git` plus the existing hardcoded list (`node_modules`, `target`, ...), so other hidden directories are scanned.
- The scan now respects the gitignore (including git's global excludes, the same way `fmt` does), skipping both ignored directories and ignored files. Previously it ignored the gitignore entirely, so a gitignored `generated/` directory could pre-select a plugin you don't want.
- Moved glob's private `dir_entries_hint` to `DirEntriesHint::from_dir_entries` so the init scan reuses it and avoids redundant `.git`/`.gitignore` reads per directory.

The scan stays bounded by the existing 1000 file / 1000 directory limits.