### PR TITLE
feat: add plugins with `dprint init` when a config file already exists

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -614,7 +614,7 @@ pub enum CliArgParserKind {
 pub fn create_cli_parser(kind: CliArgParserKind) -> clap::Command {
   fn init_command() -> Command {
     Command::new("init")
-      .about("Initializes a configuration file in the current directory.")
+      .about("Initializes a configuration file in the current directory, or adds plugins to an existing one.")
       .arg(
         Arg::new("global")
           .long("global")

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -59,7 +59,11 @@ pub struct InitConfigFileOptions<'a> {
   pub minimum_dependency_age: Option<MinimumDependencyAgeArg>,
 }
 
-pub async fn init_config_file(environment: &impl Environment, options: InitConfigFileOptions<'_>) -> Result<()> {
+pub async fn init_config_file<TEnvironment: Environment>(
+  environment: &TEnvironment,
+  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
+  options: InitConfigFileOptions<'_>,
+) -> Result<()> {
   fn get_config_paths(environment: &impl Environment, options: &InitConfigFileOptions<'_>) -> Result<Vec<PathBuf>> {
     if options.global {
       let directory = crate::configuration::resolve_global_config_dir(environment).with_context(|| {
@@ -78,17 +82,20 @@ pub async fn init_config_file(environment: &impl Environment, options: InitConfi
   }
 
   let mut config_file_paths = get_config_paths(environment, &options)?;
-  for config_path in &config_file_paths {
-    if environment.path_exists(config_path) {
-      bail!("Configuration file '{}' already exists.", config_path.display())
+  // skip the interactive prompt when asked to or when there's no interactive terminal (ex. CI)
+  let non_interactive = options.non_interactive || !environment.is_terminal_interactive();
+  if let Some(existing_path) = config_file_paths.iter().find(|path| environment.path_exists(path)) {
+    // there's nothing to prompt with when there's no terminal, so keep telling
+    // the user the file is there rather than doing something they didn't ask for
+    if non_interactive {
+      bail!("Configuration file '{}' already exists.", existing_path.display())
     }
+    return add_missing_plugins_to_config_file(environment, plugin_resolver, existing_path.clone(), &options).await;
   }
   let config_file_path = config_file_paths.remove(0);
   // a relative path (the default file names, or a relative --config) is
   // relative to the cwd; resolved so the .npmrc walk starts from the right place
   let config_dir = environment.cwd().join(&config_file_path).parent().map(|dir| dir.to_path_buf());
-  // skip the interactive prompt when asked to or when there's no interactive terminal (ex. CI)
-  let non_interactive = options.non_interactive || !environment.is_terminal_interactive();
   let text = get_init_config_file_text(
     environment,
     GetInitConfigFileTextOptions {
@@ -109,6 +116,67 @@ pub async fn init_config_file(environment: &impl Environment, options: InitConfi
   log_stdout_info!(
     environment,
     "\nIf you are working in a commercial environment please consider sponsoring dprint: https://dprint.dev/sponsor"
+  );
+  Ok(())
+}
+
+/// Adds plugins to a config file that already exists, which is what `dprint
+/// init` does instead of erroring when it's run interactively in a directory
+/// that's already set up. The plugins the config file has are shown in the
+/// prompt, but can't be selected.
+async fn add_missing_plugins_to_config_file<TEnvironment: Environment>(
+  environment: &TEnvironment,
+  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
+  config_file_path: PathBuf,
+  options: &InitConfigFileOptions<'_>,
+) -> Result<()> {
+  let config_file_path = environment.canonicalize(&config_file_path)?;
+  let config_dir = config_file_path.parent();
+  let config = resolve_config_from_path_with_bytes(
+    &ResolvedConfigPathWithText {
+      source: PathSource::new_local(config_file_path.clone()),
+      is_first_download: false,
+      content: environment.read_file(&config_file_path)?,
+      base_path: config_dir.clone().unwrap_or_else(|| environment.cwd()),
+      is_global_config: options.global,
+    },
+    environment,
+  )
+  .await?;
+  let existing_plugin_names = get_config_file_plugin_names(environment, plugin_resolver, config.plugins).await;
+  let plugins_to_add = get_init_plugins_to_add(
+    environment,
+    GetInitPluginsToAddOptions {
+      existing_plugin_names,
+      minimum_dependency_age: options.minimum_dependency_age.clone(),
+      config_dir: config_dir.map(|dir| dir.into_path_buf()),
+    },
+  )
+  .await?;
+  let entries = match plugins_to_add {
+    InitPluginsToAdd::AllPluginsConfigured => {
+      log_stdout_info!(environment, "{} already has every plugin dprint knows about.", config_file_path.display());
+      return Ok(());
+    }
+    InitPluginsToAdd::Entries(entries) => entries,
+  };
+  if entries.is_empty() {
+    log_stdout_info!(environment, "\nNo plugins were added.");
+    return Ok(());
+  }
+
+  let file_text = environment.read_file(&config_file_path)?;
+  let file_text = add_plugins_to_config(&file_text, &[], &entries)?;
+  environment.write_file(&config_file_path, &file_text)?;
+  log_stdout_info!(
+    environment,
+    "\nAdded {} to {}",
+    if entries.len() == 1 {
+      "1 plugin".to_string()
+    } else {
+      format!("{} plugins", entries.len())
+    },
+    config_file_path.display()
   );
   Ok(())
 }
@@ -786,17 +854,7 @@ async fn get_possible_plugins_to_add<TEnvironment: Environment>(
   let info_file = read_info_file(environment)
     .await
     .map_err(|err| anyhow!("Failed downloading info file. {:#}", err))?;
-  let current_plugin_names = get_config_file_plugins(plugin_resolver, current_plugins)
-    .await
-    .into_iter()
-    .filter_map(|(plugin_reference, plugin_result)| match plugin_result {
-      Ok(plugin) => Some(plugin.info().name.to_string()),
-      Err(err) => {
-        log_warn!(environment, "Failed resolving plugin: {}\n\n{:#}", plugin_reference.path_source.display(), err);
-        None
-      }
-    })
-    .collect::<HashSet<_>>();
+  let current_plugin_names = get_config_file_plugin_names(environment, plugin_resolver, current_plugins).await;
   Ok(
     info_file
       .latest_plugins
@@ -1559,6 +1617,26 @@ pub async fn output_resolved_config<TEnvironment: Environment>(
   Ok(())
 }
 
+/// The names of the plugins a config file resolves to, skipping (with a
+/// warning) the ones that fail to resolve.
+async fn get_config_file_plugin_names<TEnvironment: Environment>(
+  environment: &TEnvironment,
+  plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
+  current_plugins: Vec<PluginSourceReference>,
+) -> HashSet<String> {
+  get_config_file_plugins(plugin_resolver, current_plugins)
+    .await
+    .into_iter()
+    .filter_map(|(plugin_reference, plugin_result)| match plugin_result {
+      Ok(plugin) => Some(plugin.info().name.to_string()),
+      Err(err) => {
+        log_warn!(environment, "Failed resolving plugin: {}\n\n{:#}", plugin_reference.path_source.display(), err);
+        None
+      }
+    })
+    .collect()
+}
+
 async fn get_config_file_plugins<TEnvironment: Environment>(
   plugin_resolver: &Rc<PluginResolver<TEnvironment>>,
   current_plugins: Vec<PluginSourceReference>,
@@ -1865,8 +1943,87 @@ mod test {
         c.add_includes("**/*.txt");
       })
       .build();
+    // there's nothing to prompt with, so it says the file is already there
+    let error_message = run_test_cli(vec!["init", "--yes"], &environment).err().unwrap();
+    assert_eq!(error_message.to_string(), "Configuration file 'dprint.json' already exists.");
+    environment.set_terminal_interactive(false);
     let error_message = run_test_cli(vec!["init"], &environment).err().unwrap();
     assert_eq!(error_message.to_string(), "Configuration file 'dprint.json' already exists.");
+  }
+
+  #[test]
+  fn should_add_plugins_to_existing_config_file_on_initialize() {
+    let environment = get_setup_env(SetupEnvOptions {
+      config_has_wasm: true,
+      config_has_wasm_checksum: false,
+      config_has_process: false,
+      remote_has_wasm_checksum: false,
+      remote_has_process_checksum: false,
+    });
+    // the plugin the config file already has isn't selectable
+    environment.set_multi_selection_result(vec![0]);
+    run_test_cli(vec!["init"], &environment).unwrap();
+    assert_eq!(
+      environment.take_multi_selection_items(),
+      vec!["[ ] test-process-plugin", "[x] test-plugin (already in config) (locked)"]
+    );
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Select plugins to add (space to toggle, type to filter, enter to finish):"]
+    );
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![format!("\nAdded 1 plugin to {}", Path::new("/").join("dprint.json").display())]
+    );
+    assert_eq!(
+      environment.read_file("./dprint.json").unwrap(),
+      r#"{
+  "plugins": [
+    "https://plugins.dprint.dev/test-plugin-0.1.0.wasm",
+    "https://plugins.dprint.dev/test-plugin-3.json"
+  ]
+}"#
+    );
+  }
+
+  #[test]
+  fn should_not_change_existing_config_file_on_initialize_when_nothing_selected() {
+    let environment = get_setup_env(SetupEnvOptions {
+      config_has_wasm: true,
+      config_has_wasm_checksum: false,
+      config_has_process: false,
+      remote_has_wasm_checksum: false,
+      remote_has_process_checksum: false,
+    });
+    let original_text = environment.read_file("./dprint.json").unwrap();
+    environment.set_multi_selection_result(vec![]);
+    run_test_cli(vec!["init"], &environment).unwrap();
+    assert_eq!(
+      environment.take_stderr_messages(),
+      vec!["Select plugins to add (space to toggle, type to filter, enter to finish):"]
+    );
+    assert_eq!(environment.take_stdout_messages(), vec!["\nNo plugins were added."]);
+    assert_eq!(environment.read_file("./dprint.json").unwrap(), original_text);
+  }
+
+  #[test]
+  fn should_not_prompt_on_initialize_when_config_file_has_every_plugin() {
+    let environment = get_setup_env(SetupEnvOptions {
+      config_has_wasm: true,
+      config_has_wasm_checksum: false,
+      config_has_process: true,
+      remote_has_wasm_checksum: false,
+      remote_has_process_checksum: false,
+    });
+    run_test_cli(vec!["init"], &environment).unwrap();
+    assert!(environment.take_multi_selection_items().is_empty());
+    assert_eq!(
+      environment.take_stdout_messages(),
+      vec![format!(
+        "{} already has every plugin dprint knows about.",
+        Path::new("/").join("dprint.json").display()
+      )]
+    );
   }
 
   #[test]
@@ -1967,7 +2124,7 @@ mod test {
   #[test]
   fn should_error_when_global_config_file_already_exists() {
     let environment = TestEnvironmentBuilder::new().write_file("/config/dprint/dprint.json", "{}").build();
-    let error_message = run_test_cli(vec!["config", "init", "--global"], &environment).err().unwrap();
+    let error_message = run_test_cli(vec!["config", "init", "--global", "--yes"], &environment).err().unwrap();
     assert_eq!(
       error_message.to_string(),
       format!(

--- a/crates/dprint/src/commands/config.rs
+++ b/crates/dprint/src/commands/config.rs
@@ -1965,7 +1965,7 @@ mod test {
     run_test_cli(vec!["init"], &environment).unwrap();
     assert_eq!(
       environment.take_multi_selection_items(),
-      vec!["[ ] test-process-plugin", "[x] test-plugin (already in config) (locked)"]
+      vec!["[ ] test-process-plugin", "[x] test-plugin — already in config (locked)"]
     );
     assert_eq!(
       environment.take_stderr_messages(),

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use anyhow::bail;
 use dprint_core::async_runtime::future;
 use dprint_core::plugins::wasm::{self};
 use jsonc_parser::cst::CstInputValue;
@@ -10,6 +11,7 @@ use jsonc_parser::cst::CstRootNode;
 
 use crate::environment::DirEntry;
 use crate::environment::Environment;
+use crate::plugins::InfoFile;
 use crate::plugins::InfoFilePluginInfo;
 use crate::plugins::MinimumDependencyAgeError;
 use crate::plugins::ResolveNpmLatestOptions;
@@ -17,6 +19,7 @@ use crate::plugins::read_info_file;
 use crate::plugins::resolve_dependency_age_cutoff;
 use crate::utils::DependencyAgeCutoff;
 use crate::utils::MinimumDependencyAgeArg;
+use crate::utils::MultiSelectItem;
 
 /// Maximum number of files to look at when scanning the current directory to
 /// decide which plugins to pre-select. Keeps `dprint init` fast in large repos.
@@ -39,57 +42,49 @@ pub struct GetInitConfigFileTextOptions {
   pub config_dir: Option<PathBuf>,
 }
 
+/// Options for [`get_init_plugins_to_add`].
+pub struct GetInitPluginsToAddOptions {
+  /// Names, as they appear in the info file, of the plugins the config file
+  /// already has. They're shown in the prompt, but can't be selected.
+  pub existing_plugin_names: HashSet<String>,
+  /// Don't add an npm plugin version published more recently than this.
+  pub minimum_dependency_age: Option<MinimumDependencyAgeArg>,
+  /// Directory of the config file being added to. An .npmrc setting
+  /// `min-release-age` is looked for here and in its ancestors.
+  pub config_dir: Option<PathBuf>,
+}
+
+/// The outcome of prompting for plugins to add to a config file that already
+/// exists.
+pub enum InitPluginsToAdd {
+  /// The config file already has every plugin the info file knows about, so
+  /// there was nothing to prompt for.
+  AllPluginsConfigured,
+  /// The entries to append to the config file's `plugins` array. Empty when
+  /// the user selected nothing.
+  Entries(Vec<String>),
+}
+
 pub async fn get_init_config_file_text(environment: &impl Environment, options: GetInitConfigFileTextOptions) -> Result<String> {
-  let info = match read_info_file(environment).await {
-    Ok(info) => {
-      // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
-      if wasm::PLUGIN_SYSTEM_SCHEMA_VERSION < info.plugin_system_schema_version {
-        log_error!(
-          environment,
-          concat!(
-            "You are using an old version of dprint so the created config file may not be as helpful of a starting point. ",
-            "Consider upgrading to support new plugins. ",
-            "Plugin system schema version is {}, latest is {}."
-          ),
-          wasm::PLUGIN_SYSTEM_SCHEMA_VERSION,
-          info.plugin_system_schema_version,
-        );
-        None
-      } else {
-        Some(info)
-      }
-    }
-    Err(err) => {
-      log_error!(
-        environment,
-        concat!(
-          "There was a problem getting the latest plugin info. ",
-          "The created config file may not be as helpful of a starting point. ",
-          "Error: {}"
-        ),
-        err,
-      );
-      None
-    }
-  };
+  let info = read_plugin_info_file(environment).await;
 
   let selected_plugins = if let Some(info) = info {
     let latest_plugins = info.latest_plugins;
     // pre-select the plugins that match files found in the current directory
     let project_files = scan_project_files(environment);
-    let defaults = compute_default_selections(&latest_plugins, &project_files);
+    let defaults = compute_default_selections(&latest_plugins, &project_files, &[]);
 
     let mut selected_indexes = if options.non_interactive {
       defaults.iter().enumerate().filter_map(|(i, on)| on.then_some(i)).collect::<Vec<_>>()
     } else {
       // show the pre-selected plugins at the top of the list
-      let order = display_order(&defaults);
+      let order = display_order(&defaults, &[]);
       let prompt_message = "Select plugins (space to toggle, type to filter, enter to finish):";
       let items = order
         .iter()
-        .map(|&i| (defaults[i], plugin_display_text(&latest_plugins[i])))
+        .map(|&i| MultiSelectItem::new(plugin_display_text(&latest_plugins[i]), defaults[i]))
         .collect::<Vec<_>>();
-      let chosen = environment.get_multi_selection(prompt_message, 0, &items)?;
+      let chosen = environment.get_multi_selection(prompt_message, 0, items)?;
       chosen.into_iter().map(|display_index| order[display_index]).collect::<Vec<_>>()
     };
     // keep the config file in info.json order regardless of the display order
@@ -130,6 +125,96 @@ pub async fn get_init_config_file_text(environment: &impl Environment, options: 
   };
 
   Ok(json_text)
+}
+
+/// Prompts for plugins to add to a config file that already exists,
+/// pre-selecting the ones that match files in the current directory the config
+/// doesn't already have a plugin for. The plugins it does have are shown in
+/// the prompt for context, but can't be selected.
+pub async fn get_init_plugins_to_add(environment: &impl Environment, options: GetInitPluginsToAddOptions) -> Result<InitPluginsToAdd> {
+  let Some(info) = read_plugin_info_file(environment).await else {
+    bail!("Could not get the latest plugin info, so there's nothing to select from.");
+  };
+  let latest_plugins = info.latest_plugins;
+  let already_configured = latest_plugins
+    .iter()
+    .map(|plugin| options.existing_plugin_names.contains(&plugin.name))
+    .collect::<Vec<_>>();
+  if already_configured.iter().all(|configured| *configured) {
+    return Ok(InitPluginsToAdd::AllPluginsConfigured);
+  }
+
+  // pre-select the plugins matching files in the current directory, leaving out
+  // the file types the config file's plugins already handle
+  let project_files = scan_project_files(environment);
+  let defaults = compute_default_selections(&latest_plugins, &project_files, &already_configured);
+  // show the pre-selected plugins at the top and the ones already in the config at the bottom
+  let order = display_order(&defaults, &already_configured);
+  let prompt_message = "Select plugins to add (space to toggle, type to filter, enter to finish):";
+  let items = order
+    .iter()
+    .map(|&i| {
+      if already_configured[i] {
+        MultiSelectItem::non_selectable(format!("{} (already in config)", latest_plugins[i].name))
+      } else {
+        MultiSelectItem::new(plugin_display_text(&latest_plugins[i]), defaults[i])
+      }
+    })
+    .collect::<Vec<_>>();
+  let chosen = environment.get_multi_selection(prompt_message, 0, items)?;
+  let mut selected_indexes = chosen.into_iter().map(|display_index| order[display_index]).collect::<Vec<_>>();
+  // add them to the config file in info.json order regardless of the display order
+  selected_indexes.sort_unstable();
+
+  // an .npmrc setting `min-release-age` is looked for where the config file lives
+  let age_cutoff = resolve_dependency_age_cutoff(options.minimum_dependency_age.as_ref(), options.config_dir.as_deref(), environment);
+  // resolve concurrently — a plugin distributed on npm costs a registry round trip
+  let entries = future::join_all(
+    selected_indexes
+      .iter()
+      .map(|&index| resolve_plugin_entry(&latest_plugins[index], age_cutoff.as_ref(), environment)),
+  )
+  .await
+  .into_iter()
+  .collect::<Result<Vec<_>>>()?;
+  Ok(InitPluginsToAdd::Entries(entries))
+}
+
+/// Reads the plugin info file, logging why the command is going to be less
+/// helpful when it can't be read or is too new for this version of dprint.
+async fn read_plugin_info_file(environment: &impl Environment) -> Option<InfoFile> {
+  match read_info_file(environment).await {
+    Ok(info) => {
+      // ok to only check wasm here because the configuration file is only ever initialized with wasm plugins
+      if wasm::PLUGIN_SYSTEM_SCHEMA_VERSION < info.plugin_system_schema_version {
+        log_error!(
+          environment,
+          concat!(
+            "You are using an old version of dprint so the created config file may not be as helpful of a starting point. ",
+            "Consider upgrading to support new plugins. ",
+            "Plugin system schema version is {}, latest is {}."
+          ),
+          wasm::PLUGIN_SYSTEM_SCHEMA_VERSION,
+          info.plugin_system_schema_version,
+        );
+        None
+      } else {
+        Some(info)
+      }
+    }
+    Err(err) => {
+      log_error!(
+        environment,
+        concat!(
+          "There was a problem getting the latest plugin info. ",
+          "The created config file may not be as helpful of a starting point. ",
+          "Error: {}"
+        ),
+        err,
+      );
+      None
+    }
+  }
 }
 
 /// A plugin `dprint init` decided to write to the config file.
@@ -251,23 +336,36 @@ struct ProjectFiles {
 /// A plugin matches via its own file extensions / file names or via any of its
 /// config items (ex. `dprint-plugin-exec` declares no extensions of its own but
 /// pre-selects when one of its command's file types is present).
-fn compute_default_selections(plugins: &[InfoFilePluginInfo], project_files: &ProjectFiles) -> Vec<bool> {
+///
+/// `already_configured` marks the plugins a config file already has (empty when
+/// there's no config file yet). They claim their file types before anything
+/// else and are never selected, so nothing is suggested for a file type that's
+/// already handled.
+fn compute_default_selections(plugins: &[InfoFilePluginInfo], project_files: &ProjectFiles, already_configured: &[bool]) -> Vec<bool> {
+  let is_already_configured = |index: usize| already_configured.get(index).copied().unwrap_or(false);
   let mut claimed_extensions: HashSet<String> = HashSet::new();
   let mut claimed_file_names: HashSet<String> = HashSet::new();
   let mut used_config_keys: HashSet<&str> = HashSet::new();
   let mut selected = vec![false; plugins.len()];
 
   for (i, plugin) in plugins.iter().enumerate() {
+    if !is_already_configured(i) {
+      continue;
+    }
+    claimed_extensions.extend(present_extensions(plugin, project_files));
+    claimed_file_names.extend(present_file_names(plugin, project_files));
+    if let Some(config_key) = config_key(plugin) {
+      used_config_keys.insert(config_key);
+    }
+  }
+
+  for (i, plugin) in plugins.iter().enumerate() {
+    if is_already_configured(i) {
+      continue;
+    }
     // present extensions / file names that this plugin matches
-    let present_extensions = match_extensions(plugin)
-      .into_iter()
-      .filter(|ext| project_files.extensions.contains(ext))
-      .collect::<Vec<_>>();
-    let present_file_names = match_file_names(plugin)
-      .into_iter()
-      .filter(|name| project_files.file_names.contains(*name))
-      .map(|name| name.to_string())
-      .collect::<Vec<_>>();
+    let present_extensions = present_extensions(plugin, project_files);
+    let present_file_names = present_file_names(plugin, project_files);
 
     // select it only if it's the first to match at least one of those
     let claims_unclaimed =
@@ -291,12 +389,33 @@ fn compute_default_selections(plugins: &[InfoFilePluginInfo], project_files: &Pr
   selected
 }
 
+/// The extensions found in the current directory that a plugin matches.
+fn present_extensions(plugin: &InfoFilePluginInfo, project_files: &ProjectFiles) -> Vec<String> {
+  match_extensions(plugin)
+    .into_iter()
+    .filter(|ext| project_files.extensions.contains(ext))
+    .collect()
+}
+
+/// The file names found in the current directory that a plugin matches.
+fn present_file_names(plugin: &InfoFilePluginInfo, project_files: &ProjectFiles) -> Vec<String> {
+  match_file_names(plugin)
+    .into_iter()
+    .filter(|name| project_files.file_names.contains(*name))
+    .map(|name| name.to_string())
+    .collect()
+}
+
 /// The order plugins are displayed in: the pre-selected ones first (each group
-/// in info.json order), so the relevant plugins are at the top of the list.
-fn display_order(defaults: &[bool]) -> Vec<usize> {
-  let selected = (0..defaults.len()).filter(|&i| defaults[i]);
-  let unselected = (0..defaults.len()).filter(|&i| !defaults[i]);
-  selected.chain(unselected).collect()
+/// in info.json order), so the relevant plugins are at the top of the list, and
+/// the ones a config file already has at the bottom since they're only there
+/// for context.
+fn display_order(defaults: &[bool], already_configured: &[bool]) -> Vec<usize> {
+  let is_already_configured = |index: usize| already_configured.get(index).copied().unwrap_or(false);
+  let selected = (0..defaults.len()).filter(|&i| defaults[i] && !is_already_configured(i));
+  let unselected = (0..defaults.len()).filter(|&i| !defaults[i] && !is_already_configured(i));
+  let already_configured = (0..defaults.len()).filter(|&i| is_already_configured(i));
+  selected.chain(unselected).chain(already_configured).collect()
 }
 
 /// All the file extensions a plugin matches (its own plus its config items'),
@@ -797,11 +916,118 @@ mod test {
   }
 
   #[test]
+  fn should_get_plugins_to_add_to_an_existing_config_file() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        info
+          .add_plugin(wasm_plugin("a", "a", &["ts"]))
+          .add_plugin(wasm_plugin("b", "b", &["json"]))
+          .add_plugin(wasm_plugin("c", "c", &["md"]));
+      })
+      .write_file("/main.ts", "")
+      .write_file("/data.json", "")
+      .build();
+    environment.clone().run_in_runtime({
+      let environment = environment.clone();
+      async move {
+        let plugins = get_init_plugins_to_add(
+          &environment,
+          GetInitPluginsToAddOptions {
+            existing_plugin_names: HashSet::from(["a".to_string()]),
+            minimum_dependency_age: None,
+            config_dir: None,
+          },
+        )
+        .await
+        .unwrap();
+        // `b` is pre-selected because of the .json file, `a` is only shown for
+        // context since the config file already has it (even though .ts matched)
+        assert_eq!(
+          environment.take_multi_selection_items(),
+          vec!["[x] b (.json)", "[ ] c (.md)", "[x] a (already in config) (locked)"]
+        );
+        let InitPluginsToAdd::Entries(entries) = plugins else {
+          unreachable!();
+        };
+        assert_eq!(entries, vec!["https://plugins.dprint.dev/b-1.0.0.wasm".to_string()]);
+        assert_eq!(
+          environment.take_stderr_messages(),
+          vec!["Select plugins to add (space to toggle, type to filter, enter to finish):"]
+        );
+      }
+    });
+  }
+
+  #[test]
+  fn should_not_suggest_a_plugin_for_a_file_type_an_existing_plugin_handles() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        info.add_plugin(wasm_plugin("a", "a", &["ts"])).add_plugin(wasm_plugin("b", "b", &["ts"]));
+      })
+      .write_file("/main.ts", "")
+      .build();
+    environment.clone().run_in_runtime({
+      let environment = environment.clone();
+      async move {
+        let plugins = get_init_plugins_to_add(
+          &environment,
+          GetInitPluginsToAddOptions {
+            existing_plugin_names: HashSet::from(["a".to_string()]),
+            minimum_dependency_age: None,
+            config_dir: None,
+          },
+        )
+        .await
+        .unwrap();
+        // `a` already handles .ts, so `b` isn't pre-selected
+        assert_eq!(
+          environment.take_multi_selection_items(),
+          vec!["[ ] b (.ts)", "[x] a (already in config) (locked)"]
+        );
+        let InitPluginsToAdd::Entries(entries) = plugins else {
+          unreachable!();
+        };
+        assert!(entries.is_empty());
+        environment.take_stderr_messages();
+      }
+    });
+  }
+
+  #[test]
+  fn should_not_prompt_when_the_config_file_has_every_plugin() {
+    let environment = TestEnvironmentBuilder::new()
+      .with_info_file(|info| {
+        info.add_plugin(wasm_plugin("a", "a", &["ts"]));
+      })
+      .write_file("/main.ts", "")
+      .build();
+    environment.clone().run_in_runtime({
+      let environment = environment.clone();
+      async move {
+        let plugins = get_init_plugins_to_add(
+          &environment,
+          GetInitPluginsToAddOptions {
+            existing_plugin_names: HashSet::from(["a".to_string()]),
+            minimum_dependency_age: None,
+            config_dir: None,
+          },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(plugins, InitPluginsToAdd::AllPluginsConfigured));
+        assert!(environment.take_multi_selection_items().is_empty());
+      }
+    });
+  }
+
+  #[test]
   fn display_order_lists_selected_first() {
-    assert_eq!(display_order(&[false, true, false, true]), vec![1, 3, 0, 2]);
-    assert_eq!(display_order(&[true, true]), vec![0, 1]);
-    assert_eq!(display_order(&[false, false, false]), vec![0, 1, 2]);
-    assert_eq!(display_order(&[]), Vec::<usize>::new());
+    assert_eq!(display_order(&[false, true, false, true], &[]), vec![1, 3, 0, 2]);
+    assert_eq!(display_order(&[true, true], &[]), vec![0, 1]);
+    assert_eq!(display_order(&[false, false, false], &[]), vec![0, 1, 2]);
+    assert_eq!(display_order(&[], &[]), Vec::<usize>::new());
+    // the plugins already in the config file go last
+    assert_eq!(display_order(&[false, true, false], &[true, false, false]), vec![1, 2, 0]);
   }
 
   #[test]

--- a/crates/dprint/src/configuration/get_init_config_file_text.rs
+++ b/crates/dprint/src/configuration/get_init_config_file_text.rs
@@ -159,7 +159,9 @@ pub async fn get_init_plugins_to_add(environment: &impl Environment, options: Ge
     .iter()
     .map(|&i| {
       if already_configured[i] {
-        MultiSelectItem::non_selectable(format!("{} (already in config)", latest_plugins[i].name))
+        // shown with its extensions like the selectable items so filtering by a
+        // file type still surfaces the plugin that already handles it
+        MultiSelectItem::non_selectable(format!("{} — already in config", plugin_display_text(&latest_plugins[i])))
       } else {
         MultiSelectItem::new(plugin_display_text(&latest_plugins[i]), defaults[i])
       }
@@ -194,7 +196,7 @@ async fn read_plugin_info_file(environment: &impl Environment) -> Option<InfoFil
         log_error!(
           environment,
           concat!(
-            "You are using an old version of dprint so the created config file may not be as helpful of a starting point. ",
+            "You are using an old version of dprint so the latest plugins may not be suggested. ",
             "Consider upgrading to support new plugins. ",
             "Plugin system schema version is {}, latest is {}."
           ),
@@ -210,8 +212,7 @@ async fn read_plugin_info_file(environment: &impl Environment) -> Option<InfoFil
       log_error!(
         environment,
         concat!(
-          "There was a problem getting the latest plugin info. ",
-          "The created config file may not be as helpful of a starting point. ",
+          "There was a problem getting the latest plugin info, so the latest plugins may not be suggested. ",
           "Error: {}"
         ),
         err,
@@ -966,7 +967,7 @@ mod test {
         // context since the config file already has it (even though .ts matched)
         assert_eq!(
           environment.take_multi_selection_items(),
-          vec!["[x] b (.json)", "[ ] c (.md)", "[x] a (already in config) (locked)"]
+          vec!["[x] b (.json)", "[ ] c (.md)", "[x] a (.ts) — already in config (locked)"]
         );
         let InitPluginsToAdd::Entries(entries) = plugins else {
           unreachable!();
@@ -1004,7 +1005,7 @@ mod test {
         // `a` already handles .ts, so `b` isn't pre-selected
         assert_eq!(
           environment.take_multi_selection_items(),
-          vec!["[ ] b (.ts)", "[x] a (already in config) (locked)"]
+          vec!["[ ] b (.ts)", "[x] a (.ts) — already in config (locked)"]
         );
         let InitPluginsToAdd::Entries(entries) = plugins else {
           unreachable!();
@@ -1792,8 +1793,7 @@ mod test {
       );
       let mut expected_messages = get_standard_logged_messages_no_plugin_selection();
       expected_messages.push(concat!(
-        "There was a problem getting the latest plugin info. ",
-        "The created config file may not be as helpful of a starting point. ",
+        "There was a problem getting the latest plugin info, so the latest plugins may not be suggested. ",
         "Error: Error downloading https://plugins.dprint.dev/info.json - 404 Not Found"
       ));
       assert_eq!(environment.take_stderr_messages(), expected_messages);
@@ -1870,7 +1870,7 @@ mod test {
       );
       let mut expected_messages = get_standard_logged_messages_no_plugin_selection();
       expected_messages.push(concat!(
-        "You are using an old version of dprint so the created config file may not be as helpful of a starting point. ",
+        "You are using an old version of dprint so the latest plugins may not be suggested. ",
         "Consider upgrading to support new plugins. ",
         "Plugin system schema version is 4, latest is 999."
       ));

--- a/crates/dprint/src/environment/environment.rs
+++ b/crates/dprint/src/environment/environment.rs
@@ -27,6 +27,7 @@ use sys_traits::ThreadSleep;
 use crate::plugins::CompilationResult;
 use crate::utils::BasicShowConfirmStrategy;
 use crate::utils::LogLevel;
+use crate::utils::MultiSelectItem;
 use crate::utils::ProgressBars;
 use crate::utils::ShowConfirmStrategy;
 
@@ -313,7 +314,9 @@ pub trait Environment:
   fn cli_version(&self) -> String;
   fn get_time_secs(&self) -> u64;
   fn get_selection(&self, prompt_message: &str, item_indent_width: u16, items: &[String]) -> Result<usize>;
-  fn get_multi_selection(&self, prompt_message: &str, item_indent_width: u16, items: &[(bool, String)]) -> Result<Vec<usize>>;
+  /// Prompts for multiple items, returning the indexes of the selected ones.
+  /// Items that aren't selectable are shown but never returned.
+  fn get_multi_selection(&self, prompt_message: &str, item_indent_width: u16, items: Vec<MultiSelectItem>) -> Result<Vec<usize>>;
   fn confirm(&self, prompt_message: &str, default_value: bool) -> Result<bool> {
     self.confirm_with_strategy(&BasicShowConfirmStrategy {
       prompt: prompt_message,

--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -46,6 +46,7 @@ use crate::utils::FastInsecureHasher;
 use crate::utils::LogLevel;
 use crate::utils::Logger;
 use crate::utils::LoggerOptions;
+use crate::utils::MultiSelectItem;
 use crate::utils::NoProxy;
 use crate::utils::ProgressBars;
 use crate::utils::RealUrlDownloader;
@@ -602,14 +603,8 @@ impl Environment for RealEnvironment {
     show_select(&self.logger, "dprint", prompt_message, item_indent_width, items)
   }
 
-  fn get_multi_selection(&self, prompt_message: &str, item_indent_width: u16, items: &[(bool, String)]) -> Result<Vec<usize>> {
-    show_multi_select(
-      &self.logger,
-      "dprint",
-      prompt_message,
-      item_indent_width,
-      items.iter().map(|(value, text)| (value.to_owned(), text)).collect(),
-    )
+  fn get_multi_selection(&self, prompt_message: &str, item_indent_width: u16, items: Vec<MultiSelectItem>) -> Result<Vec<usize>> {
+    show_multi_select(&self.logger, "dprint", prompt_message, item_indent_width, items)
   }
 
   fn confirm_with_strategy(&self, strategy: &dyn ShowConfirmStrategy) -> Result<bool> {

--- a/crates/dprint/src/environment/test_environment.rs
+++ b/crates/dprint/src/environment/test_environment.rs
@@ -58,6 +58,7 @@ use super::PathKind;
 use super::UrlDownloader;
 use crate::plugins::CompilationResult;
 use crate::utils::LogLevel;
+use crate::utils::MultiSelectItem;
 use crate::utils::ShowConfirmStrategy;
 use crate::utils::get_bytes_hash;
 
@@ -146,6 +147,8 @@ pub struct TestEnvironment {
   remote_file_auth: Arc<Mutex<HashMap<String, Option<String>>>>,
   selection_result: Arc<Mutex<usize>>,
   multi_selection_result: Arc<Mutex<Option<Vec<usize>>>>,
+  /// The items of the last multi-selection prompt, rendered for assertions.
+  multi_selection_items: Arc<Mutex<Vec<String>>>,
   confirm_results: Arc<Mutex<Vec<Result<Option<bool>>>>>,
   is_stdout_machine_readable: Arc<Mutex<bool>>,
   dir_info_error: Arc<Mutex<Option<io::Error>>>,
@@ -187,6 +190,7 @@ impl TestEnvironment {
       remote_file_auth: Default::default(),
       selection_result: Arc::new(Mutex::new(0)),
       multi_selection_result: Arc::new(Mutex::new(None)),
+      multi_selection_items: Default::default(),
       confirm_results: Default::default(),
       is_stdout_machine_readable: Arc::new(Mutex::new(false)),
       dir_info_error: Arc::new(Mutex::new(None)),
@@ -268,6 +272,12 @@ impl TestEnvironment {
 
   pub fn set_multi_selection_result(&self, indexes: Vec<usize>) {
     *self.multi_selection_result.lock() = Some(indexes);
+  }
+
+  /// The items of the last multi-selection prompt, each rendered as it would
+  /// appear in the terminal (ex. `[x] dprint-plugin-json (locked)`).
+  pub fn take_multi_selection_items(&self) -> Vec<String> {
+    std::mem::take(&mut *self.multi_selection_items.lock())
   }
 
   pub fn set_confirm_results(&self, values: Vec<Result<Option<bool>>>) {
@@ -774,12 +784,23 @@ impl Environment for TestEnvironment {
     Ok(*self.selection_result.lock())
   }
 
-  fn get_multi_selection(&self, prompt_message: &str, _: u16, items: &[(bool, String)]) -> Result<Vec<usize>> {
+  fn get_multi_selection(&self, prompt_message: &str, _: u16, items: Vec<MultiSelectItem>) -> Result<Vec<usize>> {
     self.__log_stderr__(prompt_message);
+    *self.multi_selection_items.lock() = items
+      .iter()
+      .map(|item| {
+        format!(
+          "[{}] {}{}",
+          if item.is_selected { "x" } else { " " },
+          item.text,
+          if item.is_selectable { "" } else { " (locked)" }
+        )
+      })
+      .collect();
     let default_values = items
       .iter()
       .enumerate()
-      .filter_map(|(i, (selected, _))| if *selected { Some(i) } else { None })
+      .filter_map(|(i, item)| (item.is_selected && item.is_selectable).then_some(i))
       .collect();
     Ok(self.multi_selection_result.lock().clone().unwrap_or(default_values))
   }

--- a/crates/dprint/src/run_cli.rs
+++ b/crates/dprint/src/run_cli.rs
@@ -124,6 +124,7 @@ pub async fn run_cli<TEnvironment: Environment>(args: &CliArgs, environment: &TE
       } => {
         commands::init_config_file(
           environment,
+          plugin_resolver,
           InitConfigFileOptions {
             global: *global,
             config_arg: args.config.as_deref(),

--- a/crates/dprint/src/test_helpers.rs
+++ b/crates/dprint/src/test_helpers.rs
@@ -336,7 +336,7 @@ USAGE:
     dprint <SUBCOMMAND> [OPTIONS] [--] [files/directories/patterns]...
 
 SUBCOMMANDS:
-  init               Initializes a configuration file in the current directory.
+  init               Initializes a configuration file in the current directory, or adds plugins to an existing one.
   add                Adds a plugin to the configuration file.
   fmt                Formats the source files and writes the result to the file system.
   check              Checks for any files that haven't been formatted.

--- a/crates/dprint/src/utils/logging/multi_select.rs
+++ b/crates/dprint/src/utils/logging/multi_select.rs
@@ -3,6 +3,7 @@ use anyhow::bail;
 use crossterm::event::Event;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyModifiers;
+use deno_terminal::colors;
 
 use crate::utils::terminal::get_terminal_size;
 use crate::utils::terminal::read_terminal_key_press;
@@ -11,10 +12,40 @@ use super::Logger;
 use super::LoggerRefreshItemKind;
 use super::LoggerTextItem;
 
+/// An item in a multi-select prompt.
+pub struct MultiSelectItem {
+  pub text: String,
+  /// Whether the item starts out selected.
+  pub is_selected: bool,
+  /// Whether the user can toggle the item. A non-selectable item is shown for
+  /// context (ex. a plugin that's already in the config file) and is never
+  /// part of the result.
+  pub is_selectable: bool,
+}
+
+impl MultiSelectItem {
+  pub fn new(text: String, is_selected: bool) -> Self {
+    MultiSelectItem {
+      text,
+      is_selected,
+      is_selectable: true,
+    }
+  }
+
+  /// An item shown as selected that the user can't toggle.
+  pub fn non_selectable(text: String) -> Self {
+    MultiSelectItem {
+      text,
+      is_selected: true,
+      is_selectable: false,
+    }
+  }
+}
+
 struct MultiSelectData<'a> {
   prompt: &'a str,
   item_hanging_indent: u16,
-  items: Vec<(bool, &'a String)>,
+  items: Vec<MultiSelectItem>,
   /// Text typed by the user to narrow down the visible items.
   filter: String,
   /// Index into the currently visible (filtered) items.
@@ -23,7 +54,9 @@ struct MultiSelectData<'a> {
   scroll_offset: usize,
 }
 
-pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item_hanging_indent: u16, items: Vec<(bool, &String)>) -> Result<Vec<usize>> {
+/// Shows a multi-select prompt, returning the indexes of the selected items.
+/// Non-selectable items are shown but never returned.
+pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item_hanging_indent: u16, items: Vec<MultiSelectItem>) -> Result<Vec<usize>> {
   let mut data = MultiSelectData {
     prompt,
     items,
@@ -65,7 +98,10 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
         KeyCode::Char(' ') => {
           // toggle the active item's selection
           if let Some(&item_index) = visible.get(data.active_index) {
-            data.items[item_index].0 = !data.items[item_index].0;
+            let item = &mut data.items[item_index];
+            if item.is_selectable {
+              item.is_selected = !item.is_selected;
+            }
           }
         }
         KeyCode::Backspace => {
@@ -101,8 +137,8 @@ pub fn show_multi_select(logger: &Logger, context_name: &str, prompt: &str, item
 
   // return the selected indexes
   let mut result = Vec::new();
-  for (i, (is_selected, _)) in data.items.iter().enumerate() {
-    if *is_selected {
+  for (i, item) in data.items.iter().enumerate() {
+    if item.is_selected && item.is_selectable {
       result.push(i);
     }
   }
@@ -119,7 +155,7 @@ fn visible_indexes(data: &MultiSelectData) -> Vec<usize> {
     .items
     .iter()
     .enumerate()
-    .filter(|(_, (_, text))| text.to_lowercase().contains(&filter))
+    .filter(|(_, item)| item.text.to_lowercase().contains(&filter))
     .map(|(i, _)| i)
     .collect()
 }
@@ -169,13 +205,18 @@ fn render_multi_select(data: &MultiSelectData, visible: &[usize], max_visible_ro
   }
 
   for (visible_pos, &item_index) in visible.iter().enumerate().take(end).skip(data.scroll_offset) {
-    let (is_selected, item_text) = &data.items[item_index];
+    let item = &data.items[item_index];
     let mut text = String::new();
     text.push_str(if visible_pos == data.active_index { ">" } else { " " });
     text.push_str(" [");
-    text.push_str(if *is_selected { "x" } else { " " });
+    text.push_str(if item.is_selected { "x" } else { " " });
     text.push_str("] ");
-    text.push_str(item_text);
+    // dim the items that can't be toggled so it's clear they're only context
+    if item.is_selectable {
+      text.push_str(&item.text);
+    } else {
+      text.push_str(&colors::gray(&item.text).to_string());
+    }
 
     result.push(LoggerTextItem::HangingText {
       text,
@@ -190,17 +231,18 @@ fn render_multi_select(data: &MultiSelectData, visible: &[usize], max_visible_ro
   result
 }
 
+/// The prompt's final state, logged once it's done: only what the user chose,
+/// since the non-selectable items were shown for context.
 fn render_complete(data: &MultiSelectData) -> Vec<LoggerTextItem> {
   let mut result = Vec::new();
-  if data.items.iter().any(|(is_selected, _)| *is_selected) {
+  let is_chosen = |item: &MultiSelectItem| item.is_selected && item.is_selectable;
+  if data.items.iter().any(is_chosen) {
     result.push(LoggerTextItem::Text(data.prompt.to_string()));
-    for (is_selected, item_text) in data.items.iter() {
-      if *is_selected {
-        result.push(LoggerTextItem::HangingText {
-          text: format!(" * {}", item_text),
-          indent: 3 + data.item_hanging_indent,
-        });
-      }
+    for item in data.items.iter().filter(|item| is_chosen(item)) {
+      result.push(LoggerTextItem::HangingText {
+        text: format!(" * {}", item.text),
+        indent: 3 + data.item_hanging_indent,
+      });
     }
   }
   result
@@ -211,11 +253,15 @@ mod test {
   use super::*;
   use pretty_assertions::assert_eq;
 
-  fn build_data(items: &[(bool, String)]) -> MultiSelectData<'_> {
+  fn build_data(items: &[(bool, String)]) -> MultiSelectData<'static> {
+    build_data_with_items(items.iter().map(|(selected, text)| MultiSelectItem::new(text.clone(), *selected)).collect())
+  }
+
+  fn build_data_with_items(items: Vec<MultiSelectItem>) -> MultiSelectData<'static> {
     MultiSelectData {
       prompt: "Select:",
       item_hanging_indent: 0,
-      items: items.iter().map(|(selected, text)| (*selected, text)).collect(),
+      items,
       filter: String::new(),
       active_index: 0,
       scroll_offset: 0,
@@ -293,6 +339,30 @@ mod test {
       rendered_lines(&render_multi_select(&data, &visible, 10)),
       vec!["Select:", "  [x] alpha", "> [ ] beta"]
     );
+  }
+
+  #[test]
+  fn render_dims_non_selectable_items() {
+    let data = build_data_with_items(vec![
+      MultiSelectItem::new("alpha".to_string(), false),
+      MultiSelectItem::non_selectable("beta".to_string()),
+    ]);
+    let visible = visible_indexes(&data);
+    assert_eq!(
+      rendered_lines(&render_multi_select(&data, &visible, 10)),
+      vec!["Select:".to_string(), "> [ ] alpha".to_string(), format!("  [x] {}", colors::gray("beta")),]
+    );
+  }
+
+  #[test]
+  fn render_complete_only_shows_what_was_chosen() {
+    let data = build_data_with_items(vec![
+      MultiSelectItem::new("alpha".to_string(), true),
+      MultiSelectItem::new("beta".to_string(), false),
+      // shown while selecting, but not something the user chose
+      MultiSelectItem::non_selectable("gamma".to_string()),
+    ]);
+    assert_eq!(rendered_lines(&render_complete(&data)), vec!["Select:", " * alpha"]);
   }
 
   #[test]


### PR DESCRIPTION
`dprint init` erroring with "Configuration file 'dprint.json' already exists." isn't very useful when what you want is to pick up a plugin for a file type you've started using. Run interactively, it now scans the directory and prompts for plugins to add to the config file that's there.

- The plugins the config file already has are shown in the prompt but can't be selected (rendered dimmed with `(already in config)`), and they claim their file types first so nothing is suggested for a file type that's already handled.
- Selected plugins are appended to the `plugins` array with the existing `add_plugins_to_config` CST manipulation, so comments and formatting are preserved. Nothing else in the file is touched.
- It still errors as before when there's no terminal to prompt with (`--yes`, or a non-interactive terminal such as CI), since there's nothing to prompt for there.
- When the config file already has every plugin in info.json, it says so instead of showing a prompt with nothing selectable.

Supporting changes:

- `show_multi_select` items are now a `MultiSelectItem { text, is_selected, is_selectable }` rather than a `(bool, String)`. Non-selectable items are dimmed, can't be toggled, and are never returned or listed in the prompt's final summary.
- `compute_default_selections` takes the plugins a config already has so they claim their extensions / file names / config keys before anything is pre-selected; `display_order` puts them at the bottom of the list.
- `get_possible_plugins_to_add` (used by `dprint add`) and the new flow share `get_config_file_plugin_names`.