### PR TITLE
fix: include wasmtime's precompile compatibility hash in the plugin cache key

### DIFF
--- a/crates/dprint/src/environment/real_environment.rs
+++ b/crates/dprint/src/environment/real_environment.rs
@@ -648,12 +648,16 @@ impl Environment for RealEnvironment {
   fn wasm_cache_key(&self) -> String {
     let cpu = self.cpu_arch();
     let mut hash = FastInsecureHasher::default();
-    // wasmtime tunes native code to the host CPU features and embeds a
-    // compatibility check in the serialized artifact, refusing to deserialize an
-    // incompatible one (the caller then recompiles). that covers CPU-feature
-    // drift; we still hash the rustc version because deserialization can break
-    // across a rust upgrade. https://github.com/dprint/dprint/issues/735
+    // wasmtime tunes native code to the host CPU features and refuses to
+    // deserialize an artifact compiled for incompatible ones (the caller then
+    // recompiles), so include what it checks in the key. that way artifacts for
+    // different CPUs get distinct cache entries and coexist in a cache directory
+    // shared across machines, such as one restored from a CI cache, rather than
+    // each machine overwriting the other's. the rustc version is hashed too
+    // because deserialization can break across a rust upgrade.
+    // https://github.com/dprint/dprint/issues/735
     env!("RUSTC_VERSION_TEXT").hash(&mut hash);
+    crate::plugins::wasm_precompile_compatibility_hash().hash(&mut hash);
     format!("{}-{}", cpu, hash.finish())
   }
 

--- a/crates/dprint/src/plugins/cache_meta.rs
+++ b/crates/dprint/src/plugins/cache_meta.rs
@@ -81,11 +81,13 @@ impl PluginCacheMeta {
 /// they get a fresh hash; the now-unreferenced old files stay on disk until
 /// `clear-cache`.
 pub fn current_signature(environment: &impl Environment) -> String {
-  // `wasm_cache_key` already covers cpu arch + rustc version; `os` distinguishes
+  // `wasm_cache_key` already covers cpu arch, rustc version and wasmtime's
+  // precompile compatibility (cpu features etc.); `os` distinguishes
   // musl/glibc/etc for process plugins. Process plugins technically don't care
   // about the wasm bits, but folding everything in keeps the key kind-agnostic
-  // (so we can hash before resolving an npm plugin's kind) at the only cost of a
-  // rare, cheap re-extract on a dprint upgrade.
+  // (so we can hash before resolving an npm plugin's kind) at the cost of a
+  // rare, cheap re-extract on a dprint upgrade and, in a cache directory shared
+  // across machines with different cpu features, an extracted copy per variant.
   format!(
     "{}-{}-{}-{}",
     PLUGIN_CACHE_SCHEMA_VERSION,

--- a/crates/dprint/src/plugins/implementations/mod.rs
+++ b/crates/dprint/src/plugins/implementations/mod.rs
@@ -8,6 +8,7 @@ pub use wasm::WASM_PLUGIN_THREAD_STACK_SIZE;
 
 pub use wasm::WasmModuleCreator;
 pub use wasm::compile as compile_wasm;
+pub use wasm::precompile_compatibility_hash as wasm_precompile_compatibility_hash;
 
 pub use process::get_os_path as get_process_plugin_os_path;
 pub use process::parse_process_plugin_file;

--- a/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
@@ -90,6 +90,22 @@ impl WasmModule {
   }
 }
 
+/// A hash of everything wasmtime checks before loading a precompiled module:
+/// the target, the cpu features the code was tuned for, and the compiler
+/// settings. Including it in the plugin cache key gives artifacts compiled on
+/// different cpus distinct cache entries, so they can coexist in a cache
+/// directory shared across machines (ex. restored from a CI cache) instead of
+/// overwriting each other on every machine change.
+pub fn precompile_compatibility_hash() -> u64 {
+  static HASH: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+  *HASH.get_or_init(|| {
+    use std::hash::Hash;
+    let mut hasher = crate::utils::FastInsecureHasher::default();
+    new_engine().precompile_compatibility_hash().hash(&mut hasher);
+    hasher.finish()
+  })
+}
+
 // holds the engine so every module it creates shares one engine, which the
 // modules and their stores must agree on
 pub struct WasmModuleCreator {

--- a/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/load_instance.rs
@@ -91,8 +91,8 @@ impl WasmModule {
 }
 
 /// A hash of everything wasmtime checks before loading a precompiled module:
-/// the target, the cpu features the code was tuned for, and the compiler
-/// settings. Including it in the plugin cache key gives artifacts compiled on
+/// the target, the cpu features the code was tuned for, the compiler settings
+/// and the wasmtime version. Including it in the plugin cache key gives artifacts compiled on
 /// different cpus distinct cache entries, so they can coexist in a cache
 /// directory shared across machines (ex. restored from a CI cache) instead of
 /// overwriting each other on every machine change.

--- a/crates/dprint/src/plugins/implementations/wasm/mod.rs
+++ b/crates/dprint/src/plugins/implementations/wasm/mod.rs
@@ -8,6 +8,7 @@ pub use compile::*;
 use instance::*;
 pub use load_instance::WASM_PLUGIN_THREAD_STACK_SIZE;
 pub use load_instance::WasmModuleCreator;
+pub use load_instance::precompile_compatibility_hash;
 use load_instance::*;
 pub use plugin::*;
 pub use setup_wasm_plugin::*;

--- a/crates/dprint/src/plugins/mod.rs
+++ b/crates/dprint/src/plugins/mod.rs
@@ -19,6 +19,7 @@ pub use types::*;
 
 pub use implementations::WASM_PLUGIN_THREAD_STACK_SIZE;
 pub use implementations::compile_wasm;
+pub use implementations::wasm_precompile_compatibility_hash;
 pub use name_resolution::PluginNameResolutionMaps;
 pub use npm_resolution::FetchNpmLatestInfo;
 pub use npm_resolution::MinimumDependencyAgeError;


### PR DESCRIPTION
wasmtime tunes compiled plugins to the host cpu's features and refuses to load an artifact compiled for incompatible ones, so dprint recompiles. That's fine on a single machine, but in a cache directory shared across machines each machine overwrites the other's artifact and every machine change recompiles. dprint/check#28 hit this on GitHub's mixed runner pool: a job restored the cache saved by a job on a different cpu generation and recompiled a plugin, which changed the cache again.

This includes the engine's `precompile_compatibility_hash()` (target, cpu features, compiler settings) in `wasm_cache_key()`, so each cpu variant gets its own cache entry. Variants coexist in the cache directory and the recompiles stop once each variant has been compiled once.

Verified by running this build against a cache directory populated by 0.57.3: the existing five entries stayed and five new ones with the new signature were added alongside them.

The cost is one extra compiled copy per cpu variant in a shared cache, a couple of megabytes each, and the usual one-time recompile on upgrade since the signature changes.
