### PR TITLE
fix: only rewrite the incremental file when new file hashes were seen

### DIFF
--- a/crates/dprint/src/arg_parser.rs
+++ b/crates/dprint/src/arg_parser.rs
@@ -309,6 +309,19 @@ pub struct FilePatternArgs {
   pub only_dirty: bool,
 }
 
+impl FilePatternArgs {
+  /// Whether the arguments limit the run to some of the files the
+  /// configuration would otherwise cover.
+  pub fn is_partial_run(&self) -> bool {
+    self.include_patterns.is_some()
+      || self.include_pattern_overrides.is_some()
+      || !self.exclude_patterns.is_empty()
+      || self.exclude_pattern_overrides.is_some()
+      || self.only_staged
+      || self.only_dirty
+  }
+}
+
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct ParseArgsError(#[from] anyhow::Error);

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -3726,7 +3726,7 @@ text2"
       })
       .write_file("/file1.txt", "text1")
       .write_file("/file2.txt", "text2")
-      .write_file("/file3.txt", "text3")
+      .write_file("/subdir/file3.txt", "text3")
       .initialize()
       .build();
     let read_incremental_file = || {
@@ -3779,6 +3779,16 @@ text2"
     run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
     assert!(environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
     assert_eq!(read_file_hashes(&read_incremental_file()).len(), 4);
+
+    // running from a sub directory only covers that directory, so it's a
+    // partial run and merges too
+    environment.write_file("/subdir/file3.txt", "asdf3").unwrap();
+    environment.set_cwd("/subdir");
+    environment.clear_logs();
+    run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
+    assert!(!environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    assert_eq!(read_file_hashes(&read_incremental_file()).len(), 5);
+    environment.set_cwd("/");
 
     // a full run with a change writes only the hashes it saw, pruning the stale one
     environment.write_file("/file2.txt", "asdf2").unwrap();

--- a/crates/dprint/src/commands/formatting.rs
+++ b/crates/dprint/src/commands/formatting.rs
@@ -23,6 +23,7 @@ use crate::environment::Environment;
 use crate::format::EnsureStableFormat;
 use crate::format::RunForFilePathError;
 use crate::format::run_parallelized;
+use crate::incremental::GetIncrementalFileOptions;
 use crate::incremental::get_incremental_file;
 use crate::patterns::FileMatcher;
 use crate::patterns::FileMatcherOptions;
@@ -172,7 +173,17 @@ pub async fn check<TEnvironment: Environment>(
       .scope
       .config
       .as_ref()
-      .and_then(|config| get_incremental_file(cmd.incremental, config, &scope_and_paths.scope, environment))
+      .and_then(|config| {
+        get_incremental_file(
+          GetIncrementalFileOptions {
+            incremental_cli_arg: cmd.incremental,
+            is_partial_run: cmd.patterns.is_partial_run(),
+          },
+          config,
+          &scope_and_paths.scope,
+          environment,
+        )
+      })
       .map(Arc::new);
     run_parallelized(scope_and_paths, environment, incremental_file.clone(), EnsureStableFormat(false), {
       let not_formatted_files_count = not_formatted_files_count.clone();
@@ -367,7 +378,17 @@ pub async fn format<TEnvironment: Environment>(
       .scope
       .config
       .as_ref()
-      .and_then(|config| get_incremental_file(cmd.incremental, config, &scope_and_paths.scope, environment))
+      .and_then(|config| {
+        get_incremental_file(
+          GetIncrementalFileOptions {
+            incremental_cli_arg: cmd.incremental,
+            is_partial_run: cmd.patterns.is_partial_run(),
+          },
+          config,
+          &scope_and_paths.scope,
+          environment,
+        )
+      })
       .map(Arc::new);
     let output_diff = cmd.diff;
     let diff_format = cmd.diff_format;
@@ -3695,6 +3716,77 @@ text2"
         .any(|msg| msg.contains("No change: /subdir/file1.txt")),
       true
     );
+  }
+
+  #[test]
+  fn should_only_write_incremental_file_when_changed() {
+    let environment = TestEnvironmentBuilder::with_remote_wasm_plugin()
+      .with_default_config(|c| {
+        c.add_remote_wasm_plugin();
+      })
+      .write_file("/file1.txt", "text1")
+      .write_file("/file2.txt", "text2")
+      .write_file("/file3.txt", "text3")
+      .initialize()
+      .build();
+    let read_incremental_file = || {
+      let dir = environment.get_cache_dir().join_panic_relative("incremental");
+      let entries = environment.dir_info(&dir).unwrap();
+      assert_eq!(entries.len(), 1);
+      match &entries[0] {
+        crate::environment::DirEntry::File { path, .. } => environment.read_file(path).unwrap(),
+        entry => panic!("Expected a file: {:?}", entry),
+      }
+    };
+    let read_file_hashes = |text: &str| -> Vec<u64> {
+      let data: serde_json::Value = serde_json::from_str(text).unwrap();
+      data["fileHashes"].as_array().unwrap().iter().map(|v| v.as_u64().unwrap()).collect()
+    };
+    let skipped_msg = "Incremental file unchanged. Skipping write.";
+
+    run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
+    assert!(!environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    let first_text = read_incremental_file();
+    assert_eq!(read_file_hashes(&first_text).len(), 3);
+
+    // nothing changed, so the file is not rewritten and its bytes stay the same
+    // (the hashes are serialized from a HashSet, so a rewrite would reorder them)
+    for _ in 0..3 {
+      environment.clear_logs();
+      run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
+      assert!(environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+      assert_eq!(read_incremental_file(), first_text);
+    }
+
+    // formatting a subset of already formatted files learns nothing new, so
+    // the file is kept as-is rather than shrunk to just the files seen
+    environment.clear_logs();
+    run_test_cli(vec!["fmt", "--log-level=debug", "/file1.txt"], &environment).unwrap();
+    assert!(environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    assert_eq!(read_incremental_file(), first_text);
+
+    // a file changed in a partial run, so the file is rewritten with the new
+    // hash merged into the existing ones (the old hash of the changed file is
+    // kept until a full run prunes it)
+    environment.write_file("/file1.txt", "asdf").unwrap();
+    environment.clear_logs();
+    run_test_cli(vec!["fmt", "--log-level=debug", "/file1.txt"], &environment).unwrap();
+    assert!(!environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    assert_eq!(read_file_hashes(&read_incremental_file()).len(), 4);
+
+    // a full run that learns nothing new doesn't prune yet
+    environment.clear_logs();
+    run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
+    assert!(environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    assert_eq!(read_file_hashes(&read_incremental_file()).len(), 4);
+
+    // a full run with a change writes only the hashes it saw, pruning the stale one
+    environment.write_file("/file2.txt", "asdf2").unwrap();
+    environment.clear_logs();
+    run_test_cli(vec!["fmt", "--log-level=debug"], &environment).unwrap();
+    assert!(!environment.take_stderr_messages().iter().any(|msg| msg.contains(skipped_msg)));
+    assert_eq!(read_file_hashes(&read_incremental_file()).len(), 3);
+    environment.clear_logs();
   }
 
   #[test]

--- a/crates/dprint/src/incremental/incremental_file.rs
+++ b/crates/dprint/src/incremental/incremental_file.rs
@@ -26,28 +26,31 @@ impl IncrementalFileData {
 
 pub struct IncrementalFile<TEnvironment: Environment> {
   file_path: CanonicalizedPathBuf,
-  read_data: IncrementalFileData,
+  /// The data read from the existing file, when it exists and was
+  /// created with the same plugins.
+  read_data: Option<IncrementalFileData>,
   write_data: Mutex<IncrementalFileData>,
+  /// Whether the run only covers some of the files, in which case the hashes
+  /// of the files not seen this run are kept when writing.
+  is_partial_run: bool,
   environment: TEnvironment,
 }
 
 impl<TEnvironment: Environment> IncrementalFile<TEnvironment> {
-  pub fn new(file_path: CanonicalizedPathBuf, plugins_hash: u64, environment: TEnvironment) -> Self {
-    let read_data = read_incremental(&file_path, &environment);
-    let read_data = if let Some(read_data) = read_data {
+  pub fn new(file_path: CanonicalizedPathBuf, plugins_hash: u64, is_partial_run: bool, environment: TEnvironment) -> Self {
+    let read_data = read_incremental(&file_path, &environment).and_then(|read_data| {
       if read_data.plugins_hash == plugins_hash {
-        read_data
+        Some(read_data)
       } else {
         log_debug!(environment, "Plugins changed. Creating new incremental file.");
-        IncrementalFileData::new(plugins_hash)
+        None
       }
-    } else {
-      IncrementalFileData::new(plugins_hash)
-    };
+    });
     IncrementalFile {
       file_path,
       read_data,
       write_data: Mutex::new(IncrementalFileData::new(plugins_hash)),
+      is_partial_run,
       environment,
     }
   }
@@ -55,7 +58,7 @@ impl<TEnvironment: Environment> IncrementalFile<TEnvironment> {
   /// If the file text is known to be formatted.
   pub fn is_file_known_formatted(&self, file_text: &[u8]) -> bool {
     let hash = get_bytes_hash(file_text);
-    if self.read_data.file_hashes.contains(&hash) {
+    if self.read_data.as_ref().is_some_and(|data| data.file_hashes.contains(&hash)) {
       // the file is the same, so save it in the write data
       self.add_to_write_data(hash);
       true
@@ -76,6 +79,27 @@ impl<TEnvironment: Environment> IncrementalFile<TEnvironment> {
 
   pub fn write(&self) {
     let write_data = self.write_data.lock();
+    if let Some(read_data) = &self.read_data {
+      // don't rewrite the file when nothing new was learned, which is the case
+      // when every file seen this run was already known to be formatted; this
+      // keeps the file's bytes stable so a CI cache of the cache directory can
+      // detect it hasn't changed
+      if write_data.file_hashes.is_subset(&read_data.file_hashes) {
+        log_debug!(self.environment, "Incremental file unchanged. Skipping write.");
+        return;
+      }
+      // a partial run keeps the hashes of the files it didn't see, while a full
+      // run writes only what it saw so the hashes of changed and deleted files
+      // get pruned
+      if self.is_partial_run {
+        let merged_data = IncrementalFileData {
+          plugins_hash: write_data.plugins_hash,
+          file_hashes: write_data.file_hashes.union(&read_data.file_hashes).copied().collect(),
+        };
+        write_incremental(&self.file_path, &merged_data, &self.environment);
+        return;
+      }
+    }
     write_incremental(&self.file_path, &write_data, &self.environment);
   }
 }

--- a/crates/dprint/src/incremental/mod.rs
+++ b/crates/dprint/src/incremental/mod.rs
@@ -7,12 +7,20 @@ use crate::environment::Environment;
 use crate::resolution::PluginsScope;
 use crate::utils::get_bytes_hash;
 
+pub struct GetIncrementalFileOptions {
+  pub incremental_cli_arg: Option<bool>,
+  /// Whether the run only covers some of the files the configuration
+  /// would otherwise cover (ex. file paths were specified on the cli).
+  pub is_partial_run: bool,
+}
+
 pub fn get_incremental_file<TEnvironment: Environment>(
-  incremental_cli_arg: Option<bool>,
+  options: GetIncrementalFileOptions,
   config: &ResolvedConfig,
   scope: &PluginsScope<TEnvironment>,
   environment: &TEnvironment,
 ) -> Option<IncrementalFile<TEnvironment>> {
+  let incremental_cli_arg = options.incremental_cli_arg;
   if let Some(incremental_arg) = incremental_cli_arg.or(config.incremental)
     && !incremental_arg
   {
@@ -27,5 +35,10 @@ pub fn get_incremental_file<TEnvironment: Environment>(
 
   let base_path = config.base_path.clone();
   let file_path = incremental_dir.join_panic_relative(get_bytes_hash(base_path.to_string_lossy().as_bytes()).to_string());
-  Some(IncrementalFile::new(file_path, scope.plugins_hash(), environment.clone()))
+  Some(IncrementalFile::new(
+    file_path,
+    scope.plugins_hash(),
+    options.is_partial_run,
+    environment.clone(),
+  ))
 }

--- a/crates/dprint/src/incremental/mod.rs
+++ b/crates/dprint/src/incremental/mod.rs
@@ -9,8 +9,8 @@ use crate::utils::get_bytes_hash;
 
 pub struct GetIncrementalFileOptions {
   pub incremental_cli_arg: Option<bool>,
-  /// Whether the run only covers some of the files the configuration
-  /// would otherwise cover (ex. file paths were specified on the cli).
+  /// Whether the cli arguments limit the run to some of the files the
+  /// configuration would otherwise cover (ex. file paths were specified).
   pub is_partial_run: bool,
 }
 
@@ -35,10 +35,14 @@ pub fn get_incremental_file<TEnvironment: Environment>(
 
   let base_path = config.base_path.clone();
   let file_path = incremental_dir.join_panic_relative(get_bytes_hash(base_path.to_string_lossy().as_bytes()).to_string());
+  // running from a sub directory of the config only traverses that directory
+  // (see paths.rs), so that's also a partial run
+  let cwd = environment.cwd();
+  let is_in_sub_dir = cwd != base_path && cwd.starts_with(&base_path);
   Some(IncrementalFile::new(
     file_path,
     scope.plugins_hash(),
-    options.is_partial_run,
+    options.is_partial_run || is_in_sub_dir,
     environment.clone(),
   ))
 }


### PR DESCRIPTION
Previously the incremental file was rewritten on every run with only the hashes seen in that run. Since the hashes are serialized from a `HashSet`, that reordered the file's bytes every run even when nothing changed, and a run over a subset of the files (ex. `dprint fmt some/file.ts`) threw away the hashes of every other file.

Now:

- The file is left alone when every hash seen this run was already in it, so its bytes only change when something new was learned. This lets a CI cache of the cache directory (dprint/check#23) detect that nothing changed and skip saving.
- A partial run merges the new hashes into the existing ones instead of replacing them. A run is partial when the cli limits the files (file patterns, `--includes-override`, `--excludes`, `--excludes-override`, `--only-staged`, `--only-dirty`) or when running from a sub directory of the config, which only traverses that directory.
- A full run still writes only what it saw, so the hashes of changed and deleted files get pruned.

Known trade-off: a workflow that only ever does partial runs (ex. a pre-commit hook using `--only-staged`) accumulates one stale hash per edited file per run until a full run with a change prunes them. Entries are content-addressed and the incremental hash covers plugins and config, so stale entries can't produce a wrong answer; it's bloat only, at roughly 20 bytes per entry.
