### PR TITLE
docs: add bibtex-tidy and typstyle plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Repos:
 - [badness](https://github.com/jolars/dprint-plugin-badness) - LaTeX and BibTeX formatter.
 - [arity](https://github.com/jolars/dprint-plugin-arity) - R formatter.
 - [fatou](https://github.com/jolars/dprint-plugin-fatou) - Julia formatter.
+- [typstyle](https://github.com/apcamargo/dprint-plugin-typstyle) - Typst (Typstyle) formatter.
+- [bibtex-tidy](https://github.com/apcamargo/dprint-plugin-bibtex-tidy) - BibTeX (bibtex-tidy) formatter.
 - [dprint-plugin-swift](https://github.com/drluckyspin/dprint-plugin-swift) - Swift (SwiftFormat) formatter.
 
 ## Notes

--- a/website/src/_includes/partials/doc-menu.njk
+++ b/website/src/_includes/partials/doc-menu.njk
@@ -34,6 +34,8 @@
     ["Badness (LaTeX/BibTeX)", "/plugins/badness"],
     ["Arity (R)", "/plugins/arity"],
     ["Fatou (Julia)", "/plugins/fatou"],
+    ["Typstyle (Typst)", "/plugins/typstyle"],
+    ["bibtex-tidy (BibTeX)", "/plugins/bibtex-tidy"],
     ["Swift (SwiftFormat)", "/plugins/swift"],
     ["Exec (Many CLIs)", "/plugins/exec"],
     ["Creating a Plugin", "/plugin-dev"]

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -172,6 +172,11 @@ layout: layouts/base.njk
         >R</span></span></a>
     <a class="plugin-card wrapper" href="/plugins/fatou"><span class="swatch"></span><span class="meta"><span class="name">Fatou</span><span class="ext"
         >Julia</span></span></a>
+    <a class="plugin-card wrapper" href="/plugins/typstyle"><span class="swatch"></span><span class="meta"><span class="name">Typstyle</span><span class="ext"
+        >Typst</span></span></a>
+    <a class="plugin-card wrapper" href="/plugins/bibtex-tidy"><span class="swatch"></span><span class="meta"><span class="name">bibtex-tidy</span><span
+          class="ext"
+        >BibTeX</span></span></a>
   </div>
 
   <div class="plugins-label">Everything else</div>

--- a/website/src/plugins.md
+++ b/website/src/plugins.md
@@ -38,6 +38,8 @@ For the latest version and copy-paste URL of every plugin, see [plugins.dprint.d
 - [Badness](/plugins/badness) (LaTeX/BibTeX)
 - [Arity](/plugins/arity) (R)
 - [Fatou](/plugins/fatou) (Julia)
+- [Typstyle](/plugins/typstyle) (Typst)
+- [bibtex-tidy](/plugins/bibtex-tidy) (BibTeX)
 
 ## Process Plugins
 

--- a/website/src/plugins/bibtex-tidy.md
+++ b/website/src/plugins/bibtex-tidy.md
@@ -1,0 +1,43 @@
+---
+title: bibtex-tidy Plugin
+description: Documentation on the bibtex-tidy code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/bibtex-tidy">bibtex-tidy</a></li>
+  </ul>
+</nav>
+
+# bibtex-tidy Plugin
+
+Adapter plugin that formats BibTeX files via [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy).
+
+Formats .bib and .bibtex files. `dprint add` currently seeds includes for `.bib` only; add `**/*.bibtex` yourself if you use that extension.
+
+## Install and Setup
+
+In your project's directory with a dprint.json file, run:
+
+```shellsession
+dprint add apcamargo/bibtex-tidy
+```
+
+This will update your config file to have an entry for the plugin. Then optionally specify a `"bibtex-tidy"` property to add configuration:
+
+```json
+{
+  "bibtex-tidy": {
+    // bibtex-tidy config goes here
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/apcamargo/bibtex-tidy-x.x.x.wasm"
+  ]
+}
+```
+
+## Configuration
+
+See [Configuration](/plugins/bibtex-tidy/config).

--- a/website/src/plugins/bibtex-tidy/config.md
+++ b/website/src/plugins/bibtex-tidy/config.md
@@ -1,0 +1,57 @@
+---
+title: Configuration - bibtex-tidy
+description: Documentation on the configuration file for the bibtex-tidy code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/bibtex-tidy">bibtex-tidy</a></li>
+    <li><a href="/plugins/bibtex-tidy/config">Configuration</a></li>
+  </ul>
+</nav>
+
+# bibtex-tidy - Configuration
+
+Specify configuration under the `"bibtex-tidy"` key in your dprint configuration file.
+
+| Property                | Values                                                               | Default                         |
+| ----------------------- | -------------------------------------------------------------------- | ------------------------------- |
+| `lineWidth`             | Integer                                                              | Global `lineWidth`, or `80`     |
+| `indentWidth`           | Integer                                                              | Global `indentWidth`, or `2`    |
+| `newLineKind`           | `"auto"`, `"lf"`, `"crlf"`, `"system"`                               | Global `newLineKind`, or `"lf"` |
+| `useTabs`               | Boolean                                                              | Global `useTabs`, or `false`    |
+| `align`                 | Integer, Boolean                                                     | `14`                            |
+| `blankLines`            | Boolean                                                              | `false`                         |
+| `curly`                 | Boolean                                                              | `false`                         |
+| `numeric`               | Boolean                                                              | `false`                         |
+| `months`                | Boolean                                                              | `false`                         |
+| `sort`                  | Boolean, Array of strings                                            | `false`                         |
+| `duplicates`            | Boolean, Array of `"doi"` \| `"key"` \| `"abstract"` \| `"citation"` | `false`                         |
+| `merge`                 | Boolean, `"first"`, `"last"`, `"combine"`, `"overwrite"`             | `false`                         |
+| `stripEnclosingBraces`  | Boolean                                                              | `false`                         |
+| `dropAllCaps`           | Boolean                                                              | `false`                         |
+| `escape`                | Boolean, `"new"`                                                     | `true`                          |
+| `unescape`              | Boolean                                                              | `false`                         |
+| `sortFields`            | Boolean, Array of strings                                            | `false`                         |
+| `stripComments`         | Boolean                                                              | `false`                         |
+| `tidyComments`          | Boolean                                                              | `true`                          |
+| `trailingCommas`        | Boolean                                                              | `false`                         |
+| `encodeUrls`            | Boolean                                                              | `false`                         |
+| `removeEmptyFields`     | Boolean                                                              | `false`                         |
+| `removeDuplicateFields` | Boolean                                                              | `true`                          |
+| `generateKeys`          | Boolean, String                                                      | `false`                         |
+| `maxAuthors`            | Integer                                                              | Unset                           |
+| `lowercase`             | Boolean                                                              | `true`                          |
+| `enclosingBraces`       | Boolean, Array of strings                                            | `false`                         |
+| `removeBraces`          | Boolean, Array of strings                                            | `false`                         |
+| `wrap`                  | Boolean                                                              | `false`                         |
+| `omit`                  | Array of strings                                                     | `[]`                            |
+
+`lineWidth` is only used when `wrap` is set to `true`. When `useTabs` is `true`, `indentWidth` is ignored.
+
+Setting `enclosingBraces` or `removeBraces` to `true` applies them to the `title` field. `generateKeys` is experimental in bibtex-tidy.
+
+See the [plugin documentation](https://github.com/apcamargo/dprint-plugin-bibtex-tidy#configuration) and
+[JSON schema](https://plugins.dprint.dev/apcamargo/bibtex-tidy/latest/schema.json) for details.

--- a/website/src/plugins/typstyle.md
+++ b/website/src/plugins/typstyle.md
@@ -1,0 +1,43 @@
+---
+title: Typstyle Plugin
+description: Documentation on the Typstyle code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/typstyle">Typstyle</a></li>
+  </ul>
+</nav>
+
+# Typstyle Plugin
+
+Adapter plugin that formats Typst files via [Typstyle](https://github.com/typstyle-rs/typstyle).
+
+Formats .typ files.
+
+## Install and Setup
+
+In your project's directory with a dprint.json file, run:
+
+```shellsession
+dprint add apcamargo/typstyle
+```
+
+This will update your config file to have an entry for the plugin. Then optionally specify a `"typstyle"` property to add configuration:
+
+```json
+{
+  "typstyle": {
+    // typstyle config goes here
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/apcamargo/typstyle-x.x.x.wasm"
+  ]
+}
+```
+
+## Configuration
+
+See [Configuration](/plugins/typstyle/config).

--- a/website/src/plugins/typstyle/config.md
+++ b/website/src/plugins/typstyle/config.md
@@ -1,0 +1,33 @@
+---
+title: Configuration - Typstyle
+description: Documentation on the configuration file for the Typstyle code formatting plugin for dprint.
+layout: layouts/documentation.njk
+---
+
+<nav class="breadcrumb" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="/plugins">Plugins</a></li>
+    <li><a href="/plugins/typstyle">Typstyle</a></li>
+    <li><a href="/plugins/typstyle/config">Configuration</a></li>
+  </ul>
+</nav>
+
+# Typstyle - Configuration
+
+Specify configuration under the `"typstyle"` key in your dprint configuration file.
+
+| Property               | Values                           | Default                                      |
+| ---------------------- | -------------------------------- | -------------------------------------------- |
+| `lineWidth`            | Integer                          | Global `lineWidth`, or `80`                  |
+| `indentWidth`          | Integer                          | Global `indentWidth`, or `2`                 |
+| `blankLinesUpperBound` | Integer                          | `1`                                          |
+| `collapseMarkupSpaces` | Boolean                          | `false`                                      |
+| `reorderImportItems`   | Boolean                          | `true`                                       |
+| `wrapMode`             | `"none"`, `"fill"`, `"sentence"` | `"none"`                                     |
+| `lineEnding`           | `"lf"`, `"crlf"`                 | Global `newLineKind` (CRLF or LF), or `"lf"` |
+
+Typstyle always indents with spaces, so the global `useTabs` setting has no effect.
+A global `newLineKind` of `"auto"` or `"system"` is treated as `"lf"`.
+
+See the [plugin documentation](https://github.com/apcamargo/dprint-plugin-typstyle#configuration) and
+[JSON schema](https://plugins.dprint.dev/apcamargo/typstyle/latest/schema.json) for details.

--- a/website/src/scripts/plugin-url-replacer.js
+++ b/website/src/scripts/plugin-url-replacer.js
@@ -22,6 +22,8 @@ const pluginPlaceholders = new Map([
   ["\"https://plugins.dprint.dev/jolars/badness-vx.x.x.wasm\"", "jolars/badness"],
   ["\"https://plugins.dprint.dev/jolars/arity-vx.x.x.wasm\"", "jolars/arity"],
   ["\"https://plugins.dprint.dev/jolars/fatou-vx.x.x.wasm\"", "jolars/fatou"],
+  ["\"https://plugins.dprint.dev/apcamargo/typstyle-x.x.x.wasm\"", "apcamargo/typstyle"],
+  ["\"https://plugins.dprint.dev/apcamargo/bibtex-tidy-x.x.x.wasm\"", "apcamargo/bibtex-tidy"],
 ]);
 
 export function replacePluginUrls() {


### PR DESCRIPTION
This PR adds documentation pages for the [Typstyle](https://github.com/typstyle-rs/typstyle) and [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy) plugins.