### PR TITLE
docs: add sort-package-json plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Repos:
 - [pretty_yaml](https://github.com/g-plane/pretty_yaml) - YAML formatter.
 - [dprint-plugin-gofumpt](https://github.com/jakebailey/dprint-plugin-gofumpt) - Go (gofumpt) formatter.
 - [panache](https://github.com/jolars/dprint-plugin-panache) - Quarto, Pandoc, R Markdown, and Markdown formatter.
+- [dprint-plugin-sort-package-json](https://github.com/colinaaa/dprint-plugin-sort-package-json) - Sorts package.json keys into a conventional order.
 - [dprint-plugin-swift](https://github.com/drluckyspin/dprint-plugin-swift) - Swift (SwiftFormat) formatter.
 
 ## Notes

--- a/website/src/_includes/partials/doc-menu.njk
+++ b/website/src/_includes/partials/doc-menu.njk
@@ -31,6 +31,7 @@
     ["Jupyter", "/plugins/jupyter"],
     ["Gofumpt (Go)", "/plugins/gofumpt"],
     ["Panache (Quarto/Pandoc/Markdown)", "/plugins/panache"],
+    ["Sort package.json", "/plugins/sort-package-json"],
     ["Swift (SwiftFormat)", "/plugins/swift"],
     ["Exec (Many CLIs)", "/plugins/exec"],
     ["Creating a Plugin", "/plugin-dev"]

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -166,6 +166,8 @@ layout: layouts/base.njk
         >PHP</span></span></a>
     <a class="plugin-card wrapper" href="/plugins/panache"><span class="swatch"></span><span class="meta"><span class="name">Panache</span><span class="ext"
         >Quarto · Pandoc · R Markdown · Markdown</span></span></a>
+    <a class="plugin-card wrapper" href="/plugins/sort-package-json"><span class="swatch"></span><span class="meta"><span class="name"
+        >Sort package.json</span><span class="ext">package.json</span></span></a>
   </div>
 
   <div class="plugins-label">Everything else</div>

--- a/website/src/plugins.md
+++ b/website/src/plugins.md
@@ -35,6 +35,7 @@ For the latest version and copy-paste URL of every plugin, see [plugins.dprint.d
 - [Jupyter](/plugins/jupyter)
 - [Gofumpt](/plugins/gofumpt) (Go)
 - [Panache](/plugins/panache) (Quarto/Pandoc/R Markdown/Markdown)
+- [Sort package.json](/plugins/sort-package-json) (package.json)
 
 ## Process Plugins
 

--- a/website/src/plugins/sort-package-json.md
+++ b/website/src/plugins/sort-package-json.md
@@ -1,0 +1,47 @@
+---
+title: Sort package.json Plugin
+description: Documentation on the package.json sorting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/sort-package-json">Sort package.json</a></li>
+  </ul>
+</nav>
+
+# Sort package.json Plugin
+
+Formats `package.json` files by sorting keys into a conventional order. It can also sort keys inside the `scripts` object.
+
+## Install and Setup
+
+In your project's directory with a dprint.json file, run:
+
+```shellsession
+dprint add colinaaa/sort-package-json
+# or install from npm
+dprint add npm:dprint-plugin-sort-package-json
+```
+
+This will update your config file to have an entry for the plugin. Then optionally specify a `"sortPackageJson"` property to add configuration:
+
+```json
+{
+  "sortPackageJson": {
+    "sortScripts": true
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/colinaaa/sort-package-json-x.x.x.wasm"
+  ]
+}
+```
+
+## Configuration
+
+See [Configuration](/plugins/sort-package-json/config).
+
+## Source Code
+
+See [dprint-plugin-sort-package-json](https://github.com/colinaaa/dprint-plugin-sort-package-json).

--- a/website/src/plugins/sort-package-json/config.md
+++ b/website/src/plugins/sort-package-json/config.md
@@ -1,0 +1,19 @@
+---
+title: Configuration - Sort package.json
+description: Documentation on the configuration file for the package.json sorting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/sort-package-json">Sort package.json</a></li>
+    <li><a href="/plugins/sort-package-json/config">Configuration</a></li>
+  </ul>
+</nav>
+
+# Sort package.json - Configuration
+
+<div class="plugin-config-table" data-url="https://plugins.dprint.dev/colinaaa/sort-package-json/latest/schema.json">
+  Loading...
+</div>

--- a/website/src/scripts/plugin-url-replacer.js
+++ b/website/src/scripts/plugin-url-replacer.js
@@ -19,6 +19,7 @@ const pluginPlaceholders = new Map([
   ["\"https://plugins.dprint.dev/g-plane/pretty_graphql-vx.x.x.wasm\"", "g-plane/pretty_graphql"],
   ["\"https://plugins.dprint.dev/jakebailey/gofumpt-vx.x.x.wasm\"", "jakebailey/dprint-plugin-gofumpt"],
   ["\"https://plugins.dprint.dev/jolars/panache-x.x.x.wasm\"", "jolars/panache"],
+  ["\"https://plugins.dprint.dev/colinaaa/sort-package-json-x.x.x.wasm\"", "colinaaa/sort-package-json"],
 ]);
 
 export function replacePluginUrls() {


### PR DESCRIPTION
## Summary

- add installation and configuration documentation for colinaaa/sort-package-json
- list the plugin in the README, website navigation, plugin index, and homepage
- resolve the latest Wasm URL and configuration schema through plugins.dprint.dev

Depends on dprint/plugins#80.

## Testing

- dprint check
- cd website && deno install && deno task build